### PR TITLE
:sparkles: feat: chord v2.1 j-layer + wand --title 連携を source に反映

### DIFF
--- a/chezmoi/dot_config/chord/private_config.toml.tmpl
+++ b/chezmoi/dot_config/chord/private_config.toml.tmpl
@@ -170,3 +170,30 @@ action-shell = 'afplay "{{ .chezmoi.homeDir }}/.local/share/sounds/undefined_key
 name = "WONDER_RR undefined feedback"
 input = "{{ $WONDER_RR }} - *"
 action-shell = 'afplay "{{ .chezmoi.homeDir }}/.local/share/sounds/undefined_key.wav"'
+
+
+# =====================================================================
+# v2.1 stateful bindings (chord >= 0.4.0)
+# action-set-var / when-var / hold-while-timeout は dfb5f74 で本流入り。
+# 古い chord バイナリでは "missing-action" warning で drop される。
+# =====================================================================
+
+# ---- ULTRA_LL j-layer (1500ms inactivity timeout) ----
+
+[[bindings]]
+name = "ULTRA_LL + j → arm j-layer"
+input = "{{ $ULTRA_LL }} - j"
+action-set-var = "jlayer"
+hold-while-timeout = 1500
+
+[[bindings]]
+name = "ULTRA_LL + k → Enter (in j-layer)"
+input = "{{ $ULTRA_LL }} - k"
+when-var = "jlayer"
+action-keys = "return"
+
+[[bindings]]
+name = "ULTRA_LL + l → Backspace (in j-layer)"
+input = "{{ $ULTRA_LL }} - l"
+when-var = "jlayer"
+action-keys = "backspace"

--- a/chezmoi/dot_config/eventfx/config
+++ b/chezmoi/dot_config/eventfx/config
@@ -6,7 +6,9 @@
 #
 # 環境変数:
 #   共通:           $EVENTFX_EVENT / $EVENTFX_PID / $EVENTFX_APP
-#   window_focused: $EVENTFX_WINDOW_ID / $EVENTFX_TITLE
+#                   $EVENTFX_WINDOW_ID / $EVENTFX_TITLE
+#                   (text_selected でも focused window の id/title が入る。
+#                    取得不可は 0 / 空)
 #   text_selected:  $EVENTFX_SELECTION / $EVENTFX_CURSOR_X / $EVENTFX_CURSOR_Y
 #                   (cursor は Cocoa 座標, 全スクリーン)
 

--- a/chezmoi/dot_config/eventfx/executable_text-selected-launcher
+++ b/chezmoi/dot_config/eventfx/executable_text-selected-launcher
@@ -7,8 +7,9 @@
 
 # wand dev ビルドは Homebrew PATH に乗らないので明示する。
 # ビルドが入れ替わったらここを差し替える 1 箇所。
-# 注: PR #37 で stroke binary は wand に rename された。
-WAND_BIN="/Volumes/workspace/github.com/akira-toriyama/stroke/Wand-dev.app/Contents/MacOS/wand"
+# 注: PR #37 で stroke binary は wand に rename された。clone 自体も
+# stroke/ → wand/ にリネーム済 (stroke/ の方は古い fork で stale)。
+WAND_BIN="/Volumes/workspace/github.com/akira-toriyama/wand/Wand-dev.app/Contents/MacOS/wand"
 ITEMS="$HOME/.config/eventfx/text_selected.toml"
 
 [ -x "$WAND_BIN" ] || exit 0   # dev mount が外れている等は静かに諦める
@@ -35,4 +36,5 @@ exec "$WAND_BIN" \
     --show-menu \
     --items "$ITEMS" \
     --at "$X" "$Y" \
-    --selection "$EVENTFX_SELECTION"
+    --selection "$EVENTFX_SELECTION" \
+    --title "$EVENTFX_TITLE"

--- a/chezmoi/dot_config/eventfx/text_selected.toml
+++ b/chezmoi/dot_config/eventfx/text_selected.toml
@@ -40,7 +40,12 @@ separator-before = true
 action-type = "shell"
 # --copy フラグで panel 表示と同時に pbcopy。翻訳結果を後で
 # paste したいフローのテンプレ。
