### PR TITLE
:sparkles: feat(chord): [input-aliases] への移行 + gen-chord-doc.py 単純化

### DIFF
--- a/chezmoi/dot_config/chord/private_config.toml
+++ b/chezmoi/dot_config/chord/private_config.toml
@@ -2,15 +2,15 @@
 # 編集は ~/.config/chord/config.toml を直接編集 → `chezmoi re-add` で取り込み。
 # eventfx 等と同じ「直接編集 → re-add」運用。
 #
-# 修飾子 4 セット (ZMK 物理 chord) は literal で書く:
+# 修飾子 4 セット (ZMK 物理 chord) は [input-aliases] で論理名化し、
+# `input = "ULTRA_LL - c"` のように bare reference する
+# (chord の [input-aliases] 機能、akira-toriyama/chord PR #4)。
 #   ULTRA_LL   = rctrl + ralt + rshift   (RALT+RSHIFT+RCTRL, RGUI なし)
 #   MIRACLE_LM = rctrl + rcmd + rshift   (RGUI+RSHIFT+RCTRL, RALT なし)
 #   MEGA_RM    = rctrl + rcmd + ralt     (RGUI+RALT +RCTRL,  RSHIFT なし)
 #   WONDER_RR  = rcmd  + ralt + rshift   (RGUI+RALT +RSHIFT, RCTRL なし)
-# 論理名 (ULTRA_LL 等) は docs/chord.md 生成時に scripts/gen-chord-doc.py が
-# 4 組の literal → name dict で復元する。chord 本体に [input-aliases] 機能が
-# 入ったらこのファイルにも `[input-aliases]` テーブルを追加して bare 参照
-# (input = "ULTRA_LL - c") に書き換える予定。
+# 論理名は chord 自身が解決するので `gen-chord-doc.py` も [input-aliases]
+# テーブルを直接読めば docs/chord.md のショートカット表を作れる。
 #
 # chord (akira-toriyama/chord) の TOML 文法:
 #   • input  = "<mods> - <key>"   ※ key は標準名 or `keycode-<decimal>`
@@ -37,6 +37,19 @@ play-undef = 'afplay "$HOME/.local/share/sounds/undefined_key.wav"'
 
 
 # =====================================================================
+# Input aliases — chord の [input-aliases] 機能で modifier セットを論理名化。
+# bare reference (no @ prefix)。built-in modifier (cmd / ctrl / ...) と
+# 名前衝突する alias は load 時 reject される。case-insensitive。
+# =====================================================================
+
+[input-aliases]
+ULTRA_LL   = "rctrl + ralt + rshift"
+MIRACLE_LM = "rctrl + rcmd + rshift"
+MEGA_RM    = "rctrl + rcmd + ralt"
+WONDER_RR  = "rcmd + ralt + rshift"
+
+
+# =====================================================================
 # Bindings — 各 binding 直前の `# doc: <動作>` は docs/chord.md の
 # ショートカット表生成の唯一ソース（scripts/gen-chord-doc.py が読む）。
 # =====================================================================
@@ -46,53 +59,53 @@ play-undef = 'afplay "$HOME/.local/share/sounds/undefined_key.wav"'
 # doc: タブを左へ（Chrome: Ctrl+Shift+Tab）
 [[bindings]]
 name = "tab-left (Chrome)"
-input = "rctrl + ralt + rshift - c"
+input = "ULTRA_LL - c"
 apps = ["com.google.Chrome"]
 action-keys = "ctrl + shift - tab"
 
 # doc: タブを左へ（VS Code: Cmd+Shift+[）
 [[bindings]]
 name = "tab-left (VS Code)"
-input = "rctrl + ralt + rshift - c"
+input = "ULTRA_LL - c"
 apps = ["com.microsoft.VSCode"]
 action-keys = "cmd + shift - ["
 
 # doc: タブを右へ（Chrome: Ctrl+Tab）
 [[bindings]]
 name = "tab-right (Chrome)"
-input = "rctrl + ralt + rshift - v"
+input = "ULTRA_LL - v"
 apps = ["com.google.Chrome"]
 action-keys = "ctrl - tab"
 
 # doc: タブを右へ（VS Code: Cmd+Shift+]）
 [[bindings]]
 name = "tab-right (VS Code)"
-input = "rctrl + ralt + rshift - v"
+input = "ULTRA_LL - v"
 apps = ["com.microsoft.VSCode"]
 action-keys = "cmd + shift - ]"
 
 # doc: 前のウィンドウへ（rift フォーカス）
 [[bindings]]
 name = "rift focus prev"
