### PR TITLE
:wrench: chore(facet): tree hover プレビューを mirror に切替

### DIFF
--- a/chezmoi/dot_config/facet/config.toml
+++ b/chezmoi/dot_config/facet/config.toml
@@ -108,3 +108,6 @@ thumbnail-refresh-seconds = 4
 #
 # Unknown values clamp to "anchor".
 hide_method = "anchor"
+
+[tree]
+preview_mode = "mirror"


### PR DESCRIPTION
## Summary
- `[tree] preview_mode = \"mirror\"` を facet 設定に追加
- デフォルトの popover はサムネ縮小で視認が辛いため、実サイズ + WS 切替後の表示位置で確認できる mirror に切替

## Test plan
- [ ] `chezmoi apply` 後、`~/.config/facet/config.toml` に `[tree] preview_mode = \"mirror\"` が反映される
- [ ] facet 再起動後、tree sidebar の window 行ホバーで mirror 表示になる (macOS 14+)

🤖 Generated with [Claude Code](https://claude.com/claude-code)