-action-cmd = 'printf "%s" "$SELECTION" | "$HOME/.local/bin/glance" --title "Selection" --width 480 --copy'
+# title = 選択元ウィンドウのタイトル ($WAND_TARGET_TITLE)。
+# wand v4.x+ では --show-menu が --title CLI flag を受け、
+# launcher が $EVENTFX_TITLE をそれで明示注入する (env が IPC で
+# 落ちる問題の根本対策)。指定無しでも daemon 側で AX-fetch する
+# fallback あり。取得不可は "Selection" にフォールバック。
+action-cmd = 'printf "%s" "$SELECTION" | "$HOME/.local/bin/glance" --title "${WAND_TARGET_TITLE:-Selection}" --width 480 --copy'
 
 # DeepL を curl 経由でパイプにすると翻訳結果を panel に出しつつ pbcopy
 # できる ($DEEPL_API_KEY 設定済前提)。ブラウザ open 版と置き換える場合:
@@ -49,7 +54,7 @@ action-cmd = 'printf "%s" "$SELECTION" | "$HOME/.local/bin/glance" --title "Sele
 # name = "DeepL で翻訳 → 表示 + コピー"
 # icon = "SF:character.bubble"
 # action-type = "shell"
-# action-cmd = 'printf %s "$SELECTION" | curl -s -X POST "https://api-free.deepl.com/v2/translate" -H "Authorization: DeepL-Auth-Key $DEEPL_API_KEY" --data-urlencode "text@-" -d "target_lang=JA" | jq -r ".translations[0].text" | "$HOME/.local/bin/glance" --title DeepL --width 480 --copy'
+# action-cmd = 'printf %s "$SELECTION" | curl -s -X POST "https://api-free.deepl.com/v2/translate" -H "Authorization: DeepL-Auth-Key $DEEPL_API_KEY" --data-urlencode "text@-" -d "target_lang=JA" | jq -r ".translations[0].text" | "$HOME/.local/bin/glance" --title "DeepL — ${WAND_TARGET_TITLE:-Selection}" --width 480 --copy'
 
 [[launcher.item]]
 name = "文字数・行数"


### PR DESCRIPTION
## Summary

ローカル \$HOME と chezmoi source の乖離 4 件をまとめて取り込み。いずれも上流 (chord / wand) の最近の変更に追随するもので、`chezmoi status` 完全クリア + `chord --validate` 0 warnings を確認済み。

### 変更内訳

- **chord template**: v2.1 stateful bindings を追加 (chord dfb5f74)
  - `action-set-var` / `when-var` / `hold-while-timeout` を使った ULTRA_LL j-layer
  - `j` で arm → `k`=Return / `l`=Backspace、1500ms inactivity timeout
- **eventfx/config**: text_selected にも `EVENTFX_WINDOW_ID` / `TITLE` が入る注記へ修正
  - eventfx 側 `EventWatcher.swift:310` の実装と整合（live 側が正しかった）
- **eventfx/text-selected-launcher**: `WAND_BIN` を wand/ に向け直し + `--title "\$EVENTFX_TITLE"` 注入
  - wand #45 (7270b47) で `--title` flag が正式追加された
  - stroke/ はリネーム前 fork (古い)、wand/ が本流 (#29 rename 済み)
- **eventfx/text_selected.toml**: `glance --title` に `\$WAND_TARGET_TITLE` を反映
  - wand #45 が IPC 経由で env 注入する仕組みと組み合わせ
  - 取得不可は `Selection` に fallback

## Test plan

- [x] `chezmoi diff` で残差なしを確認
- [x] `chezmoi apply --force` 後 `chord --validate` が 0 warnings (19 bindings, 4 fallbacks)
- [x] `run_onchange_install-vscode-extensions.sh` が再走 → "VSCode 拡張のインストール完了"
- [ ] (手元動作) ULTRA_LL + j → k で Return / + l で Backspace
- [ ] (手元動作) text selection → glance panel タイトルに対象ウィンドウ名が出る