### PR TITLE
feat(home): login shell の PATH に /opt/homebrew/bin を追加

### DIFF
--- a/home/modules/default.nix
+++ b/home/modules/default.nix
@@ -12,6 +12,12 @@
   home.username = username;
   home.homeDirectory = "/Users/${username}";
 
+  # Homebrew の bin を login shell の PATH に載せる。
+  # nix-darwin の set-environment が作る PATH には /opt/homebrew/bin が無く、
+  # chord 等が叩く `/bin/zsh -l -c` で brew 製コマンド (facet / rift-cli 等) が
+  # command-not-found になる。hm-session-vars.sh 経由で全 shell に効かせる。
+  home.sessionPath = [ "/opt/homebrew/bin" "/opt/homebrew/sbin" ];
+
   # home-manager の状態バージョン（安易に上げない）
   home.stateVersion = "24.11";
 }


### PR DESCRIPTION
## 概要

`/bin/zsh -l -c` で起動するログインシェルの PATH に `/opt/homebrew/bin` `/opt/homebrew/sbin` を `home.sessionPath` 経由で追加する。

## 背景 / 動機

- nix-darwin の `set-environment` が組む PATH は `~/.nix-profile/bin … /usr/bin:/bin:…` で、**`/opt/homebrew/bin` を含まない**。
- chord は action-shell を `/bin/zsh -l -c "<cmd>"` で実行する (ActionDispatcher.swift)。このログインシェルは上記 nix PATH を引くため、brew 製 CLI が **command-not-found** になる。
- 実際に `ctrl + →` → `facet --view=tree --loading=2000` が `zsh:1: command not found: facet` で発火後に失敗していた (`rift-cli` も同根)。

## 変更

`home/modules/default.nix` に:

```nix
home.sessionPath = [ "/opt/homebrew/bin" "/opt/homebrew/sbin" ];
```

`hm-session-vars.sh` に `export PATH="/opt/homebrew/bin:/opt/homebrew/sbin:$PATH"` が出力され、`~/.zshenv` 経由で全シェル (login / 非interactive 含む) に効く。

## 検証

- `nix flake check --no-build` ✅
- `darwin-rebuild build --flake .#default --impure` ✅ / 成果物の `hm-session-vars.sh` に `/opt/homebrew/bin` を確認
- `switch` 適用後、chord と同条件 `env -i HOME=$HOME … /bin/zsh -l -c 'command -v facet'` → `/opt/homebrew/bin/facet` に解決
- 実機で `ctrl + →` → facet tree オーバーレイ表示を確認（ユーザー確認済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)