### PR TITLE
:sparkles: feat(chord,facet): スペース移動と facet tree 表示を連動 + Space 別 workspace

### DIFF
--- a/chezmoi/dot_config/chord/private_config.toml
+++ b/chezmoi/dot_config/chord/private_config.toml
@@ -164,6 +164,43 @@ input = "ctrl - j"
 action-keys = "return"
 
 
+# ---- facet オーバーレイ ----
+# macOS は矢印キーに常に fn (NSEventModifierFlagFunction / maskSecondaryFn) を
+# 付与する。chord の matcher は未言及カテゴリの modifier 不在を要求し、fn は
+# 完全一致 (Models.swift `self.contains(.fn) == event.contains(.fn)`) なので、
+# 物理 ctrl+→ にマッチさせるには input 側にも fn を明記する必要がある。
+# fn を書かない `ctrl - right` は実イベント (ctrl+fn+right) と一致せず発火しない。
+# bare `right` は KeyCodes で 0x7C（右矢印）に解決される（mouse 扱いは
+# `mouse.right` の時だけ）。
+#
+# action-shell は ActionDispatcher.swift で `/bin/zsh -l -c` 実行。login zsh の
+# PATH に /opt/homebrew/bin を載せるため home-manager の home.sessionPath で
+# 通している (dotfiles home/modules/default.nix)。これで bare `facet` が解決する。
+
+# doc: スペース右へ移動しつつ facet tree 表示（ctrl+→）
+# action-shell が先に発火（facet 起動・撃ちっぱなし）→ 直後に action-keys で
+# ctrl+→ を再送してスペース右移動。元イベントは consume、再送分は synthetic
+# タグ付きなので matcher に再入せずループしない。出力側にも fn を明記するのは、
+# 矢印に常に fn が付く macOS で「物理 ctrl+→」と同一イベントにし、OS のスペース
+# 移動ショートカットに一致させるため。
+# ※ action-shell + action-keys の同時発火は chord の multi-action 機能が必要
+#   （akira-toriyama/chord で実装、未リリース）。未対応バイナリでは action-keys
+#   が無視され facet のみ動く。
+[[bindings]]
+name = "space-right + facet tree"
+input = "ctrl + fn - right"
+action-shell = "facet --view=tree --loading=2000"
+action-keys = "ctrl + fn - right"
+
+# doc: スペース左へ移動しつつ facet tree 表示（ctrl+←）
+# 上の space-right と同じ仕組み（fn 明記の理由・ループしない理由は同上）。
+[[bindings]]
+name = "space-left + facet tree"
+input = "ctrl + fn - left"
+action-shell = "facet --view=tree --loading=2000"
+action-keys = "ctrl + fn - left"
+
+
 # ---- 未定義キー効果音フォールバック ----
 # 4 修飾子セット (ULTRA_LL/MIRACLE_LM/MEGA_RM/WONDER_RR) で実バインド済みの
 # キー以外を押すと効果音を鳴らす。chord v0.2.0 PR5 の `[[fallbacks]]` +

--- a/chezmoi/dot_config/facet/config.toml
+++ b/chezmoi/dot_config/facet/config.toml
@@ -111,3 +111,49 @@ hide_method = "anchor"
 
 [tree]
 preview_mode = "mirror"
+
+# -----------------------------------------------------------------
+# Per-native-Space workspaces  [space.N]
+# -----------------------------------------------------------------
+# Each native macOS Space keeps its own independent set of facet
+# workspaces. `N` is the native Space's position in Mission Control
+# order (1-based, user Spaces only — fullscreen Spaces don't count).
+# Inside a section, `index = "name"` works exactly like [workspace].
+# A native Space WITHOUT a [space.N] section falls back to the
+# global [workspace] above. Edits take effect on facet restart.
+#
+# Note: the mapping is by Mission Control position, so reordering
+# Spaces in Mission Control re-points these sections (cosmetic only
+# — windows stay scoped to their real Space).
+
+[space.1]
+1 = "WS1-1"
+2 = "WS1-2"
+3 = "WS1-3"
+
+[space.2]
+1 = "WS2-1"
+2 = "WS2-2"
+3 = "WS2-3"
+4 = "WS2-4"
+
+[space.3]
+1 = "WS3-1"
+2 = "WS3-2"
+3 = "WS3-3"
+4 = "WS3-4"
+5 = "WS3-5"
+
+[space.4]
+1 = "WS4-1"
+2 = "WS4-2"
+3 = "WS4-3"
+4 = "WS4-4"
+5 = "WS4-5"
+
+[space.5]
+1 = "WS5-1"
+2 = "WS5-2"
+3 = "WS5-3"
+4 = "WS5-4"
+5 = "WS5-5"

--- a/docs/chord.md
+++ b/docs/chord.md
@@ -80,6 +80,8 @@ private_config.toml の `# doc:` 行＋`[[bindings]]` を編集 →
 | `Ctrl + H` | Backspace | * |
 | `Ctrl + D` | 前方削除（Forward Delete） | * |
 | `Ctrl + J` | Return | * |
+| `Ctrl + Fn + right` | スペース右へ移動しつつ facet tree 表示（ctrl+→） | * |
+| `Ctrl + Fn + left` | スペース左へ移動しつつ facet tree 表示（ctrl+←） | * |
 
 <!-- END AUTO-GENERATED -->
 


### PR DESCRIPTION
## Summary

facet をネイティブ Space 運用に統合する設定変更。

- **chord** (`dot_config/chord/private_config.toml`): `ctrl+→` / `ctrl+←` に `facet --view=tree` 起動を重ねるオーバーレイ binding を追加。`action-shell` で facet を起動し、`action-keys` で `ctrl+fn+→/←` を再送して macOS のスペース移動と連動させる。矢印に常時付与される `fn` を input/output 両方に明記して物理イベントと一致させている。
- **facet** (`dot_config/facet/config.toml`): ネイティブ Space ごとに独立した workspace を持たせる `[space.1]`〜`[space.5]` を追加。

## Test plan

- [x] `chord --validate` PASS（21 bindings / dropped 0 / warnings 0）
- [x] `chezmoi verify` クリーン（source ↔ live 一致、apply 済み）
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)