### PR TITLE
:memo: docs: .tmpl 廃止後の stale 参照整理 + cross-repo 家訓 + ワークフロー整合

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,16 +58,16 @@ flowchart TD
 
 ## GitHub / CI
 
-- **作業ブランチは `main` 一本** (2026-05-27 に `rebuild` を統合・削除。CI も main 単発)。
-- **コミットは論理単位ごとに即 push**（`git push origin main`、auto-push 方針）。
-- **コミットメッセージは gitmoji + Conventional Commits**: `:sparkles: feat(nix): ...` / `:memo: docs(roadmap): ...` / `:fire: fix(...): ...`。`git log -n 20` でスタイルを確認してから書く。
+- **`main` は唯一の永続ブランチ**（2026-05-27 に `rebuild` を統合・削除。CI も main へ単発）。作業は短命な feature ブランチを切り、**PR 経由で `main` に squash-merge** する（直 push はしない）。
+- **フロー**: `git checkout -b <type>/<topic>` → 論理単位で commit → `git push -u origin <branch>` → `gh pr create` → CI green → `gh pr merge --squash`（`--auto` 可）。実例は [docs/operations.md](docs/operations.md)。
+- **コミットメッセージは gitmoji + Conventional Commits**: `:sparkles: feat(nix): ...` / `:memo: docs(roadmap): ...` / `:bug: fix(...): ...`。`git log -n 20` でスタイルを確認してから書く。
 - **CI ジョブ（[.github/workflows/ci.yml](.github/workflows/ci.yml)、push と PR でトリガー）**:
   - `nix flake check --no-build` — Nix の型/eval 検査（Linux runner）
   - `shellcheck` — `install.sh` 静的解析
   - 規約検知 — `chezmoi/` 配下 shebang スクリプトの `executable_` 接頭辞強制
   - `chezmoi templates render` — 全 `.tmpl` の `execute-template` 検証
-- **CI green を確認してから push の次の作業へ**。失敗したら**新規コミットで修正**（`--amend` は使わない）。
-- **PR/--force push は禁止**。ユーザー明示指示があった場合のみ。
+- **CI green を確認してからマージ**。失敗したら**新規コミットで修正**（push 済みへの `--amend` は使わない）。
+- **`--force` push / 履歴改変は禁止**（ユーザー明示指示がある場合のみ）。
 
 ## シークレット取扱（YOU MUST）
 
@@ -96,6 +96,7 @@ flowchart TD
 - `system.defaults` は **ByHost ドメイン（`-currentHost`）には書けない**。Display 配置や一部 Finder 詳細は activationScripts で `defaults -currentHost write` を使う以外手がない。
 - macOS の **TCC/sandbox で保護されたアプリ**（Mail / Safari / Calendar 等）の defaults は switch が成功しても無音で適用されない。AI は「修正」追加で深追いしない。
 - chezmoi run スクリプトは **`run_onchange_` 既定**（idempotent）。`run_once_` は本当に一度きりの bootstrap でのみ使う。
+- chord config パス（`dot_config/chord/private_config.toml`）は `.tmpl` の `{{ include }}`・`verify-chord-*.yml` の `paths:`・`gen-chord-doc.py` の **4 箇所**が指す。リネーム時は同時更新（PR #123 で古参照を踏んだ）。config 文法を released chord より先行させると `verify-chord-validate.yml`（tap の chord で strict 検証）が落ちる。`.tmpl` 自体は read-only で他リポに副作用なし。詳細 → [docs/operations.md §5.7](docs/operations.md)。
 - 編集を許したい AI/ユーザー共有ファイル（例: `~/.claude/settings.json`）は home.file に直接書かず **`mkOutOfStoreSymlink`** で逃がす（直書きは Nix store immutable で AI 編集できなくなる）。
 
 ## よく使うコマンド（Claude が推測できないもの）

--- a/docs/chord.md
+++ b/docs/chord.md
@@ -85,7 +85,7 @@ private_config.toml の `# doc:` 行＋`[[bindings]]` を編集 →
 
 ## chord 文法の制約メモ
 
-- **L/R 修飾子は side-specific**: tmpl 冒頭の `{{ $ULTRA_LL := "rctrl + ralt + rshift" }}`
+- **L/R 修飾子は side-specific**: `[input-aliases]` の `ULTRA_LL = "rctrl + ralt + rshift"`
   のように **右側修飾子トークンに固定**している。chord v0.2.0 の PR1
   (`ed1c032 feat(core)!: side-specific modifier tokens`) で `rctrl/ralt/rshift/rcmd` /
   `lctrl/...` トークンが解禁されたため。これにより ZMK ファームの右側修飾子チョードだけが
@@ -100,7 +100,7 @@ private_config.toml の `# doc:` 行＋`[[bindings]]` を編集 →
 
 4 修飾子セット (ULTRA_LL/MIRACLE_LM/MEGA_RM/WONDER_RR) で実バインド済みの
 キー以外を押すと効果音 (`undefined_key.wav`) を鳴らす。chord v0.2.0 PR5 の
