### PR TITLE
:sparkles: feat(drift): add-homebrew helper を Nix で PATH に + 詳細レポート連携

### DIFF
--- a/home/modules/packages.nix
+++ b/home/modules/packages.nix
@@ -29,5 +29,13 @@
     # install.sh の一発再現を確認できる (GitHub Actions の macos-15 runner も
     # 中身は Tart)。手元再現テストの起点。
     tart
+
+    # === homebrew drift 運用 helper ===
+    # `add-homebrew --name=foo --desc="..."` で homebrew.nix の brews/casks に
+    # 1 行追記する (cask/formula 自動判定)。drift 詳細レポート
+    # (system/modules/scripts/check-homebrew-drift.sh) の「宣言:」行から案内される。
+    # source は system/modules/scripts/add-homebrew.sh (単一ソース)。
+    (writeShellScriptBin "add-homebrew"
+      (builtins.readFile ../../system/modules/scripts/add-homebrew.sh))
   ];
 }

--- a/home/modules/packages.nix
+++ b/home/modules/packages.nix
@@ -31,11 +31,14 @@
     tart
 
     # === homebrew drift 運用 helper ===
-    # `add-homebrew --name=foo --desc="..."` で homebrew.nix の brews/casks に
-    # 1 行追記する (cask/formula 自動判定)。drift 詳細レポート
-    # (system/modules/scripts/check-homebrew-drift.sh) の「宣言:」行から案内される。
-    # source は system/modules/scripts/add-homebrew.sh (単一ソース)。
+    # add-homebrew: homebrew.nix の brews/casks(+tap) に 1 行追記 (cask/formula 自動判定)。
+    #   末尾で homebrew-drift-check を呼んで md 再生成 + 通知まで自動。
+    # homebrew-drift-check: drift を再チェックして md 再生成 + 通知 (launchd と同一 source)。
+    #   詳細 md の「削除/install」コマンドに `&& homebrew-drift-check` で chain される。
+    # source はいずれも system/modules/scripts/*.sh (単一ソース)。
     (writeShellScriptBin "add-homebrew"
       (builtins.readFile ../../system/modules/scripts/add-homebrew.sh))
+    (writeShellScriptBin "homebrew-drift-check"
+      (builtins.readFile ../../system/modules/scripts/check-homebrew-drift.sh))
   ];
 }

--- a/system/modules/scripts/add-homebrew.sh
+++ b/system/modules/scripts/add-homebrew.sh
@@ -3,14 +3,20 @@
 # cask か formula(brew) かは brew info で自動判定 (formula 優先)。
 # drift 詳細レポート (check-homebrew-drift.sh) の「宣言:」行から呼ばれる想定。
 #
+# tap formula/cask (owner/repo/name 形式) の場合は taps にも自動で追記する
+# (nix-darwin homebrew は宣言された tap からしか解決しないため)。
+#
 # Usage:
 #   add-homebrew.sh --name="act" --desc="Run your GitHub Actions locally"
 #   add-homebrew.sh --name="acsandmann/tap/rift"          # --desc 省略時は brew info から補完
+#                                                          # tap (acsandmann/tap) も自動追記
 #
 # 追記後は手で `nix flake check` → PR を想定 (このスクリプトは switch しない)。
 set -euo pipefail
 
-export PATH="/opt/homebrew/bin:/run/current-system/sw/bin:/nix/var/nix/profiles/default/bin:/usr/bin:/bin"
+# per-user nix profile bin も含める (ghq 等を brew から消して Nix 版に寄せた後も解決できるように)
+NIX_PROFILE_BIN="/etc/profiles/per-user/$(id -un)/bin"
+export PATH="/opt/homebrew/bin:${NIX_PROFILE_BIN}:/run/current-system/sw/bin:/nix/var/nix/profiles/default/bin:/usr/bin:/bin"
 
 NAME=""
 DESC=""
@@ -51,23 +57,50 @@ if [ -z "$DESC" ]; then
   fi
 fi
 
