### PR TITLE
:wrench: chore(facet): live の [layout] (gap 設定) を source に同期

### DIFF
--- a/chezmoi/dot_config/facet/config.toml
+++ b/chezmoi/dot_config/facet/config.toml
@@ -153,3 +153,8 @@ preview-mode = "mirror"
 3 = "WS5-3"
 4 = "WS5-4"
 5 = "WS5-5"
+
+[layout]
+inner-gap = 12
+outer-gap = 12
+outer-gap-left = 520


### PR DESCRIPTION
## 概要
facet が実行時に live (`~/.config/facet/config.toml`) へ書き込んだ `[layout]` 節を chezmoi source へ `re-add` で取り込み、source ⇔ live の乖離 (`chezmoi status` の `MM`) を解消する。

## 変更
- `chezmoi/dot_config/facet/config.toml` に `[layout]` を追加
  - `inner-gap = 12`
  - `outer-gap = 12`
  - `outer-gap-left = 520`

## 背景
dotfiles-drift の毎朝チェックおよび pre-push の `chezmoi verify` が乖離を検知するため、**layout あり側を維持する方向** (`re-add`) で同期。#129 と同種の facet 正規化同期。

🤖 Generated with [Claude Code](https://claude.com/claude-code)