### PR TITLE
:sparkles: feat(homebrew): monodraw cask を宣言追加

### DIFF
--- a/system/modules/homebrew.nix
+++ b/system/modules/homebrew.nix
@@ -55,6 +55,7 @@
       "transmission"        # BitTorrent
       "warp"                # ターミナル（任意）
       "zed"                 # エディタ（vscode と棲み分けの可能性）
+      "monodraw"            # ASCII アート / テキスト図エディタ
 
       # 明示的に未宣言（破棄方針）:
       #   google-japanese-ime  ← azookey に置換済。cleanup=zap 化で消える


### PR DESCRIPTION
## 概要
ASCII アート / テキスト図エディタ **Monodraw** を nix-darwin homebrew の cask に宣言追加する。

## 変更
- `system/modules/homebrew.nix` の casks に `monodraw` を追加

## 補足
- Helftone 直販版と同一の Developer ID 署名ビルド（cask も同じバイナリ）。
- ライセンスは購入済みキーをアプリ内入力で投入するため、dotfiles 側は本体管理のみ（秘密はリテラル化しない方針に準拠）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)