-# 既に宣言済みなら no-op
-if grep -q "\"$NAME\"" "$HB"; then
-  echo "既に宣言済み: $NAME (homebrew.nix)" >&2
-  exit 0
+# "    <section> = [" の直後に 1 行挿入 (awk で値は -v 経由 → escaping 不要)
+insert_after_block() {
+  local section="$1" line="$2"
+  awk -v sec="$section" -v ln="$line" '
+    $0 == "    " sec " = [" { print; print ln; next }
+    { print }
+  ' "$HB" > "$HB.tmp" && mv "$HB.tmp" "$HB"
+}
+
+# tap formula/cask (owner/repo/name 形式) なら tap も宣言する。
+# nix-darwin homebrew は宣言された tap からしか解決しないので、これが無いと
+# 新 PC の switch で "No available formula/cask" になる (既存 omniwm と同じ理由)。
+if [[ "$NAME" == */*/* ]]; then
+  TAP="${NAME%/*}"   # owner/repo/name → owner/repo
+  if grep -q "\"$TAP\"" "$HB"; then
+    echo "tap 宣言済み: $TAP"
+  else
+    insert_after_block "taps" "      \"$TAP\"  # ${NAME##*/} 等のカスタム tap"
+    echo "✓ taps に追記: $TAP"
+  fi
 fi
 
-# "    SECTION = [" の直後に 1 行挿入 (awk で値は -v 経由 → escaping 不要)
-LINE="      \"$NAME\"  # ${DESC:-TODO}"
-awk -v sec="$SECTION" -v ln="$LINE" '
-  $0 == "    " sec " = [" { print; print ln; next }
-  { print }
-' "$HB" > "$HB.tmp" && mv "$HB.tmp" "$HB"
+# 本体 (brews/casks) の宣言。既に宣言済みなら no-op。
+if grep -q "\"$NAME\"" "$HB"; then
+  echo "既に宣言済み: $NAME (homebrew.nix)"
+else
+  LINE="      \"$NAME\"  # ${DESC:-TODO}"
+  insert_after_block "$SECTION" "$LINE"
+  echo "✓ $SECTION に追記: $NAME"
+  echo "    $LINE"
+fi
 
-echo "✓ $SECTION に追記: $NAME"
-echo "    $LINE"
 echo
 echo "次:"
 echo "  cd \"$FLAKE_DIR\""
 echo "  nix flake check --no-build --impure   # eval 確認"
 echo "  git add system/modules/homebrew.nix && git diff --cached"
+
+# 宣言を反映したので drift を再チェック (md 再生成 + 通知)。
+# nix eval は dirty working tree を見るので、追記分が即 declared 扱いになる。
+echo
+echo "→ drift 再チェック (md 再生成 + 通知)"
+if command -v homebrew-drift-check >/dev/null 2>&1; then
+  homebrew-drift-check >/dev/null 2>&1 || true
+else
+  "$FLAKE_DIR/system/modules/scripts/check-homebrew-drift.sh" >/dev/null 2>&1 || true
+fi

--- a/system/modules/scripts/add-homebrew.sh
+++ b/system/modules/scripts/add-homebrew.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# homebrew.nix の brews / casks に 1 行宣言を追記する。
+# cask か formula(brew) かは brew info で自動判定 (formula 優先)。
+# drift 詳細レポート (check-homebrew-drift.sh) の「宣言:」行から呼ばれる想定。
+#
+# Usage:
+#   add-homebrew.sh --name="act" --desc="Run your GitHub Actions locally"
+#   add-homebrew.sh --name="acsandmann/tap/rift"          # --desc 省略時は brew info から補完
+#
+# 追記後は手で `nix flake check` → PR を想定 (このスクリプトは switch しない)。
+set -euo pipefail
+
+export PATH="/opt/homebrew/bin:/run/current-system/sw/bin:/nix/var/nix/profiles/default/bin:/usr/bin:/bin"
+
+NAME=""
+DESC=""
+for arg in "$@"; do
+  case "$arg" in
+    --name=*) NAME="${arg#--name=}" ;;
+    --desc=*) DESC="${arg#--desc=}" ;;
+    *) echo "unknown arg: $arg (使い方: --name=... [--desc=...])" >&2; exit 1 ;;
+  esac
+done
+[ -z "$NAME" ] && { echo "--name は必須" >&2; exit 1; }
+
+# flake dir 解決
+FLAKE_DIR="${DOTFILES_FLAKE_DIR:-}"
+if [ -z "$FLAKE_DIR" ] && command -v ghq >/dev/null 2>&1; then
+  FLAKE_DIR=$(ghq list -p github.com/akira-toriyama/dotfiles 2>/dev/null | head -1)
+fi
+[ -z "$FLAKE_DIR" ] && [ -d "$HOME/dotfiles" ] && FLAKE_DIR="$HOME/dotfiles"
+[ -z "$FLAKE_DIR" ] && { echo "flake が見つからない" >&2; exit 1; }
+HB="$FLAKE_DIR/system/modules/homebrew.nix"
+
+# cask / formula 判定 (formula 優先 = CLI が多いため)
+if brew info --formula "$NAME" >/dev/null 2>&1; then
+  SECTION="brews"
+elif brew info --cask "$NAME" >/dev/null 2>&1; then
+  SECTION="casks"
+else
+  echo "error: '$NAME' は formula でも cask でも見つからない" >&2
+  exit 1
+fi
+
+# desc 省略時は brew info から補完 (推奨値)
+if [ -z "$DESC" ]; then
+  if [ "$SECTION" = "brews" ]; then
+    DESC=$(brew info --formula "$NAME" --json=v2 2>/dev/null | jq -r '.formulae[0].desc // empty' || true)
+  else
+    DESC=$(brew info --cask "$NAME" --json=v2 2>/dev/null | jq -r '.casks[0].desc // empty' || true)
+  fi
+fi
+
+# 既に宣言済みなら no-op
+if grep -q "\"$NAME\"" "$HB"; then
+  echo "既に宣言済み: $NAME (homebrew.nix)" >&2
+  exit 0
+fi
+
+# "    SECTION = [" の直後に 1 行挿入 (awk で値は -v 経由 → escaping 不要)
+LINE="      \"$NAME\"  # ${DESC:-TODO}"
+awk -v sec="$SECTION" -v ln="$LINE" '
+  $0 == "    " sec " = [" { print; print ln; next }
+  { print }
+' "$HB" > "$HB.tmp" && mv "$HB.tmp" "$HB"
+
+echo "✓ $SECTION に追記: $NAME"
+echo "    $LINE"
+echo
+echo "次:"
+echo "  cd \"$FLAKE_DIR\""
+echo "  nix flake check --no-build --impure   # eval 確認"
+echo "  git add system/modules/homebrew.nix && git diff --cached"

