### PR TITLE
:bug: fix(host): users.users.root.home を明示 (nix-darwin 新 assertion 対応)

### DIFF
--- a/system/hosts/generic.nix
+++ b/system/hosts/generic.nix
@@ -24,6 +24,9 @@
     name = username;
     home = "/Users/${username}";
   };
+  # nix-darwin master の最近の assertion で root.home が明示必要に。
+  # 既定の /var/root を明示するだけで eval が通る (上流要請の最小準拠)。
+  users.users.root.home = "/var/root";
   system.primaryUser = username;
 
   nix.enable = false;


### PR DESCRIPTION
## Summary

PR #114 merge 後の `darwin-rebuild switch` で以下のエラーが発生:

\`\`\`
error:
Failed assertions:
- \`users.users.root.home\` must be set to either \`null\` or \`/var/root\`.
\`\`\`

nix-darwin master が直近で `users.users.root.home` の明示を要求する assertion を追加したのが原因 (PR #114 の CI が通った後、7h 程度の間に上流が変わった)。修正は generic.nix に 1 行:

\`\`\`nix
users.users.root.home = "/var/root";
\`\`\`

## Test plan

- [x] \`nix flake check --no-build --impure\` ✅
- [ ] merge 後 \`darwin-rebuild switch --flake .#default --impure\` 完走

🤖 Generated with [Claude Code](https://claude.com/claude-code)