### PR TITLE
:memo: docs(chord): 旧パス参照 capsule-corp → canon

### DIFF
--- a/chezmoi/run_onchange_after_chord-validate.sh.tmpl
+++ b/chezmoi/run_onchange_after_chord-validate.sh.tmpl
@@ -1,5 +1,5 @@
 #!/bin/sh
-# chord config validation gate (旧 capsule-corp/host/chord/render.sh の責務を継承)。
+# chord config validation gate (旧 canon/host/chord/render.sh の責務を継承)。
 # chezmoi apply 後に走り、chord 在中時のみ実体ファイルを --validate する。
 # 失敗時 exit 1 で chezmoi apply の戻り値に validate 失敗が残る (CI/手元両対応)。
 # chord 未インストール環境 (fresh bootstrap / CI Linux) では何もせず exit 0。


### PR DESCRIPTION
## Summary

- `chezmoi/run_onchange_after_chord-validate.sh.tmpl` 冒頭コメント `旧 capsule-corp/host/chord/render.sh` → `旧 canon/host/chord/render.sh` (リポジトリ名リネームに追従)
- chezmoi の sha256 トリガには影響しない (コメント変更のみで template 本体は同一)

## Test plan

- [ ] `chezmoi apply --dry-run` で再実行トリガが発火しないこと (sha256 sum 不変)

🤖 Generated with [Claude Code](https://claude.com/claude-code)