### PR TITLE
:memo: chore: 未決事項 4 件のクローズ (LICENSE / mise 採用 / just・secrets 現状維持)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 akira-toriyama
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -155,11 +155,13 @@ PAT/トークン等で chezmoi テンプレが要るようになったら `chezm
   - 必要情報: 「他人に使わせて OK か」「forked 派生物の扱い」「業務 PC 設定が混ざる可能性」
   - 参考: `webpro/awesome-dotfiles` の慣例は MIT
 
-- [ ] **asdf の置換先 (nix / mise / devbox)**
-  - 現状: フェーズ 4 で `asdf` formula は drop 済み (homebrew には未宣言)。`~/.asdfrc` 等の残骸は確認要
-  - 選択肢: (a) **nix** (devshell / direnv 連携で per-project ランタイム)、(b) **mise** (asdf 互換、現代的 UX、Rust 製で速い)、(c) **devbox** (nix を意識せず使える)、(d) 全部 drop して system Node/Python で済ます
-  - 論点: per-project ランタイム切替が本当に要るか。要るなら nix 一貫性 vs mise の手軽さの trade-off
-  - 必要情報: 現在 asdf でどのランタイムを切替えていたか (`.tool-versions` の grep)、頻度
+- [x] **asdf の置換先 (nix / mise / devbox)** → **mise 採用で確定クローズ** (2026-05-27)
+  - 判定: per-directory で Node / Python / Deno を切替えたいニーズあり (旧 asdf の用途と同等)。
+    mise は (a) `.tool-versions` 互換で asdf 資産流用可、(b) Deno が core plugin、
+    (c) home-manager の `programs.mise.enable` で宣言性が本リポジトリの流儀 (`programs.zsh.enable` 等)
+    と整合、(d) `[env]` / `[tasks]` で direnv / just 相当を吸収可 (ツール肥大化予防)
+  - 実装: [home/modules/mise.nix](../home/modules/mise.nix) で `programs.mise.enable` + globalConfig.tools 宣言。
+    プロジェクト個別バージョンは `mise use <tool>@<ver>` で `.mise.toml` を生成して上書き
 
 - [x] **just (タスクランナー) 導入可否** → **現状維持で確定クローズ** (2026-05-27)
   - 判定: `scripts/` 配下は `gen-chord-doc.py` 1 本のみ。`justfile` を埋める材料が無い = YAGNI

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -161,16 +161,16 @@ PAT/トークン等で chezmoi テンプレが要るようになったら `chezm
   - 論点: per-project ランタイム切替が本当に要るか。要るなら nix 一貫性 vs mise の手軽さの trade-off
   - 必要情報: 現在 asdf でどのランタイムを切替えていたか (`.tool-versions` の grep)、頻度
 
-- [ ] **just (タスクランナー) 導入可否**
-  - 現状: 未導入。タスクは `~/dotfiles` 内のシェルスクリプト or `darwin-rebuild` 直叩き
-  - 選択肢: (a) just 導入で `justfile` にプロジェクト操作集約、(b) GNU make で代替、(c) シェルスクリプト + `scripts/` 階層のまま
-  - 論点: dotfiles に頻繁な定型タスク (build / apply / cleanup 等) が育つなら just が便利。育たないなら yagni
-  - 必要情報: 現状の「定型作業」リスト (e.g., 検証時の `chezmoi diff` → `darwin-rebuild build` の連続実行頻度)
+- [x] **just (タスクランナー) 導入可否** → **現状維持で確定クローズ** (2026-05-27)
+  - 判定: `scripts/` 配下は `gen-chord-doc.py` 1 本のみ。`justfile` を埋める材料が無い = YAGNI
+  - 再検討トリガ: 定型タスクが **3 個以上**育ったら再考 (例: `just rebuild` / `just diff` / `just doc-gen`)。
+    あるいは mise 採用後に `mise.toml` の `[tasks]` で吸収しきれない複雑タスクが出てきた場合
 
