### PR TITLE
:wrench: chore(facet): facet が正規化した live 形を source に同期

### DIFF
--- a/chezmoi/dot_config/facet/config.toml
+++ b/chezmoi/dot_config/facet/config.toml
@@ -29,7 +29,7 @@
 # Default for a fresh `curl` install: "tree" (the always-on-top
 # sidebar — facet's primary surface; the grid is a TS3-style
 # overview you summon on demand with `facet --view=grid`).
-default_view = "tree"
+default-view = "tree"
 
 
 # -----------------------------------------------------------------
@@ -63,10 +63,6 @@ cols = 5
 #   "up"   — label above each cell (Mission Control / TS3 style).
 #   "down" — label below each cell (Stage Manager / dock style).
 label-position = "up"
-
-# Workspace label font size in points. Clamped 8..32. The label
-# band height tracks this so larger labels reserve more space.
-label-size = 15
 
 # Background ScreenCaptureKit refresh cadence (seconds) that keeps
 # grid-view thumbnails warm so `--view=grid` paints immediately
@@ -110,7 +106,7 @@ thumbnail-refresh-seconds = 4
 hide_method = "anchor"
 
 [tree]
-preview_mode = "mirror"
+preview-mode = "mirror"
 
 # -----------------------------------------------------------------
 # Per-native-Space workspaces  [space.N]


### PR DESCRIPTION
## Summary

`chezmoi re-add ~/.config/facet/config.toml`。PR #128 は `default_view`/`preview_mode`（アンダースコア）+ `label-size=15` でコミットしたが、その後 facet が live config を `default-view`/`preview-mode`（ハイフン）+ label-size 無しに正規化していた。live の正規形を source に取り込み `chezmoi verify` を clean にする。

> 補足: facet は現在開発中（[facet PRs](https://github.com/akira-toriyama/facet/pulls)）のため config 形式が流動的。この同期は現時点の正規形を取り込むもので、facet の変更に応じて今後も更新される想定。

## Test plan

- [x] `chezmoi verify` clean（source ↔ live 一致）
- [ ] CI green