--- a/system/modules/scripts/check-homebrew-drift.sh
+++ b/system/modules/scripts/check-homebrew-drift.sh
@@ -17,14 +17,14 @@
 #     display notification は macOS 15 で banner 抑止されがちなため不採用。
 #   - -group homebrew-drift 固定で「通知センターに常に最新 1 件」運用
 #   - 実行ログ (append): /tmp/homebrew-drift.log
-#   - 詳細レポート (overwrite): /tmp/homebrew-drift-latest.txt
+#   - 詳細レポート (overwrite, Markdown): /tmp/homebrew-drift-latest.md
 set -eu
 
 # 「明示的に未宣言（破棄方針）」相当の cask は通知から除外する。
 # homebrew.nix 末尾コメントの破棄方針リストとは別管理。両方を更新する想定。
 IGNORE_EXTRA_CASKS="google-japanese-ime karabiner-elements"
 
-DETAIL_FILE="/tmp/homebrew-drift-latest.txt"
+DETAIL_FILE="/tmp/homebrew-drift-latest.md"
 # 詳細レポートの「宣言:」行が指す helper。FLAKE_DIR 解決後に絶対パス化する。
 ADD_SH=""
 
@@ -49,12 +49,18 @@ if [ -z "$FLAKE_DIR" ] || [ ! -e "$FLAKE_DIR/flake.nix" ]; then
   exit 0
 fi
 
-# add-homebrew は Nix (home.packages の writeShellScriptBin) で PATH に乗る。
+# add-homebrew / homebrew-drift-check は Nix (writeShellScriptBin) で PATH に乗る。
 # 未配置の新 PC では repo の実体パスにフォールバック。
 if command -v add-homebrew >/dev/null 2>&1; then
   ADD_SH="add-homebrew"
 else
   ADD_SH="$FLAKE_DIR/system/modules/scripts/add-homebrew.sh"