-input = "rctrl + ralt + rshift - d"
+input = "ULTRA_LL - d"
 action-shell = "rift-cli execute window prev"
 
 # doc: 次のウィンドウへ（rift フォーカス）
 [[bindings]]
 name = "rift focus next"
-input = "rctrl + ralt + rshift - f"
+input = "ULTRA_LL - f"
 action-shell = "rift-cli execute window next"
 
 # doc: AltTab 起動（全スペース。旧 cmd+ctrl+tab）
 [[bindings]]
 name = "alttab all-spaces"
-input = "rctrl + ralt + rshift - a"
+input = "ULTRA_LL - a"
 action-shell = "/Applications/AltTab.app/Contents/MacOS/AltTab --show=1"
 
 # doc: AltTab 起動（現スペース。旧 alt+tab）
 [[bindings]]
 name = "alttab current-space"
-input = "rctrl + ralt + rshift - s"
+input = "ULTRA_LL - s"
 action-shell = "/Applications/AltTab.app/Contents/MacOS/AltTab --show=0"
 
 
@@ -162,22 +175,22 @@ action-keys = "return"
 
 [[fallbacks]]
 name = "ULTRA_LL undefined feedback"
-input = "rctrl + ralt + rshift - *"
+input = "ULTRA_LL - *"
 action-shell = "@play-undef"
 
 [[fallbacks]]
 name = "MIRACLE_LM undefined feedback"
-input = "rctrl + rcmd + rshift - *"
+input = "MIRACLE_LM - *"
 action-shell = "@play-undef"
 
 [[fallbacks]]
 name = "MEGA_RM undefined feedback"
-input = "rctrl + rcmd + ralt - *"
+input = "MEGA_RM - *"
 action-shell = "@play-undef"
 
 [[fallbacks]]
 name = "WONDER_RR undefined feedback"
-input = "rcmd + ralt + rshift - *"
+input = "WONDER_RR - *"
 action-shell = "@play-undef"
 
 
@@ -191,18 +204,18 @@ action-shell = "@play-undef"
 
 [[bindings]]
 name = "ULTRA_LL + j → arm j-layer"
-input = "rctrl + ralt + rshift - j"
+input = "ULTRA_LL - j"
 action-set-var = "jlayer"
 hold-while-timeout = 1500
 
 [[bindings]]
 name = "ULTRA_LL + k → Enter (in j-layer)"
-input = "rctrl + ralt + rshift - k"
+input = "ULTRA_LL - k"
 when-var = "jlayer"
 action-keys = "return"
 
 [[bindings]]
 name = "ULTRA_LL + l → Backspace (in j-layer)"
-input = "rctrl + ralt + rshift - l"
+input = "ULTRA_LL - l"
 when-var = "jlayer"
 action-keys = "backspace"

--- a/chezmoi/dot_config/facet/config.toml
+++ b/chezmoi/dot_config/facet/config.toml
@@ -108,3 +108,6 @@ thumbnail-refresh-seconds = 4
 #
 # Unknown values clamp to "anchor".
 hide_method = "anchor"
+
+[tree]
+preview_mode = "mirror"

--- a/docs/chord.md
+++ b/docs/chord.md
@@ -7,11 +7,11 @@ ZMK ファームから届くチョードを macOS 側で捕まえてアクショ
 ## ファイル
 
 - [chezmoi/dot_config/chord/private_config.toml](../chezmoi/dot_config/chord/private_config.toml):
-  plain TOML（**唯一のソース**、template 評価なし）。`[[bindings]]`（実バインド）
-  と `[[fallbacks]]`（未定義キー効果音）、`[aliases]`（shell-action の DRY 化）
-  を含む。ZMK 右側修飾子セット 4 個は literal 表記
-  （`rctrl + ralt + rshift` = ULTRA_LL 等）。論理名は docs 生成時に
-  `scripts/gen-chord-doc.py` の dict が復元する。
+  plain TOML（**唯一のソース**、template 評価なし）。`[options]`、
+  `[aliases]`（shell-action の DRY 化）、`[input-aliases]`（modifier セットの
+  論理名）、`[[bindings]]`、`[[fallbacks]]` を含む。ZMK 右側修飾子セット 4 個
+  (ULTRA_LL/MIRACLE_LM/MEGA_RM/WONDER_RR) は `[input-aliases]` で **論理名定義**
+  → `input = "ULTRA_LL - c"` のように bare reference する。
 - [chezmoi/run_onchange_after_chord-validate.sh.tmpl](../chezmoi/run_onchange_after_chord-validate.sh.tmpl):
   `chezmoi apply` 後に `chord --validate` を走らせる検証ゲート。chord 在中時のみ
   実行され、失敗時は exit 1 を返す（fresh bootstrap や CI Linux では no-op）。
