### PR TITLE
:wrench: chore(homebrew): borders 宣言 + add-homebrew ヒントの zsh コメント対応

### DIFF
--- a/system/modules/homebrew.nix
+++ b/system/modules/homebrew.nix
@@ -19,9 +19,11 @@
     # === カスタム tap brew はユーザー方針で原則 drop（新PC で WM スタック再考）===
     # 例外: omniwm は cask だが barutsrb/tap 由来のため tap だけ宣言が要る。
     taps = [
+      "felixkratz/formulae"  # borders 等のカスタム tap
       "barutsrb/tap"   # omniwm (Niri-inspired tiling WM by BarutSRB) を解決するため
     ];
     brews = [
+      "felixkratz/formulae/borders"  # A window border system for macOS
       "terminal-notifier" # macOS 通知 CLI。launchd-drift.nix の drift 検知通知で使用
     ];
 

--- a/system/modules/scripts/add-homebrew.sh
+++ b/system/modules/scripts/add-homebrew.sh
@@ -90,9 +90,9 @@ else
 fi
 
 echo
-echo "次:"
+echo "次 (eval 確認 → 差分確認。zsh でそのまま貼れるよう行末コメント無し):"
 echo "  cd \"$FLAKE_DIR\""
-echo "  nix flake check --no-build --impure   # eval 確認"
+echo "  nix flake check --no-build --impure"
 echo "  git add system/modules/homebrew.nix && git diff --cached"
 
 # 宣言を反映したので drift を再チェック (md 再生成 + 通知)。


### PR DESCRIPTION
## 変更

- **homebrew.nix**: `felixkratz/formulae/borders` を `brews` に宣言、`felixkratz/formulae` tap も追記（`add-homebrew` が tap formula を検知して taps + brews 両方に追記）
- **add-homebrew.sh**: 「次:」ガイドの `nix flake check ... # eval 確認` の行末コメントを除去
  - zsh は対話シェルで `interactive_comments` がデフォルト無効 → 貼ると `# eval 確認` が引数化して `unexpected argument 'eval'` エラーになっていた
  - コメントを見出し行に移し、各コマンド行を paste-safe に

## Test plan

- [x] `nix flake check --no-build --impure` → borders 追加後も eval OK (default/ci)
- [x] shellcheck (nix 経由) clean
- [ ] merge 後 `darwin-rebuild switch` で borders 宣言が反映（既 install のため install は no-op）

🤖 Generated with [Claude Code](https://claude.com/claude-code)