### PR TITLE
:sparkles: feat(launchd): homebrew drift を daily 検知 + macOS 通知

### DIFF
--- a/system/modules/default.nix
+++ b/system/modules/default.nix
@@ -6,5 +6,6 @@
   imports = [
     ./homebrew.nix
     ./defaults.nix
+    ./launchd-drift.nix
   ];
 }

--- a/system/modules/homebrew.nix
+++ b/system/modules/homebrew.nix
@@ -21,7 +21,9 @@
     taps = [
       "barutsrb/tap"   # omniwm (Niri-inspired tiling WM by BarutSRB) を解決するため
     ];
-    brews = [ ];
+    brews = [
+      "terminal-notifier" # macOS 通知 CLI。launchd-drift.nix の drift 検知通知で使用
+    ];
 
     casks = [
       # 1Password 8 デスクトップ。SSH エージェント / op CLI 連携の前提

--- a/system/modules/launchd-drift.nix
+++ b/system/modules/launchd-drift.nix
@@ -1,0 +1,26 @@
+{ ... }:
+
+{
+  # homebrew.nix の宣言 ↔ 実 install を毎日 1 回チェックする LaunchAgent。
+  # drift があれば macOS 通知 (osascript) を出すだけ。自動修正はしない。
+  # スクリプト本体は ./scripts/check-homebrew-drift.sh (Nix store にコピーされる)。
+  # 手動実行は: bash $(readlink ~/Library/LaunchAgents/org.nixos.homebrew-drift.plist | xargs grep -A1 ProgramArguments | tail -1 | sed 's/.*>\(.*\)<.*/\1/')
+  # シンプルには: ~/Volumes/workspace/.../system/modules/scripts/check-homebrew-drift.sh を直接叩く。
+  launchd.user.agents.homebrew-drift = {
+    serviceConfig = {
+      Label = "org.nixos.homebrew-drift";
+      ProgramArguments = [
+        "/bin/bash"
+        "${./scripts/check-homebrew-drift.sh}"
+      ];
+      # 毎日 09:00 に起動。ログイン時は走らせない (RunAtLoad = false)。
+      StartCalendarInterval = [{
+        Hour = 9;
+        Minute = 0;
+      }];
+      RunAtLoad = false;
+      StandardOutPath = "/tmp/homebrew-drift.log";
+      StandardErrorPath = "/tmp/homebrew-drift.log";
+    };
+  };
+}

--- a/system/modules/launchd-drift.nix
+++ b/system/modules/launchd-drift.nix
@@ -1,11 +1,10 @@
-{ ... }:
+{ username, ... }:
 
 {
   # homebrew.nix の宣言 ↔ 実 install を毎日 1 回チェックする LaunchAgent。
-  # drift があれば macOS 通知 (osascript) を出すだけ。自動修正はしない。
+  # drift があれば macOS 通知 (terminal-notifier) を出すだけ。自動修正はしない。
   # スクリプト本体は ./scripts/check-homebrew-drift.sh (Nix store にコピーされる)。
-  # 手動実行は: bash $(readlink ~/Library/LaunchAgents/org.nixos.homebrew-drift.plist | xargs grep -A1 ProgramArguments | tail -1 | sed 's/.*>\(.*\)<.*/\1/')
-  # シンプルには: ~/Volumes/workspace/.../system/modules/scripts/check-homebrew-drift.sh を直接叩く。
+  # 手動実行は: bash <repo>/system/modules/scripts/check-homebrew-drift.sh
   launchd.user.agents.homebrew-drift = {
     serviceConfig = {
       Label = "org.nixos.homebrew-drift";
@@ -23,4 +22,27 @@
       StandardErrorPath = "/tmp/homebrew-drift.log";
     };
   };
+
+  # 初回 darwin-rebuild switch で 1 度だけ「通知許可ページを開く」hint。
+  # terminal-notifier の通知許可がデフォ OFF なので、許可が漏れると drift
+  # 検知通知が silent failure する。誘導しないと気付けない事案を回避。
+  # flag file ($HOME/.local/state/dotfiles/tn-permission-hinted) の有無で
+  # 冪等化、2 回目以降の switch では何もしない。
+  # 再 hint させたい時は flag file を rm。
+  system.activationScripts.notifyPermissionHint.text = ''
+    HINT_FLAG="/Users/${username}/.local/state/dotfiles/tn-permission-hinted"
+    if [ ! -f "$HINT_FLAG" ] && [ -x /opt/homebrew/bin/terminal-notifier ]; then
+      echo "[notifyPermissionHint] first-run hint を表示します"
+      sudo -u ${username} /opt/homebrew/bin/terminal-notifier \
+        -group "homebrew-drift-setup" \
+        -title "homebrew-drift セットアップ" \
+        -subtitle "通知許可をお願いします" \
+        -message "System Settings → 通知 → terminal-notifier を ON にしてください" \
+        -sound Pop || true
+      sudo -u ${username} open \
+        "x-apple.systempreferences:com.apple.preference.notifications" || true
+      sudo -u ${username} mkdir -p "$(dirname "$HINT_FLAG")"
+      sudo -u ${username} touch "$HINT_FLAG"
+    fi
+  '';
 }

--- a/system/modules/scripts/check-homebrew-drift.sh
+++ b/system/modules/scripts/check-homebrew-drift.sh
@@ -4,10 +4,15 @@
 #
 # 仕様:
 #   - cask: 双方向 (未宣言 install / 未 install 宣言) の両方検出
-#   - brew: missing (宣言 - install) のみ。brew leaves で top-level 比較
+#   - brew: 双方向 (未宣言 install / 未 install 宣言) の両方検出
+#           ※ install 側は `brew leaves` を使い deps を除外、top-level のみ比較
 #   - mas:  bootstrapBrewOverride で masApps が常に {} になるため対象外
 #   - 通知本文には最初の「未宣言 cask」の brew description を添える
 #   - flake パスは ghq → $HOME/dotfiles → $DOTFILES_FLAKE_DIR の順で解決
+#   - 通知は terminal-notifier (brew formula、homebrew.nix の brews で宣言)
+#     osascript の display notification は macOS 15 で Script Editor 経由に
+#     なり banner 抑止されがちなため不採用。
+#   - -group homebrew-drift 固定で「通知センターに常に最新 1 件」運用
 #   - 出力は /tmp/homebrew-drift.log にも残る (launchd の StandardOutPath)
 set -eu
 
@@ -57,16 +62,18 @@ for ignore in $IGNORE_EXTRA_CASKS; do
   extra_casks=$(echo "$extra_casks" | grep -v "^${ignore}$" || true)
 done
 missing_casks=$(comm -23 <(echo "$declared_casks") <(echo "$installed_casks") | grep -v '^$' || true)
+extra_brews=$(comm -13 <(echo "$declared_brews") <(echo "$installed_brews") | grep -v '^$' || true)
 missing_brews=$(comm -23 <(echo "$declared_brews") <(echo "$installed_brews") | grep -v '^$' || true)
 
 # stderr/log にも残す
 {
   [ -n "$extra_casks" ]   && printf '[未宣言 cask]\n%s\n' "$extra_casks"
   [ -n "$missing_casks" ] && printf '[未 install cask]\n%s\n' "$missing_casks"
+  [ -n "$extra_brews" ]   && printf '[未宣言 brew]\n%s\n' "$extra_brews"
   [ -n "$missing_brews" ] && printf '[未 install brew]\n%s\n' "$missing_brews"
 } || true
 
-if [ -z "$extra_casks$missing_casks$missing_brews" ]; then
+if [ -z "$extra_casks$missing_casks$extra_brews$missing_brews" ]; then
   echo "[$(date)] no drift"
   exit 0
 fi
@@ -75,6 +82,7 @@ fi
 summary=""
 [ -n "$extra_casks" ]   && summary="$summary 未宣言 cask: $(echo "$extra_casks" | tr '\n' ' ')"
 [ -n "$missing_casks" ] && summary="$summary / 未 install cask: $(echo "$missing_casks" | tr '\n' ' ')"
+[ -n "$extra_brews" ]   && summary="$summary / 未宣言 brew: $(echo "$extra_brews" | tr '\n' ' ')"
 [ -n "$missing_brews" ] && summary="$summary / 未 install brew: $(echo "$missing_brews" | tr '\n' ' ')"
 
 # 最初の「未宣言 cask」だけ brew info の description を添える (なぜ入れたかのヒント)
@@ -84,11 +92,16 @@ if [ -n "$first_extra" ]; then
   [ -n "$desc" ] && summary="$summary - 例: $first_extra → $desc"
 fi
 
-# osascript の文字列に " が混ざるとパース崩れ。エスケープ。
-escaped=$(printf '%s' "$summary" | sed 's/"/\\"/g')
-
-osascript \
-  -e "display notification \"$escaped\" with title \"homebrew drift\" subtitle \"system/modules/homebrew.nix を更新\" sound name \"Pop\"" \
-  >/dev/null 2>&1 || true
-
-echo "[$(date)] notified: $summary"
+# 通知。terminal-notifier 未導入なら log だけ残して exit (新 PC 初日対策)。
+if command -v terminal-notifier >/dev/null 2>&1; then
+  terminal-notifier \
+    -group "homebrew-drift" \
+    -title "homebrew drift" \
+    -subtitle "system/modules/homebrew.nix を更新" \
+    -message "$summary" \
+    -sound Pop \
+    >/dev/null 2>&1 || true
+  echo "[$(date)] notified: $summary"
+else
+  echo "[$(date)] terminal-notifier not found, drift logged only: $summary"
+fi

--- a/system/modules/scripts/check-homebrew-drift.sh
+++ b/system/modules/scripts/check-homebrew-drift.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+# system/modules/homebrew.nix の宣言と実 install の drift を 1 日 1 回検知し、
+# 差分があれば macOS 通知を出す。launchd-drift.nix から daily 起動される。
+#
+# 仕様:
+#   - cask: 双方向 (未宣言 install / 未 install 宣言) の両方検出
+#   - brew: missing (宣言 - install) のみ。brew leaves で top-level 比較
+#   - mas:  bootstrapBrewOverride で masApps が常に {} になるため対象外
+#   - 通知本文には最初の「未宣言 cask」の brew description を添える
+#   - flake パスは ghq → $HOME/dotfiles → $DOTFILES_FLAKE_DIR の順で解決
+#   - 出力は /tmp/homebrew-drift.log にも残る (launchd の StandardOutPath)
+set -eu
+
+# 「明示的に未宣言（破棄方針）」相当の cask は通知から除外する。
+# homebrew.nix 末尾コメントの破棄方針リストとは別管理。両方を更新する想定。
+IGNORE_EXTRA_CASKS="google-japanese-ime karabiner-elements"
+
+# launchd 環境は PATH がほぼ空。Homebrew + Nix の bin を明示注入する。
+PATH="/opt/homebrew/bin:/run/current-system/sw/bin:/nix/var/nix/profiles/default/bin:/usr/bin:/bin"
+export PATH
+
+FLAKE_DIR="${DOTFILES_FLAKE_DIR:-}"
+if [ -z "$FLAKE_DIR" ] && command -v ghq >/dev/null 2>&1; then
+  FLAKE_DIR=$(ghq list -p github.com/akira-toriyama/dotfiles 2>/dev/null | head -1)
+fi
+if [ -z "$FLAKE_DIR" ] && [ -d "$HOME/dotfiles" ]; then
+  FLAKE_DIR="$HOME/dotfiles"
+fi
+if [ -z "$FLAKE_DIR" ] || [ ! -e "$FLAKE_DIR/flake.nix" ]; then
+  echo "[$(date)] flake not found, skipping"
+  exit 0
+fi
+
+echo "[$(date)] checking drift against $FLAKE_DIR"
+
+# 宣言側: nix eval (失敗時は空)
+declared_casks=$(
+  nix eval --json "$FLAKE_DIR#darwinConfigurations.default.config.homebrew.casks" --impure 2>/dev/null \
+    | jq -r '.[] | if type == "object" then .name else . end' 2>/dev/null | sort || true
+)
+declared_brews=$(
+  nix eval --json "$FLAKE_DIR#darwinConfigurations.default.config.homebrew.brews" --impure 2>/dev/null \
+    | jq -r '.[] | if type == "object" then .name else . end' 2>/dev/null | sort || true
+)
+
+# 実 install 側
+installed_casks=$(brew list --cask 2>/dev/null | sort || true)
+# brew leaves = top-level (依存だけで入った formula は除外)。
+# 宣言に無い leaves が出ても、それは「明示 install してまだ宣言してない」もの。
+installed_brews=$(brew leaves 2>/dev/null | sort || true)
+
+# diff (POSIX: comm を使う)
+extra_casks_raw=$(comm -13 <(echo "$declared_casks") <(echo "$installed_casks") | grep -v '^$' || true)
+# IGNORE_EXTRA_CASKS を除外
+extra_casks=$extra_casks_raw
+for ignore in $IGNORE_EXTRA_CASKS; do
+  extra_casks=$(echo "$extra_casks" | grep -v "^${ignore}$" || true)
+done
+missing_casks=$(comm -23 <(echo "$declared_casks") <(echo "$installed_casks") | grep -v '^$' || true)
+missing_brews=$(comm -23 <(echo "$declared_brews") <(echo "$installed_brews") | grep -v '^$' || true)
+
+# stderr/log にも残す
+{
+  [ -n "$extra_casks" ]   && printf '[未宣言 cask]\n%s\n' "$extra_casks"
+  [ -n "$missing_casks" ] && printf '[未 install cask]\n%s\n' "$missing_casks"
+  [ -n "$missing_brews" ] && printf '[未 install brew]\n%s\n' "$missing_brews"
+} || true
+
+if [ -z "$extra_casks$missing_casks$missing_brews" ]; then
+  echo "[$(date)] no drift"
+  exit 0
+fi
+
+# 通知本文を組み立て (空行除去 + 1 行サマリ化)
+summary=""
+[ -n "$extra_casks" ]   && summary="$summary 未宣言 cask: $(echo "$extra_casks" | tr '\n' ' ')"
+[ -n "$missing_casks" ] && summary="$summary / 未 install cask: $(echo "$missing_casks" | tr '\n' ' ')"
+[ -n "$missing_brews" ] && summary="$summary / 未 install brew: $(echo "$missing_brews" | tr '\n' ' ')"
+
+# 最初の「未宣言 cask」だけ brew info の description を添える (なぜ入れたかのヒント)
+first_extra=$(echo "$extra_casks" | head -n1)
+if [ -n "$first_extra" ]; then
+  desc=$(brew info --cask "$first_extra" --json=v2 2>/dev/null | jq -r '.casks[0].desc // empty' 2>/dev/null || true)
+  [ -n "$desc" ] && summary="$summary - 例: $first_extra → $desc"
+fi
+
+# osascript の文字列に " が混ざるとパース崩れ。エスケープ。
+escaped=$(printf '%s' "$summary" | sed 's/"/\\"/g')
+
+osascript \
+  -e "display notification \"$escaped\" with title \"homebrew drift\" subtitle \"system/modules/homebrew.nix を更新\" sound name \"Pop\"" \
+  >/dev/null 2>&1 || true
+
+echo "[$(date)] notified: $summary"


### PR DESCRIPTION
## Summary

- `homebrew.nix` の宣言と実 install の乖離を毎日 09:00 にチェック
- 差分があれば **terminal-notifier** で macOS 通知 (osascript display notification は macOS 15 で抑止されがちなため不採用)
- nix-darwin の `launchd.user.agents` で宣言、`darwin-rebuild switch` で plist 自動生成
- 初回 switch 時に「通知許可ページを開く」hint を 1 回だけ表示 (`system.activationScripts.notifyPermissionHint`、flag file で冪等)

## 検知範囲

| 種類 | 検知 | 備考 |
|---|---|---|
| cask | 双方向 (未宣言 install / 未 install 宣言) | 主目的 |
| brew | 双方向 (未宣言 install / 未 install 宣言) | `brew leaves` で top-level 比較 |
| mas | 対象外 | `bootstrapBrewOverride` で `masApps = {}` 固定 |

## 通知

- title: `homebrew drift` / subtitle: `system/modules/homebrew.nix を更新`
- message: drift 内容 + 最初の未宣言 cask の brew description
- `-group homebrew-drift` 固定 → 通知センターに常に最新 1 件のみ
- 0 件の日 = silent / log: `/tmp/homebrew-drift.log`

## 初回 hint

`darwin-rebuild switch` 実行時、`$HOME/.local/state/dotfiles/tn-permission-hinted` が無ければ 1 回だけ:
1. terminal-notifier テスト通知発火
2. `open` で通知設定を表示
3. flag file を touch → 以降は何もしない

再 hint させたい時は flag file を rm。

## ignore list

`google-japanese-ime` / `karabiner-elements` は破棄方針として通知から除外。`scripts/check-homebrew-drift.sh` の `IGNORE_EXTRA_CASKS` と `homebrew.nix` 末尾コメントを両方更新する想定。

## 手元 drift (= 本 PR で可視化される)

`brew leaves` で `brews` 宣言外の 8 件:
- `acsandmann/tap/rift` / `akira-toriyama/tap/{chord,facet,ws-tabs}` / `act` / `asdf` / `chezmoi` / `cirruslabs/cli/tart`

別 PR でクリーンナップ or 宣言化判断。

## Test plan

- [x] shellcheck clean
- [x] nix flake check --no-build --impure
- [x] スクリプト直叩きで drift 8 件検知
- [x] terminal-notifier 通知表示確認 (手元)
- [ ] merge 後 darwin-rebuild switch → plist 配置 + initial hint
- [ ] launchctl kickstart -p gui/$UID/org.nixos.homebrew-drift で即時テスト
- [ ] 翌 09:00 自動起動

## 関連 finding (別 PR 推奨)

- docs/operations.md §5.3 の手元 drift コマンド `jq -r '.[]'` は objects 出力で常に全件 mismatch → `.[].name` 修正必要
- brew leaves 8 件のクリーンナップ判断

🤖 Generated with [Claude Code](https://claude.com/claude-code)