@@ -19,21 +19,21 @@ ZMK ファームから届くチョードを macOS 側で捕まえてアクショ
   hash を埋め込み、変更時の再走トリガに使うため）。
 - [scripts/gen-chord-doc.py](../scripts/gen-chord-doc.py):
   上記 config の `# doc:` コメントから本ドキュメントのショートカット表を生成。
-  4 修飾子セット (ULTRA_LL/MIRACLE_LM/MEGA_RM/WONDER_RR) の literal → 論理名
-  mapping を内部 dict で保持。
+  `input` の token を `_format_token` で表記正規化するだけ。論理名
+  (ULTRA_LL 等) は原文のまま出力されるので、`[input-aliases]` で定義した
+  名前がそのまま表に出る。
 
 ## 使い方
 
 ```sh
 $EDITOR ~/.config/chord/config.toml         # 直接編集（eventfx 等と同じ運用）
-chord --validate --config ~/.config/chord/config.toml  # 動作確認（任意）
+chord --validate                            # 動作確認（任意）
 chezmoi re-add ~/.config/chord/config.toml  # source に取り込み
 ```
 
 chord は vnode 監視で自動 reload するので明示 `chord --reload` は不要。
-修飾子組を変える場合は literal を一括置換 (`sed` 等)。将来 chord 本体に
-`[input-aliases]` 機能が入ったら、bare 参照 (`input = "ULTRA_LL - c"`) に
-書き換える予定。
+修飾子組を変える場合は `[input-aliases]` テーブルの 1 行を書き換えるだけで、
+binding 側 (`input = "ULTRA_LL - c"`) は触らずに済む。
 
 ## chord 側のセットアップ（参考）
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -299,13 +299,47 @@ op read "op://Vault/Item/field"
 | `mas install` が無音失敗 | brew 同梱 mas のバグ（過去 1.8.6 系で macOS 15+ 不具合）→ Nix 側 `mas`（`home/modules/packages.nix`）経由で叩く |
 | `system.defaults` がアプリに反映されない | TCC/sandbox 保護領域（Mail/Safari/Calendar 等）は switch 成功でも適用されない、深追いしない |
 
+### 5.10 chord daemon を手元 build で入れ替え（AX 維持）
+
+chord 本体に PR が ship されたけど tap formula がまだ古い、という過渡期に「手元 build を brew install の代わりに走らせる」手順。chord-dev 自己署名で再署名すれば既存 AX (Accessibility) 許可が引き継がれる。
+
+```sh
+# 1. 最新 chord (PR 含む main) を release build
+cd "$(ghq root)/github.com/akira-toriyama/chord"
+git switch main && git pull
+swift build -c release
+
+# 2. daemon 停止
+brew services stop chord
+sleep 1
+
+# 3. brew install の Chord.app 中の binary を swap
+CHORD_APP=/opt/homebrew/Cellar/chord/0.4.0/Chord.app
+NEW=/Volumes/workspace/github.com/akira-toriyama/chord/.build/release/chord
+cp "$CHORD_APP/Contents/MacOS/chord" "$CHORD_APP/Contents/MacOS/chord.bak"
+cp "$NEW" "$CHORD_APP/Contents/MacOS/chord"
+
+# 4. chord-dev で再署名 (TCC が同一 identity として認識 → AX 維持)
+codesign --force --sign chord-dev "$CHORD_APP"
+
+# 5. daemon 再起動 + 確認
+brew services start chord
+sleep 2
+chord --doctor
+# bindings: N loaded, ... 0 dropped (期待値)
+```
+
+戻すとき: `cp "$CHORD_APP/Contents/MacOS/chord.bak" "$CHORD_APP/Contents/MacOS/chord" && codesign --force --sign chord-dev "$CHORD_APP" && brew services restart chord`
+
+正規 tap release が出たら `brew upgrade chord && chord --resign` で本来の運用に戻る。
+
 </details>
 
 ---
 
-## 将来計画メモ
+## 完了済の大きな migration
 
