### PR TITLE
:sparkles: feat(chord): v0.6.0 syntax 移行 ($prefix + [action-aliases])

### DIFF
--- a/chezmoi/dot_config/chord/private_config.toml
+++ b/chezmoi/dot_config/chord/private_config.toml
@@ -3,7 +3,7 @@
 # eventfx 等と同じ「直接編集 → re-add」運用。
 #
 # 修飾子 4 セット (ZMK 物理 chord) は [input-aliases] で論理名化し、
-# `input = "ULTRA_LL - c"` のように bare reference する
+# `input = "$ULTRA_LL - c"` のように `$prefix` で参照する
 # (chord の [input-aliases] 機能、akira-toriyama/chord PR #4)。
 #   ULTRA_LL   = rctrl + ralt + rshift   (RALT+RSHIFT+RCTRL, RGUI なし)
 #   MIRACLE_LM = rctrl + rcmd + rshift   (RGUI+RSHIFT+RCTRL, RALT なし)
@@ -28,17 +28,17 @@ exclude-apps = []
 
 
 # =====================================================================
-# Aliases — chord 0.3.x の [aliases] 機能で shell-action を DRY 化。
+# Aliases — chord の [action-aliases] 機能 (v0.6.0+)で shell-action を DRY 化。
 # `@name` で参照。$HOME は zsh -l -c が実行時展開する。
 # =====================================================================
 
-[aliases]
+[action-aliases]
 play-undef = 'afplay "$HOME/.local/share/sounds/undefined_key.wav"'
 
 
 # =====================================================================
 # Input aliases — chord の [input-aliases] 機能で modifier セットを論理名化。
-# bare reference (no @ prefix)。built-in modifier (cmd / ctrl / ...) と
+# `$prefix` で参照 (v0.6.0+、no @ prefix と区別)。built-in modifier (cmd / ctrl / ...) と
 # 名前衝突する alias は load 時 reject される。case-insensitive。
 # =====================================================================
 
@@ -59,53 +59,53 @@ WONDER_RR  = "rcmd + ralt + rshift"
 # doc: タブを左へ（Chrome: Ctrl+Shift+Tab）
 [[bindings]]
 name = "tab-left (Chrome)"
-input = "ULTRA_LL - c"
+input = "$ULTRA_LL - c"
 apps = ["com.google.Chrome"]
 action-keys = "ctrl + shift - tab"
 
 # doc: タブを左へ（VS Code: Cmd+Shift+[）
 [[bindings]]
 name = "tab-left (VS Code)"
-input = "ULTRA_LL - c"
+input = "$ULTRA_LL - c"
 apps = ["com.microsoft.VSCode"]
 action-keys = "cmd + shift - ["
 
 # doc: タブを右へ（Chrome: Ctrl+Tab）
 [[bindings]]
 name = "tab-right (Chrome)"
-input = "ULTRA_LL - v"
+input = "$ULTRA_LL - v"
 apps = ["com.google.Chrome"]
 action-keys = "ctrl - tab"
 
 # doc: タブを右へ（VS Code: Cmd+Shift+]）
 [[bindings]]
 name = "tab-right (VS Code)"
-input = "ULTRA_LL - v"
+input = "$ULTRA_LL - v"
 apps = ["com.microsoft.VSCode"]
 action-keys = "cmd + shift - ]"
 
 # doc: 前のウィンドウへ（rift フォーカス）
 [[bindings]]
 name = "rift focus prev"
-input = "ULTRA_LL - d"
+input = "$ULTRA_LL - d"
 action-shell = "rift-cli execute window prev"
 
 # doc: 次のウィンドウへ（rift フォーカス）
 [[bindings]]
 name = "rift focus next"
-input = "ULTRA_LL - f"
+input = "$ULTRA_LL - f"
 action-shell = "rift-cli execute window next"
 
 # doc: AltTab 起動（全スペース。旧 cmd+ctrl+tab）
 [[bindings]]
 name = "alttab all-spaces"
-input = "ULTRA_LL - a"
+input = "$ULTRA_LL - a"
 action-shell = "/Applications/AltTab.app/Contents/MacOS/AltTab --show=1"
 
 # doc: AltTab 起動（現スペース。旧 alt+tab）
 [[bindings]]
 name = "alttab current-space"