+fi
+# RECHECK = drift 再チェック (md 再生成 + 通知)。削除/install コマンドに chain する。
+if command -v homebrew-drift-check >/dev/null 2>&1; then
+  RECHECK="homebrew-drift-check"
+else
+  RECHECK="$FLAKE_DIR/system/modules/scripts/check-homebrew-drift.sh"
 fi
 
 echo "[$(date)] checking drift against $FLAKE_DIR"
@@ -130,87 +136,104 @@ get_desc_brew() {
   brew info --formula "$1" --json=v2 2>/dev/null | jq -r '.formulae[0].desc // empty' 2>/dev/null || true
 }
 
+# Markdown コードフェンス用ヘルパ (sh コマンドを ```sh ... ``` で囲む)。
+# バッククォートは literal 出力が目的なので SC2016 を抑止。
+# shellcheck disable=SC2016
+fence() { printf '```sh\n%s\n```\n' "$1"; }
+
 {
-  echo "homebrew drift detected at $(date '+%Y-%m-%d %H:%M:%S')"
-  echo "flake: $FLAKE_DIR"
+  echo "# homebrew drift"
   echo
-  echo "概要: $subtitle"
+  echo "- 検知: $(date '+%Y-%m-%d %H:%M:%S')"
+  echo "- flake: \`$FLAKE_DIR\`"
+  echo "- 概要: **$subtitle**"
   echo
 
   if [ "$n_dup" -gt 0 ]; then
-    echo "============================================================"
-    echo "■ Nix と brew で二重 install (${n_dup} 件)"
-    echo "  home.packages (Nix) に同名があるので brew 側を消すのが正。"
-    echo "  ↓ そのまま貼って実行 (Nix 版が残る):"
-    echo "------------------------------------------------------------"
+    echo "## Nix と brew で二重 install (${n_dup} 件)"
+    echo
+    echo "> home.packages (Nix) に同名あり → **brew 側を消す** (Nix 版が残る)。下を貼るだけ。"
+    echo
     while IFS= read -r name; do
       [ -z "$name" ] && continue
       desc=$(get_desc_brew "$name")
-      echo "・$name${desc:+  ($desc)}"
-      echo "    brew uninstall $name"
+      echo "- **$name**${desc:+ — $desc}"
+      fence "brew uninstall $name && $RECHECK"
+      echo
     done <<< "$dup_brews"
     echo
   fi
 
   if [ "$n_ub" -gt 0 ]; then
-    echo "============================================================"
-    echo "■ 未宣言 brew (${n_ub} 件) — brew のみ。宣言化 or 削除を判断"
-    echo "------------------------------------------------------------"
+    echo "## 未宣言 brew (${n_ub} 件) — brew のみ"
+    echo
+    echo "> 宣言化 (Nix に取り込む) か 削除 かを判断。"
+    echo
     while IFS= read -r name; do
       [ -z "$name" ] && continue
       desc=$(get_desc_brew "$name")
-      echo "・$name${desc:+  ($desc)}"
-      echo "    宣言: $ADD_SH --name=\"$name\" --desc=\"$desc\""
-      echo "    削除: brew uninstall $name"
+      echo "### $name${desc:+ — $desc}"
+      echo "- 宣言 (実行後に自動で再チェック+通知)"
+      fence "$ADD_SH --name=\"$name\" --desc=\"$desc\""
+      echo "- 削除"
+      fence "brew uninstall $name && $RECHECK"
+      echo
     done <<< "$undeclared_brews"
     echo
   fi
 
   if [ "$n_ec" -gt 0 ]; then
-    echo "============================================================"
-    echo "■ 未宣言 cask (${n_ec} 件) — install 済だが homebrew.nix に無い"
-    echo "------------------------------------------------------------"
+    echo "## 未宣言 cask (${n_ec} 件) — install 済だが homebrew.nix に無い"
+    echo
     while IFS= read -r name; do
       [ -z "$name" ] && continue
       desc=$(get_desc_cask "$name")
-      echo "・$name${desc:+  ($desc)}"
-      echo "    宣言: $ADD_SH --name=\"$name\" --desc=\"$desc\""
-      echo "    削除: brew uninstall --cask $name"
+      echo "### $name${desc:+ — $desc}"
+      echo "- 宣言 (実行後に自動で再チェック+通知)"
+      fence "$ADD_SH --name=\"$name\" --desc=\"$desc\""
+      echo "- 削除"
+      fence "brew uninstall --cask $name && $RECHECK"
+      echo
     done <<< "$extra_casks"
     echo
   fi
 
   if [ "$n_mc" -gt 0 ]; then
-    echo "============================================================"
-    echo "■ 未 install cask (${n_mc} 件) — 宣言済だが install されてない"
-    echo "------------------------------------------------------------"
+    echo "## 未 install cask (${n_mc} 件) — 宣言済だが install されてない"
+    echo
     while IFS= read -r name; do
       [ -z "$name" ] && continue
       desc=$(get_desc_cask "$name")
-      echo "・$name${desc:+  ($desc)}"
-      echo "    install: brew install --cask $name"
-      echo "    宣言取消: homebrew.nix の casks から削除"
+      echo "### $name${desc:+ — $desc}"
+      echo "- install"
+      fence "brew install --cask $name && $RECHECK"
+      echo "- 宣言取消: \`homebrew.nix\` の casks から該当行を削除"
+      echo
     done <<< "$missing_casks"
     echo
   fi
 
   if [ "$n_mb" -gt 0 ]; then
-    echo "============================================================"
-    echo "■ 未 install brew (${n_mb} 件) — 宣言済だが install されてない"
-    echo "------------------------------------------------------------"
+    echo "## 未 install brew (${n_mb} 件) — 宣言済だが install されてない"
+    echo
     while IFS= read -r name; do
       [ -z "$name" ] && continue
       desc=$(get_desc_brew "$name")
-      echo "・$name${desc:+  ($desc)}"
-      echo "    install: brew install $name"
-      echo "    宣言取消: homebrew.nix の brews から削除"
+      echo "### $name${desc:+ — $desc}"
+      echo "- install"
+      fence "brew install $name && $RECHECK"
+      echo "- 宣言取消: \`homebrew.nix\` の brews から該当行を削除"
+      echo
     done <<< "$missing_brews"
     echo
   fi
 
-  echo "============================================================"
-  echo "再チェック: launchctl kickstart -p gui/\$UID/org.nixos.homebrew-drift"
-  echo "実行ログ: tail -30 /tmp/homebrew-drift.log"
+  echo "---"
+  echo
+  echo "- 手動で再チェック (md 再生成 + 通知)"
+  fence "$RECHECK"
+  echo "- 実行ログ"
+  fence "tail -30 /tmp/homebrew-drift.log"
 } > "$DETAIL_FILE"
 
 # 通知。terminal-notifier 未導入なら log だけ残して exit (新 PC 初日対策)。
