### PR TITLE
:robot: chore(drift): 35 brew の drift を検知 (DriftBot demo)

### DIFF
--- a/system/modules/homebrew.nix
+++ b/system/modules/homebrew.nix
@@ -22,6 +22,42 @@
       "barutsrb/tap"   # omniwm (Niri-inspired tiling WM by BarutSRB) を解決するため
     ];
     brews = [
+      # === DriftBot 検知分 (要レビュー: コメント書き直し / 適切なグループへ移動 / 不要なら削除) ===
+      "acsandmann/tap/rift"  # Tiling window manager for macOS  # TODO: review
+      "act"  # Run your GitHub Actions locally  # TODO: review
+      "akira-toriyama/tap/chord"  # Global keyboard + mouse hotkey daemon for macOS  # TODO: review
+      "akira-toriyama/tap/facet"  # Workspace + window manager for macOS — tree sidebar & TS3-style grid  # TODO: review
+      "akira-toriyama/tap/ws-tabs"  # Translucent workspace + window tab panel for the rift window manager  # TODO: review
+      "asdf"  # Extendable version manager with support for Ruby, Node.js, Erlang & more  # TODO: review
+      "chezmoi"  # Manage your dotfiles across multiple diverse machines, securely  # TODO: review
+      "cirruslabs/cli/tart"  # Run macOS and Linux VMs on Apple Hardware  # TODO: review
+      "cliclick"  # Tool for emulating mouse and keyboard events  # TODO: review
+      "cmake"  # Cross-platform make  # TODO: review
+      "colima"  # Container runtimes on MacOS (and Linux) with minimal setup  # TODO: review
+      "direnv"  # Load/unload environment variables based on $PWD  # TODO: review
+      "docker"  # Pack, ship and run any application as a lightweight container  # TODO: review
+      "docker-compose"  # Isolated development environments using Docker  # TODO: review
+      "f2"  # Command-line batch renaming tool  # TODO: review
+      "felixkratz/formulae/borders"  # A window border system for macOS  # TODO: review
+      "gh"  # GitHub command-line tool  # TODO: review
+      "ghq"  # Remote repository management made easy  # TODO: review
+      "gifski"  # Highest-quality GIF encoder based on pngquant  # TODO: review
+      "git-cliff"  # Highly customizable changelog generator  # TODO: review
+      "gperf"  # Perfect hash function generator  # TODO: review
+      "hudochenkov/sshpass/sshpass"  # ?  # TODO: review
+      "jackielii/tap/skhd-zig"  # ?  # TODO: review
+      "jq"  # Lightweight and flexible command-line JSON processor  # TODO: review
+      "koekeishiya/formulae/krp"  # Utility to adjust keyrepeat settings for MacOS.  # TODO: review
+      "koekeishiya/formulae/yabai"  # A tiling window manager for macOS based on binary space partitioning.  # TODO: review
+      "mas"  # Mac App Store command-line interface  # TODO: review
+      "ninja"  # Small build system for use with gyp or CMake  # TODO: review
+      "node"  # Open-source, cross-platform JavaScript runtime environment  # TODO: review
+      "pipx"  # Execute binaries from Python packages in isolated environments  # TODO: review
+      "shellcheck"  # Static analysis and lint tool, for (ba)sh scripts  # TODO: review
+      "sleepwatcher"  # Monitors sleep, wakeup, and idleness of a Mac  # TODO: review
+      "trash"  # CLI tool that moves files or folder to the trash  # TODO: review
+      "watchman"  # Watch files and take action when they change  # TODO: review
+      "yt-dlp"  # Feature-rich command-line audio/video downloader  # TODO: review
       "terminal-notifier" # macOS 通知 CLI。launchd-drift.nix の drift 検知通知で使用
     ];
 


### PR DESCRIPTION
## これは DriftBot (C 案) の検証用 demo PR (draft)

`brew leaves` にあるが `homebrew.nix` の `brews` に未宣言の項目を自動で宣言化提案したもの。

### 自動でやったこと
- `system/modules/homebrew.nix` の `brews` に「DriftBot 検知分」ブロックを追記
- 各行に brew description をコメント、`# TODO: review` マーカー
- `nix flake check --no-build` で eval 通過を確認

### レビュー側の手作業 (= C の手動部分)
- [ ] コメントを「なぜ入れるか」に書き直し
- [ ] 適切な group ブロックに行を移動
- [ ] 不要なもの (旧 WM / 移行済 CLI 等) は行削除 → 別途 `brew uninstall`
- [ ] draft 解除 → merge

🤖 DriftBot demo (Claude Code)