-`[[fallbacks]]` + `*` ワイルドカードで実装（tmpl 末尾）。
+`[[fallbacks]]` + `*` ワイルドカードで実装（private_config.toml の `[[fallbacks]]` 群）。
 
 - `[[bindings]]` が全 miss した時だけ `[[fallbacks]]` が評価される
   → 既存バインドの誤爆は発生しない

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -258,6 +258,16 @@ sh <(curl -fsSL https://raw.githubusercontent.com/akira-toriyama/dotfiles/main/i
 
 新規追加する場合は `run_once_` ではなく **`run_onchange_` を既定**（idempotent）。`run_once_` は本当に一度きりの bootstrap 用。
 
+#### 家訓: `.tmpl` / chord config を動かすときの影響範囲
+
+- **`.tmpl` 自体は read-only**: `run_onchange_after_chord-validate.sh.tmpl` は chord config を `include` で読んで `chord --validate` するだけで、**他リポへ書き込まないので副作用は出ない**。`verify-chord-validate.yml` も apply target を `~/.config/chord` に絞っている。「`.tmpl` 編集で他リポが壊れる」心配は不要。
+- **chord config パスは 4 箇所が同じファイルを指す**ので、リネーム/移動は同時に直す（PR #108 の `.tmpl` 廃止後、PR #123 で古参照を踏んだ実績あり）:
+  1. `chezmoi/run_onchange_after_chord-validate.sh.tmpl` の `{{ include "dot_config/chord/private_config.toml" | sha256sum }}`
+  2. `.github/workflows/verify-chord-validate.yml` の `paths:` フィルタ
+  3. `.github/workflows/verify-chord-doc.yml` の `paths:` フィルタ
+  4. `scripts/gen-chord-doc.py` の `CONFIG`
+- **config 文法は released chord と歩調を合わせる**: `verify-chord-validate.yml` は brew tap (`akira-toriyama/tap`) の **released** chord を install して strict 検証する。config の文法が released 版を追い越すと CI が落ちる。tap が追いつくまでは §5.10 の手元 build を使うか、文法変更と tap release を揃える。
+
 ### 5.8 よく使うコマンド早見表
 
 ```sh
@@ -311,7 +321,7 @@ sleep 1
 #    `/opt/homebrew/opt/chord` は現バージョンへの symlink (例: ../Cellar/chord/0.5.0)
 #    なので version 数字を埋め込まずに済む。
 CHORD_APP="$(brew --prefix chord)/Chord.app"
-NEW=/Volumes/workspace/github.com/akira-toriyama/chord/.build/release/chord
+NEW="$(ghq root)/github.com/akira-toriyama/chord/.build/release/chord"
 cp "$CHORD_APP/Contents/MacOS/chord" "$CHORD_APP/Contents/MacOS/chord.bak"
 cp "$NEW" "$CHORD_APP/Contents/MacOS/chord"
 

--- a/scripts/gen-chord-doc.py
+++ b/scripts/gen-chord-doc.py
@@ -25,7 +25,7 @@ import sys
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
-TMPL = ROOT / "chezmoi" / "dot_config" / "chord" / "private_config.toml"
+CONFIG = ROOT / "chezmoi" / "dot_config" / "chord" / "private_config.toml"
 DOC = ROOT / "docs" / "chord.md"
 
 BEGIN = "<!-- AUTO-GENERATED (scripts/gen-chord-doc.py from chezmoi/dot_config/chord/private_config.toml) — do not edit -->"
@@ -78,7 +78,7 @@ def build_block() -> str:
     current_input: str | None = None
     current_apps: list[str] = []
     in_binding = False
-    lines = TMPL.read_text(encoding="utf-8").splitlines()
+    lines = CONFIG.read_text(encoding="utf-8").splitlines()
 
     def flush() -> None:
         nonlocal pending_doc, current_input, current_apps
@@ -126,7 +126,7 @@ def build_block() -> str:
 
     if not rows:
         raise SystemExit(
-            f"{TMPL.name}: # doc + [[bindings]] の組が見つかりません ({TMPL})"
+            f"{CONFIG.name}: # doc + [[bindings]] の組が見つかりません ({CONFIG})"
         )
 
     out = [BEGIN, ""]


### PR DESCRIPTION
## Summary

PR #108 の `.tmpl` 廃止後に残っていた古い参照・記述を整理し、`.tmpl`/chord config を触るときの cross-repo の家訓を明文化。あわせて CLAUDE.md の GitHub/CI 節を実際の運用（PR フロー）に整合させた。

- **docs/chord.md**: 旧テンプレ構文 `{{ $ULTRA_LL := ... }}` / `tmpl 末尾` → 現行 `[input-aliases]` テーブル / `private_config.toml の [[fallbacks]] 群`。
- **scripts/gen-chord-doc.py**: plain TOML を指すのに misleading だった変数 `TMPL` → `CONFIG`（出力不変）。
- **docs/operations.md §5.7**: 家訓を追加 — ①`.tmpl` は read-only で他リポに副作用なし ②chord config パスは 4 箇所（`.tmpl` の `include` / `verify-chord-*.yml` の `paths:` / `gen-chord-doc.py`）が同じファイルを指すのでリネーム時は同時更新（PR #123 で古参照を踏んだ教訓）③config 文法は brew tap の released chord と歩調を合わせる。§5.10 の `/Volumes` ハードコードを `$(ghq root)` に統一。
- **CLAUDE.md**: GitHub/CI 節の「`git push origin main` / PR 禁止」という stale 記述を実態（feature ブランチ → PR → squash-merge）に修正。落とし穴に家訓ポインタを 1 行追加。

## Test plan

- [x] `python3 scripts/gen-chord-doc.py --check` → 同期済み（変数 rename 後も出力不変）
- [x] `chezmoi --source ./chezmoi execute-template < chezmoi/run_onchange_after_chord-validate.sh.tmpl` → render OK
- [ ] CI（`chezmoi templates render` / `verify-chord-doc`）green を確認

> 注: 配布物（`chezmoi/dot_*` / Nix）は不変。docs + Python 変数 rename のみで、`verify-chord-validate.yml` の trigger paths には触れていない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)