@@ -219,7 +242,7 @@ if command -v terminal-notifier >/dev/null 2>&1; then
     -group "homebrew-drift" \
     -title "homebrew drift" \
     -subtitle "$subtitle" \
-    -message "クリックで詳細を開く (code $DETAIL_FILE)" \
+    -message "クリックで詳細 (.md) を開く" \
     -execute "/opt/homebrew/bin/code $DETAIL_FILE" \
     -sound Pop \
     >/dev/null 2>&1 || true

--- a/system/modules/scripts/check-homebrew-drift.sh
+++ b/system/modules/scripts/check-homebrew-drift.sh
@@ -25,14 +25,17 @@ set -eu
 IGNORE_EXTRA_CASKS="google-japanese-ime karabiner-elements"
 
 DETAIL_FILE="/tmp/homebrew-drift-latest.txt"
+# 詳細レポートの「宣言:」行が指す helper。FLAKE_DIR 解決後に絶対パス化する。
+ADD_SH=""
+
+# Nix (home.packages) が置く per-user profile の bin。
+#   - ここに同名があれば「brew と Nix の二重 install」と判定する
+#   - add-homebrew (writeShellScriptBin) もここに入るので PATH にも含める
+NIX_PROFILE_BIN="/etc/profiles/per-user/$(id -un)/bin"
 
 # launchd 環境は PATH がほぼ空。Homebrew + Nix の bin を明示注入する。