-input = "ULTRA_LL - s"
+input = "$ULTRA_LL - s"
 action-shell = "/Applications/AltTab.app/Contents/MacOS/AltTab --show=0"
 
 
@@ -170,27 +170,27 @@ action-keys = "return"
 # `*` ワイルドカードで実装。[[bindings]] が全 miss した時だけ [[fallbacks]]
 # が評価されるので、既存バインドとの誤爆は発生しない。
 # 音は 1 種共通（旧 skhd 時代の運用と同じ）。アセットは dotfiles 管轄、
-# `@play-undef` (上の [aliases]) 経由で参照する。
+# `@play-undef` (上の [action-aliases]) 経由で参照する。
 # `# doc:` は付けない（README ショートカット表に出さない＝負のバインド扱い）。
 
 [[fallbacks]]
 name = "ULTRA_LL undefined feedback"
-input = "ULTRA_LL - *"
+input = "$ULTRA_LL - *"
 action-shell = "@play-undef"
 
 [[fallbacks]]
 name = "MIRACLE_LM undefined feedback"
-input = "MIRACLE_LM - *"
+input = "$MIRACLE_LM - *"
 action-shell = "@play-undef"
 
 [[fallbacks]]
 name = "MEGA_RM undefined feedback"
-input = "MEGA_RM - *"
+input = "$MEGA_RM - *"
 action-shell = "@play-undef"
 
 [[fallbacks]]
 name = "WONDER_RR undefined feedback"
-input = "WONDER_RR - *"
+input = "$WONDER_RR - *"
 action-shell = "@play-undef"
 
 
@@ -204,18 +204,18 @@ action-shell = "@play-undef"
 
 [[bindings]]
 name = "ULTRA_LL + j → arm j-layer"
-input = "ULTRA_LL - j"
+input = "$ULTRA_LL - j"
 action-set-var = "jlayer"
 hold-while-timeout = 1500
 
 [[bindings]]
 name = "ULTRA_LL + k → Enter (in j-layer)"
-input = "ULTRA_LL - k"
+input = "$ULTRA_LL - k"
 when-var = "jlayer"
 action-keys = "return"
 
 [[bindings]]
 name = "ULTRA_LL + l → Backspace (in j-layer)"
-input = "ULTRA_LL - l"
+input = "$ULTRA_LL - l"
 when-var = "jlayer"
 action-keys = "backspace"

--- a/docs/chord.md
+++ b/docs/chord.md
@@ -8,10 +8,10 @@ ZMK ファームから届くチョードを macOS 側で捕まえてアクショ
 
 - [chezmoi/dot_config/chord/private_config.toml](../chezmoi/dot_config/chord/private_config.toml):
   plain TOML（**唯一のソース**、template 評価なし）。`[options]`、
-  `[aliases]`（shell-action の DRY 化）、`[input-aliases]`（modifier セットの
+  `[action-aliases]`（shell-action の DRY 化、`@name`）、`[input-aliases]`（modifier セットの
   論理名）、`[[bindings]]`、`[[fallbacks]]` を含む。ZMK 右側修飾子セット 4 個
   (ULTRA_LL/MIRACLE_LM/MEGA_RM/WONDER_RR) は `[input-aliases]` で **論理名定義**
-  → `input = "ULTRA_LL - c"` のように bare reference する。
+  → `input = "$ULTRA_LL - c"` のように `$prefix` で参照する。
 - [chezmoi/run_onchange_after_chord-validate.sh.tmpl](../chezmoi/run_onchange_after_chord-validate.sh.tmpl):
   `chezmoi apply` 後に `chord --validate` を走らせる検証ゲート。chord 在中時のみ
   実行され、失敗時は exit 1 を返す（fresh bootstrap や CI Linux では no-op）。
@@ -33,7 +33,7 @@ chezmoi re-add ~/.config/chord/config.toml  # source に取り込み
 
 chord は vnode 監視で自動 reload するので明示 `chord --reload` は不要。
 修飾子組を変える場合は `[input-aliases]` テーブルの 1 行を書き換えるだけで、