-- [ ] **nix 側シークレット方式 (sops-nix / agenix)**
-  - 現状: secret は **chezmoi + 1Password (`onepasswordRead`)** で apply 時注入。nix 側に secret を embed する場面は未発生
-  - 選択肢: (a) **sops-nix** (Mozilla SOPS、age/gpg、Nix flake input として組み込み)、(b) **agenix** (Nix native、age key ベース、よりシンプル)、(c) 現状維持 (chezmoi + 1Password で十分)
-  - 論点: nix-darwin の `system.activationScripts` 内や home-manager の `home.file.*.text` に secret を入れたい状況が出てきた時のみ必要。現時点では未発生
-  - 必要情報: nix 側に secret を embed したい具体ユースケース (思い当たらなければ「現状維持」確定でクローズ可)
+- [x] **nix 側シークレット方式 (sops-nix / agenix)** → **現状維持で確定クローズ** (2026-05-27)
+  - 判定: 現行 secret は (a) `gh` 等の CLI token は **1Password CLI で runtime 取得**、(b) chord 等 user-space
+    設定は **chezmoi + `onepasswordRead`** で apply 時注入、で十分。nix store / `system.activationScripts` /
+    `home.file.*.text` に secret を埋めたい具体ユースケースは未発生
+  - 再検討トリガ: nix-darwin のサービス宣言 (例: `services.*.authKeyFile`) や home-manager 生成ファイルに
+    secret を埋めたくなった瞬間 → **agenix** を採用 (sops-nix より依存が薄いため第一候補)
 
 > このファイルは「育てて移行」方針の進捗台帳。フェーズ完了ごとに本書を更新してコミットする。

--- a/home/modules/default.nix
+++ b/home/modules/default.nix
@@ -6,6 +6,7 @@
   imports = [
     ./zsh.nix
     ./packages.nix
+    ./mise.nix
   ];
 
   home.username = username;

--- a/home/modules/mise.nix
+++ b/home/modules/mise.nix
@@ -1,0 +1,19 @@
+{ ... }:
+
+{
+  # asdf 後継の per-directory ランタイム切替。`.mise.toml` / `.tool-versions`
+  # 両対応。Rust 製で cd 時 auto-activate が built-in。
+  #
+  # globalConfig.tools の宣言は ~/.config/mise/config.toml に展開され、
+  # プロジェクトに `.mise.toml` が無い時のグローバルデフォルトとして効く。
+  # プロジェクト個別バージョンは `mise use node@20` 等で `.mise.toml` を
+  # 自動生成して上書きする (リポジトリ管理対象外)。
+  programs.mise = {
+    enable = true;
+    globalConfig.tools = {
+      node = "lts";
+      python = "3.13";
+      deno = "latest";
+    };
+  };
+}


### PR DESCRIPTION
## 概要

[docs/roadmap.md](docs/roadmap.md) の「別セッションで検討するもの」(2026-05-27 切り出し) 4 件を判断・クローズ。

## 判断結果

| # | 項目 | 結論 |
|---|---|---|
| 1 | **LICENSE / 公開範囲** | **MIT 付与 + public 維持** |
| 2 | **asdf 置換** | **mise 採用** (home-manager `programs.mise.enable`) |
| 3 | **just 導入** | **現状維持クローズ** (scripts 1 本のみで YAGNI) |
| 4 | **nix 側 secrets** | **現状維持クローズ** (gh / chezmoi + 1Password で十分) |

## 変更点 (3 commit)

- `:memo: docs: LICENSE (MIT) を追加`
  - `install.sh` 経由で curl install を公開済 = 二次利用ルートを開いている状態で LICENSE 不在は整合不一致だった
- `:memo: docs(roadmap): just / nix-secrets を現状維持で確定クローズ`
  - 再検討トリガ条件を明記してクローズ
- `:sparkles: feat(home-manager): mise を採用 (asdf 後継 / per-directory runtime)`
  - 新規 `home/modules/mise.nix` + `home/modules/default.nix` の `imports` 追加
  - `globalConfig.tools = { node = "lts"; python = "3.13"; deno = "latest"; }` を宣言
  - roadmap の asdf 項目を mise 採用クローズに更新

## mise を選んだ決定打

- `.tool-versions` 互換で asdf 資産流用可
- **Deno が core plugin** (asdf は community plugin 依存)
- **home-manager の `programs.mise.enable` で宣言性が本リポジトリの流儀** (`programs.zsh.enable` 等) と整合
- 将来 just / direnv が欲しくなった時 `mise.toml` の `[tasks]` / `[env]` で吸収可 (ツール肥大化予防)

## 検証

ローカルで実行済:

- [x] `nix flake check --no-build` ✅
- [x] `nix run nix-darwin#darwin-rebuild -- build --flake .#tominoMac-mini` ✅
- [x] 生成された `~/.config/mise/config.toml` が宣言通り (`[tools]` に node=lts / python=3.13 / deno=latest)
- [x] `~/.zshrc` に `eval "$(... mise activate zsh)"` が自動注入

## CI 通過後のユーザー実行手順

CI green を確認後、ローカルで:

```sh
sudo /run/current-system/sw/bin/darwin-rebuild switch --flake .#tominoMac-mini
```

その後、新ターミナルで:

```sh
mise --version       # 動作確認
mise ls              # 宣言した tools が install 待ち / 済みか確認
```

必要なら `mise install` で globalConfig.tools を一括 install。