-PATH="/opt/homebrew/bin:/run/current-system/sw/bin:/nix/var/nix/profiles/default/bin:/usr/bin:/bin"
+PATH="/opt/homebrew/bin:${NIX_PROFILE_BIN}:/run/current-system/sw/bin:/nix/var/nix/profiles/default/bin:/usr/bin:/bin"
 export PATH
-
-# Nix (home.packages) が置く per-user profile の bin。ここに同名があれば
-# 「brew と Nix の二重 install」と判定する。
-NIX_PROFILE_BIN="/etc/profiles/per-user/$(id -un)/bin"
 
 FLAKE_DIR="${DOTFILES_FLAKE_DIR:-}"
 if [ -z "$FLAKE_DIR" ] && command -v ghq >/dev/null 2>&1; then
@@ -44,6 +47,14 @@ fi
 if [ -z "$FLAKE_DIR" ] || [ ! -e "$FLAKE_DIR/flake.nix" ]; then
   echo "[$(date)] flake not found, skipping"
   exit 0
+fi
+
+# add-homebrew は Nix (home.packages の writeShellScriptBin) で PATH に乗る。
+# 未配置の新 PC では repo の実体パスにフォールバック。
+if command -v add-homebrew >/dev/null 2>&1; then
+  ADD_SH="add-homebrew"
+else
+  ADD_SH="$FLAKE_DIR/system/modules/scripts/add-homebrew.sh"
 fi
 
 echo "[$(date)] checking drift against $FLAKE_DIR"
@@ -149,7 +160,7 @@ get_desc_brew() {
       [ -z "$name" ] && continue
       desc=$(get_desc_brew "$name")
       echo "・$name${desc:+  ($desc)}"
-      echo "    宣言: homebrew.nix の brews に  \"$name\"  を追記"
+      echo "    宣言: $ADD_SH --name=\"$name\" --desc=\"$desc\""
       echo "    削除: brew uninstall $name"
     done <<< "$undeclared_brews"
     echo
@@ -163,7 +174,7 @@ get_desc_brew() {
       [ -z "$name" ] && continue
       desc=$(get_desc_cask "$name")
       echo "・$name${desc:+  ($desc)}"
-      echo "    宣言: homebrew.nix の casks に  \"$name\"  を追記"
+      echo "    宣言: $ADD_SH --name=\"$name\" --desc=\"$desc\""
       echo "    削除: brew uninstall --cask $name"
     done <<< "$extra_casks"
     echo


### PR DESCRIPTION
## Summary

drift 詳細レポートの「宣言:」行を、homebrew.nix へ 1 行追記する **即実行コマンド** に変更。

\`\`\`
・act  (Run your GitHub Actions locally)
    宣言: add-homebrew --name="act" --desc="Run your GitHub Actions locally"
    削除: brew uninstall act
\`\`\`

## 変更

- **`system/modules/scripts/add-homebrew.sh`** (新規)
  - `--name` / `--desc` を取り、`brew info` で cask/formula 自動判定 → `brews`/`casks` に追記
  - `--desc` 省略時は brew description で補完 (推奨値)
  - 既宣言なら no-op、tap formula (`a/b/name`) も対応
- **`home/modules/packages.nix`**: `writeShellScriptBin "add-homebrew"` で PATH に (source は上記 .sh 単一)
- **`check-homebrew-drift.sh`**:
  - 「宣言:」行を `add-homebrew --name=... --desc=...` に (未配置の新 PC は repo 実体パスへ fallback)
  - PATH に per-user nix profile bin を追加 (launchd 環境でも `add-homebrew` 解決可能に)

## 管理方針

helper は **Nix `writeShellScriptBin`** で PATH に乗せる (B 案)。責務マトリクス「Nix でビルド可能な CLI → home-manager」に準拠。chezmoi (executable_) ではなく Nix 側が所有。

## Test plan

- [x] shellcheck clean (両 script)
- [x] nix flake check --no-build --impure
- [x] add-homebrew.sh 単体テスト (act 追記 → 正しい位置に挿入 → revert 確認)
- [x] 詳細レポートに `add-homebrew --name=... --desc=...` が出ることを確認
- [ ] merge 後 darwin-rebuild switch → `add-homebrew` が PATH に乗る
- [ ] `add-homebrew --name=act` 実行 → homebrew.nix に追記される

🤖 Generated with [Claude Code](https://claude.com/claude-code)