-binding 側 (`input = "ULTRA_LL - c"`) は触らずに済む。
+binding 側 (`input = "$ULTRA_LL - c"`) は触らずに済む。
 
 ## chord 側のセットアップ（参考）
 
@@ -64,14 +64,14 @@ private_config.toml の `# doc:` 行＋`[[bindings]]` を編集 →
 
 | Chord | Action | Apps |
 |---|---|---|
-| `ULTRA_LL + C` | タブを左へ（Chrome: Ctrl+Shift+Tab） | com.google.Chrome |
-| `ULTRA_LL + C` | タブを左へ（VS Code: Cmd+Shift+[） | com.microsoft.VSCode |
-| `ULTRA_LL + V` | タブを右へ（Chrome: Ctrl+Tab） | com.google.Chrome |
-| `ULTRA_LL + V` | タブを右へ（VS Code: Cmd+Shift+]） | com.microsoft.VSCode |
-| `ULTRA_LL + D` | 前のウィンドウへ（rift フォーカス） | * |
-| `ULTRA_LL + F` | 次のウィンドウへ（rift フォーカス） | * |
-| `ULTRA_LL + A` | AltTab 起動（全スペース。旧 cmd+ctrl+tab） | * |
-| `ULTRA_LL + S` | AltTab 起動（現スペース。旧 alt+tab） | * |
+| `$ULTRA_LL + C` | タブを左へ（Chrome: Ctrl+Shift+Tab） | com.google.Chrome |
+| `$ULTRA_LL + C` | タブを左へ（VS Code: Cmd+Shift+[） | com.microsoft.VSCode |
+| `$ULTRA_LL + V` | タブを右へ（Chrome: Ctrl+Tab） | com.google.Chrome |
+| `$ULTRA_LL + V` | タブを右へ（VS Code: Cmd+Shift+]） | com.microsoft.VSCode |
+| `$ULTRA_LL + D` | 前のウィンドウへ（rift フォーカス） | * |
+| `$ULTRA_LL + F` | 次のウィンドウへ（rift フォーカス） | * |
+| `$ULTRA_LL + A` | AltTab 起動（全スペース。旧 cmd+ctrl+tab） | * |
+| `$ULTRA_LL + S` | AltTab 起動（現スペース。旧 alt+tab） | * |
 | `kp_1` | Mission Control（全ワークスペースをグリッド表示） | * |
 | `Ctrl + B` | ← Left | * |
 | `Ctrl + F` | → Right | * |

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -314,7 +314,9 @@ brew services stop chord
 sleep 1
 
 # 3. brew install の Chord.app 中の binary を swap