-- **chord `[input-aliases]` 機能** — chord 本体に modifier セットの alias 解決機能を追加できれば、`chezmoi/dot_config/chord/private_config.toml` の literal modifier 表記 (`rctrl + ralt + rshift - c` × 14 箇所) を bare 論理名 (`ULTRA_LL - c`) に書き戻せる。`scripts/gen-chord-doc.py` の hardcoded dict も削除可。PR #108 では Phase 1（dotfiles 単独で `.tmpl` 廃止）まで実行、Phase 2 は別 PR 想定。
+- **chord `[input-aliases]` 機能 + 論理名移行** — chord 本体 ([akira-toriyama/chord PR #4](https://github.com/akira-toriyama/chord/pull/4)) で `[input-aliases]` 機能が ship 済。`chezmoi/dot_config/chord/private_config.toml` は `[input-aliases]` テーブル + bare `ULTRA_LL` 参照に移行済、`scripts/gen-chord-doc.py` の hardcoded dict も削除済。daemon 入れ替え手順は下の 5.10 を参照。
 
 ## 参考
 

--- a/scripts/gen-chord-doc.py
+++ b/scripts/gen-chord-doc.py
@@ -4,9 +4,14 @@
 
 各 `[[bindings]]` 直前の `# doc: <動作>` 行を唯一のソースとし、docs/chord.md
 内の AUTO-GENERATED マーカー間（markdown 表）を書き換える。
-ショートカット表記は `input = "..."` から導出。modifier セットが ZMK 物理
-chord の 4 組（ULTRA_LL/MIRACLE_LM/MEGA_RM/WONDER_RR）に一致する場合は
-論理名で出力する（literal の `rctrl + ralt + rshift` ではなく `ULTRA_LL`）。
+
+ショートカット表記は `input = "..."` から導出。`input` 内の token は:
+  • built-in modifier (cmd / ctrl / shift / ...) → 表記正規化（Cmd / Ctrl /
+    ...）
+  • chord の `[input-aliases]` で定義された論理名 (ULTRA_LL 等) →
+    そのまま出力（bare reference を尊重）
+  • 単文字キー → 大文字
+  • 複数文字キー (kp_1 / forward_delete / left 等) → そのまま
 
   python3 scripts/gen-chord-doc.py            # 生成して docs/chord.md を更新
   python3 scripts/gen-chord-doc.py --check    # 差分があれば exit 1 (CI 用)
@@ -31,18 +36,9 @@ BIND_RE = re.compile(r'^\[\[bindings\]\]\s*$')
 INPUT_RE = re.compile(r'^input\s*=\s*"(.+?)"\s*$')
 APPS_RE = re.compile(r'^apps\s*=\s*\[(.+?)\]\s*$')
 
-# ZMK 物理 chord (4 修飾子セット) の literal → 論理名 mapping。
-# 順序非依存に照合するため frozenset で持つ。
-# chord 本体に [input-aliases] 機能が入ったら、config の [input-aliases]
-# テーブルを直接読む実装に差し替えてこの dict を削除する予定。
-MODIFIER_SET_NAMES: dict[frozenset[str], str] = {
-    frozenset(["rctrl", "ralt", "rshift"]): "ULTRA_LL",
-    frozenset(["rctrl", "rcmd", "rshift"]): "MIRACLE_LM",
-    frozenset(["rctrl", "rcmd", "ralt"]):   "MEGA_RM",
-    frozenset(["rcmd",  "ralt", "rshift"]): "WONDER_RR",
-}
-
 # 修飾子トークンの表記正規化（chord の input 文法に合わせる）。
+# [input-aliases] で定義された論理名 (ULTRA_LL 等) はこの dict に該当
+# しないので、_format_token のフォールバックで原文のまま出力される。
 _MOD = {
     "cmd": "Cmd", "opt": "Opt", "alt": "Opt", "option": "Opt",
     "ctrl": "Ctrl", "control": "Ctrl",
@@ -51,8 +47,8 @@ _MOD = {
 
 
 def _format_token(tok: str) -> str:
-    """修飾子は表記正規化、単文字は大文字、複数文字キー（kp_1/forward_delete/
-    left 等）はそのまま。"""
+    """built-in modifier は表記正規化、単文字は大文字、複数文字キー / 論理名
+    （ULTRA_LL 等）はそのまま。"""
     low = tok.lower()
     if low in _MOD:
         return _MOD[low]
@@ -60,17 +56,13 @@ def _format_token(tok: str) -> str:
 
 
 def chord_str(input_raw: str) -> str:
-    """`rctrl + ralt + rshift - c` → `ULTRA_LL + C`（4 set のいずれかに該当時）。
-    `ctrl + shift - tab` → `Ctrl + Shift + Tab`（該当しない時の通常表記）。
-    mods の有無に対応（単押し: `kp_1` → `kp_1`）。"""
+    """`ULTRA_LL - c` → `ULTRA_LL + C`（input-aliases の bare reference）。
+    `ctrl + shift - tab` → `Ctrl + Shift + Tab`（built-in modifier 表記）。
+    `kp_1` → `kp_1`（単押しキー）。"""
     if " - " in input_raw:
         mod_part, key_part = input_raw.split(" - ", 1)
-        mods_lower = [t.strip().lower() for t in mod_part.split("+")]
-        key = _format_token(key_part.strip())
-        ms_name = MODIFIER_SET_NAMES.get(frozenset(mods_lower))
-        if ms_name:
-            return f"{ms_name} + {key}"
         toks = [_format_token(t.strip()) for t in mod_part.split("+")]
+        key = _format_token(key_part.strip())
         return " + ".join(toks + [key])
     return _format_token(input_raw.strip())
 


### PR DESCRIPTION
## Summary

[akira-toriyama/chord PR #4](https://github.com/akira-toriyama/chord/pull/4) で chord 本体に `[input-aliases]` 機能が ship されたので、**Phase 2 migration** を実行。modifier 4 セット (ULTRA_LL/MIRACLE_LM/MEGA_RM/WONDER_RR) を literal から論理名 bare reference に置換、`gen-chord-doc.py` の hardcoded dict も削除。

## 変更内訳

### `chezmoi/dot_config/chord/private_config.toml`
- ヘッダコメントを「literal で書く」→「`[input-aliases]` で論理名化」に更新
- 新規 `[input-aliases]` テーブル:
  ```toml
  [input-aliases]
  ULTRA_LL   = "rctrl + ralt + rshift"
  MIRACLE_LM = "rctrl + rcmd + rshift"
  MEGA_RM    = "rctrl + rcmd + ralt"
  WONDER_RR  = "rcmd + ralt + rshift"
  ```
- 全 bindings / fallbacks の `input` を literal から bare 論理名に置換（15 箇所: ULTRA_LL ×12 / 他 3 set 各 1）
- 例: `"rctrl + ralt + rshift - c"` → `"ULTRA_LL - c"`

### `scripts/gen-chord-doc.py`
- `MODIFIER_SET_NAMES` dict (4 set の literal → 論理名 mapping) を **削除**
- `chord_str()` を簡素化: input を split → 各 token を `_format_token` で正規化するだけ
  - built-in modifier (cmd/ctrl/...) → `Cmd` / `Ctrl` 等に正規化
  - 論理名 (ULTRA_LL 等) → 原文のまま出力（chord の `[input-aliases]` で定義されていれば config 内で完結）
- docstring を新挙動に合わせて更新

### `docs/chord.md`
- ファイル説明から「literal で書く」「dict が復元する」記述を削除
- `[input-aliases]` / bare reference / 修飾子組変更は table 1 行書き換えで済む 旨に更新

### `docs/operations.md`
- 「将来計画メモ」→「完了済の大きな migration」にリネーム、Phase 2 完了を明記
- **§5.10 chord daemon を手元 build で入れ替え (AX 維持)** を新設
  - tap formula が PR 反映前の過渡期向け手順
  - `codesign --force --sign chord-dev` で AX 引き継ぎ

## 動作確認

```
$ chezmoi diff
(empty — live ↔ source 一致)

$ chord --validate --strict
parsed: 19 bindings, 4 fallbacks, 1 aliases; dropped: 0, undefined-aliases: 0, warnings: 0

$ python3 scripts/gen-chord-doc.py --check
chord doc は同期済み

$ chord --list --json | jq '.input_aliases'
{
  "ULTRA_LL": "rctrl + ralt + rshift",
  "MIRACLE_LM": "rctrl + rcmd + rshift",
  "MEGA_RM": "rctrl + rcmd + ralt",
  "WONDER_RR": "rcmd + ralt + rshift"
}

$ chord --list --json | jq '.bindings[0].input.raw, .bindings[0].input.modifiers'
"ULTRA_LL - c"
["rctrl", "ropt", "rshift"]

$ chord --doctor
bindings: 19 loaded, 4 fallbacks, 1 aliases, 0 dropped
daemon: running
```

実機 daemon は手元 build (chord main、PR #4 含む) に既に入れ替え済（手順は §5.10）。`ULTRA_LL + c` 等の物理チョード動作確認済。

## 依存関係

- akira-toriyama/chord PR #4 (merged as 1813b9f) — `[input-aliases]` 機能本体
- daemon が PR #4 を含むビルドであることが前提（tap formula はまだ未更新、本 PR の §5.10 に過渡期手順あり）

## Test plan

- [x] `chezmoi diff` 空
- [x] `chord --validate --strict` 0 warnings
- [x] `gen-chord-doc.py --check` 同期済
- [x] `docs/chord.md` table が論理名で出力 (ULTRA_LL + C 等)
- [x] 実機 daemon で ULTRA_LL チョード動作
- [ ] CI green を待つ