-CHORD_APP=/opt/homebrew/Cellar/chord/0.4.0/Chord.app
+#    `/opt/homebrew/opt/chord` は現バージョンへの symlink (例: ../Cellar/chord/0.5.0)
+#    なので version 数字を埋め込まずに済む。
+CHORD_APP="$(brew --prefix chord)/Chord.app"
 NEW=/Volumes/workspace/github.com/akira-toriyama/chord/.build/release/chord
 cp "$CHORD_APP/Contents/MacOS/chord" "$CHORD_APP/Contents/MacOS/chord.bak"
 cp "$NEW" "$CHORD_APP/Contents/MacOS/chord"

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -35,12 +35,6 @@ gh pr create --title "..." --body "..."
 gh pr merge --auto --squash
 ```
 
-### 注意点
-
-- **`.tmpl` を持つのは現状 `run_onchange_after_chord-validate.sh.tmpl` のみ** で、これは `{{ include ... | sha256sum }}` で chord config の hash を埋め込む技術的必要から（他ファイル変更を再走トリガに使う）。直接編集対象ではないので運用上の影響なし。
-- 将来もし `.tmpl` を新規追加するなら、その対象ファイルは `chezmoi re-add` ではなく **source `.tmpl` を直接編集**する必要がある（template 変数が literal に戻ってしまうため）。
-- `run_onchange_` スクリプトは `chezmoi apply` で hash 変化を検知して再走する（例: chord-validate.sh は chord config の sha256 を埋め込んでいる）。
-
 </details>
 
 ---

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -335,7 +335,7 @@ chord --doctor
 
 ## 完了済の大きな migration
 
-- **chord `[input-aliases]` 機能 + 論理名移行** — chord 本体 ([akira-toriyama/chord PR #4](https://github.com/akira-toriyama/chord/pull/4)) で `[input-aliases]` 機能が ship 済。`chezmoi/dot_config/chord/private_config.toml` は `[input-aliases]` テーブル + bare `ULTRA_LL` 参照に移行済、`scripts/gen-chord-doc.py` の hardcoded dict も削除済。daemon 入れ替え手順は下の 5.10 を参照。
+- **chord `[input-aliases]` 機能 + 論理名移行** — chord 本体で `[input-aliases]` 機能が ship 済 ([PR #4](https://github.com/akira-toriyama/chord/pull/4) v0.5.0 初版、[PR #7](https://github.com/akira-toriyama/chord/pull/7) で v0.6.0 として `$prefix` 必須 + `[aliases]` → `[action-aliases]` rename + schema v2 → v3)。`chezmoi/dot_config/chord/private_config.toml` は `[action-aliases]` + `[input-aliases]` + `$prefix` 参照 (`input = "$ULTRA_LL - c"`) に移行済。`scripts/gen-chord-doc.py` の hardcoded dict は削除済 (chord 自身が alias 解決)。daemon 入れ替えは `brew upgrade chord && chord --resign` か 5.10 の手元 build 手順を参照。
 
 ## 参考
 


### PR DESCRIPTION
## Summary

[akira-toriyama/chord v0.6.0](https://github.com/akira-toriyama/chord/releases/tag/v0.6.0) ([PR #7](https://github.com/akira-toriyama/chord/pull/7)) の breaking changes に追随。

## 変更

### `chezmoi/dot_config/chord/private_config.toml`
- `[aliases]` → `[action-aliases]` テーブル名変更
- 全 bindings / fallbacks の `input` を **bare → `$prefix`** に置換 (15 箇所)
  - `"ULTRA_LL - c"` → `"$ULTRA_LL - c"` 等
- ヘッダコメントの「bare reference」記述を「`$prefix` で参照」に修正

### `docs/chord.md`
- AUTO-GENERATED table が `$ULTRA_LL + C` 等で再生成 (`gen-chord-doc.py` は token をそのまま formatter に渡すので `$ULTRA_LL` がそのまま出る)
- `[aliases]` 記述 → `[action-aliases]` (`@name`) に更新
- 使い方説明の `bare reference` → `$prefix` 参照に書き換え

### `docs/operations.md`
- 完了済 migration セクションに **chord v0.6.0** の追記 (PR #7、`$prefix`、`[action-aliases]`、schema v3、`brew upgrade chord` 手順)

## 動作確認

```
$ brew upgrade akira-toriyama/tap/chord
# → 0.6.0 installed (Cellar/chord/0.6.0)

$ chord --quit
$ sed -i.bak 's/^\[aliases\]/[action-aliases]/; s/input = "(ULTRA_LL|...)/input = "$\1/g' ~/.config/chord/config.toml
$ chord --resign
# chord-dev で再署名 + brew services restart (AX 維持)

$ chord --validate --strict
parsed: 19 bindings, 4 fallbacks, 1 action-aliases; dropped: 0, undefined-action-aliases: 0, warnings: 0

$ chord --doctor
bindings: 19 loaded, 4 fallbacks, 1 action-aliases, 0 dropped
daemon: running

$ python3 scripts/gen-chord-doc.py --check
chord doc は同期済み

$ chezmoi diff ~/.config/chord/config.toml
(empty — live ↔ source 一致)
```

物理 ZMK チョード (`\$ULTRA_LL + c` 等) で実機動作確認済。

## 依存関係

- akira-toriyama/chord v0.6.0 (released today、tap formula 自動 bump 済)
- daemon を v0.6.0 に上げないと旧 syntax (bare `ULTRA_LL`) は drop されるが、本 PR は **v0.6.0 syntax** を含むので、merge 前に daemon を upgrade することが前提

## Test plan

- [x] live config が v0.6.0 syntax で valid
- [x] `chord --validate --strict` 0 warnings
- [x] `gen-chord-doc.py --check` 同期済
- [x] chezmoi diff 空 (source ↔ live)
- [x] 物理チョード動作確認
- [ ] CI green を待つ