### PR TITLE
:sparkles: feat(drift): drift 通知を terminal-notifier → osascript ダイアログに

### DIFF
--- a/system/modules/homebrew.nix
+++ b/system/modules/homebrew.nix
@@ -24,7 +24,6 @@
     ];
     brews = [
       "felixkratz/formulae/borders"  # A window border system for macOS
-      "terminal-notifier" # macOS 通知 CLI。launchd-drift.nix の drift 検知通知で使用
     ];
 
     casks = [

--- a/system/modules/launchd-drift.nix
+++ b/system/modules/launchd-drift.nix
@@ -1,9 +1,10 @@
-{ username, ... }:
+{ ... }:
 
 {
   # dotfiles の各種 drift (homebrew 宣言↔実 install / chezmoi source↔live / git 未push・
-  # 滞留未commit) を毎日 1 回チェックし、差分があれば macOS 通知 (terminal-notifier) を
-  # 1 件出すだけの LaunchAgent。自動修正はしない。
+  # 滞留未commit) を毎日 1 回チェックし、差分があれば macOS の中央ダイアログ (osascript
+  # display dialog) を出すだけの LaunchAgent。自動修正はしない。通知許可は不要
+  # (アプリ自身のダイアログ = TCC 対象外) なので、環境構築だけで通知が機能する。
   # スクリプト本体は ./scripts/check-dotfiles-drift.sh (Nix store にコピーされる)。
   # 手動実行は: dotfiles-drift-check (または bash <repo>/system/modules/scripts/check-dotfiles-drift.sh)
   launchd.user.agents.dotfiles-drift = {
@@ -23,27 +24,4 @@
       StandardErrorPath = "/tmp/dotfiles-drift.log";
     };
   };
-
-  # 初回 darwin-rebuild switch で 1 度だけ「通知許可ページを開く」hint。
-  # terminal-notifier の通知許可がデフォ OFF なので、許可が漏れると drift
-  # 検知通知が silent failure する。誘導しないと気付けない事案を回避。
-  # flag file ($HOME/.local/state/dotfiles/tn-permission-hinted) の有無で
-  # 冪等化、2 回目以降の switch では何もしない。
-  # 再 hint させたい時は flag file を rm。
-  system.activationScripts.notifyPermissionHint.text = ''
-    HINT_FLAG="/Users/${username}/.local/state/dotfiles/tn-permission-hinted"
-    if [ ! -f "$HINT_FLAG" ] && [ -x /opt/homebrew/bin/terminal-notifier ]; then
-      echo "[notifyPermissionHint] first-run hint を表示します"
-      sudo -u ${username} /opt/homebrew/bin/terminal-notifier \
-        -group "dotfiles-drift-setup" \
-        -title "dotfiles-drift セットアップ" \
-        -subtitle "通知許可をお願いします" \
-        -message "System Settings → 通知 → terminal-notifier を ON にしてください" \
-        -sound Pop || true
-      sudo -u ${username} open \
-        "x-apple.systempreferences:com.apple.preference.notifications" || true
-      sudo -u ${username} mkdir -p "$(dirname "$HINT_FLAG")"
-      sudo -u ${username} touch "$HINT_FLAG"
-    fi
-  '';
 }

--- a/system/modules/scripts/check-dotfiles-drift.sh
+++ b/system/modules/scripts/check-dotfiles-drift.sh
@@ -14,14 +14,27 @@
 #        ※ unpushed: commit したのに origin に無い (= 新 Mac で再現できない)
 #        ※ uncommitted: STALE_DAYS 日以上触られていない時だけ通知 (作業中のノイズ回避)
 #
+# 設計方針 (全ての「新 PC で再現できない」穴をこの check でカバーはしない):
+#   - 「source が綺麗に再現できるか」は CI の switch-smoke が別途実証する。本 check は
+#     その CI が原理的に見られない「live にあるが source に無い」穴だけを担当する。
+#   - 静的に分かる穴 (モジュール配線忘れ = orphan 等) は CI 側で弾く (マージ前ブロック)。
+#   - あえて検知しない / できない穴 (accept・defer):
+#       ⑤ masApps        : mas 上流バグで凍結中の既知ギャップ
+#       ⑥ 1Password 参照  : テンプレに op:// が無いうちは対象外 (参照追加時に resolver 検討)
+#       ⑦ 管理外 GUI 設定 : 追跡是非は意図問題 → chezmoi add する運用規律で対応
+#       未宣言の手動 defaults: どれを再現したいかは意図問題で原理的に検知不能
+#         (defaults は「宣言済キーが実 live と一致するか」の逆監査のみ担当する)
+#
 # 通知:
-#   - terminal-notifier で件数サマリを 1 件だけ。詳細 (description + 対応コマンド) は
-#     /tmp/dotfiles-drift-latest.md に書き出し、通知クリックで code が **新規ウィンドウ**
-#     (`code -n`) で開く。
-#   - 悪い状態が続く限り毎回 (= 毎朝 9:00 の起動ごとに) 通知する。重複抑止はしない:
-#     dotfiles/ が壊れている間は毎日リマインドが欲しいという運用方針。banner は数秒で
-#     消えるが -group 指定で通知センターでは最新 1 件に置き換わる。md は毎回最新に更新。
-#   - drift が解消したら md・hash を削除し、残っていた通知も -remove で消す。
+#   - osascript の display dialog で 画面中央にウィンドウ を出す。通知許可ゲートが無い
+#     (アプリ自身のダイアログ = TCC 対象外) ので、環境構築だけで機能する
+#     (terminal-notifier 方式で要った「通知許可を手動 ON」の人手が不要になる)。
+#   - 件数サマリを表示し、「詳細を開く」で詳細 (description + 対応コマンド) を
+#     /tmp/dotfiles-drift-latest.md から code の新規ウィンドウ (`code -n`) で開く。
+#   - 悪い状態が続く限り毎回 (= 毎朝 9:00 の起動ごとに) 出す。重複抑止はしない:
+#     dotfiles/ が壊れている間は毎日リマインドが欲しいという運用方針。timeout 無し =
+#     押すまで残る。md は毎回最新に更新。
+#   - drift が解消したら md を削除する。
 #   - flake パスは ghq → $HOME/dotfiles → $DOTFILES_FLAKE_DIR の順で解決
 #   - 実行ログ (append): /tmp/dotfiles-drift.log (launchd の Std{Out,Err}Path)
 set -eu
@@ -41,7 +54,6 @@ IGNORE_EXTRA_CASKS="google-japanese-ime karabiner-elements"
 # 縮める / 未コミットを別カテゴリで即通知する等を検討する。
 STALE_DAYS=3
 
-GROUP="dotfiles-drift"
 DETAIL_FILE="/tmp/dotfiles-drift-latest.md"
 # 詳細レポートの「宣言:」行が指す helper。switch 済み環境で使う前提なので bare 名。
 ADD_SH="add-homebrew"
@@ -161,7 +173,6 @@ total=$(( n_ec + n_mc + n_dup + n_ub + n_mb + n_cz + n_unpushed + n_stale ))
 if [ "$total" -eq 0 ]; then
   echo "[$(date)] no drift"
   rm -f "$DETAIL_FILE" "$HOME/.local/state/dotfiles/drift-notified.sha"
-  command -v terminal-notifier >/dev/null 2>&1 && terminal-notifier -remove "$GROUP" >/dev/null 2>&1 || true
   exit 0
 fi
 
@@ -327,22 +338,29 @@ fence() { printf '```sh\n%s\n```\n' "$1"; }
 
 # ============================================================
 # 通知。
-#   - terminal-notifier 未導入なら log だけ残して exit (新 PC 初日対策)。
-#   - 悪い状態が続く限り起動ごとに通知 (重複抑止なし)。-group で最新 1 件に置き換わる。
-#   - クリックで code が新規ウィンドウ (-n) で詳細 md を開く。
+#   - osascript の display dialog で画面中央にウィンドウを出す。通知許可ゲートが無い
+#     (アプリ自身のダイアログ = TCC 対象外) ため、環境構築だけで機能する。
+#   - LaunchAgent は gui/<uid> セッションで動くので dialog を描画できる。画面ロック中 /
+#     ログイン前はセッションが有効になった時に出る (launchd の catch-up)。
+#   - 「詳細を開く」で code が新規ウィンドウ (-n) で詳細 md を開く。timeout 無し =
+#     押すまで残る。GUI セッションが無い文脈 (CI / ssh 等) では出せず log だけ残す。
+#   - subtitle は固定文字列 + 件数のみ (外部入力なし) なので dialog 文字列に直に埋める。
 # ============================================================
-if command -v terminal-notifier >/dev/null 2>&1; then
-  # 悪い状態が続く限り、起動ごと (= 毎朝 9:00) に必ず通知する。重複抑止はしない。
-  # -group 指定で通知センターでは最新 1 件に置き換わる。
-  terminal-notifier \
-    -group "$GROUP" \
-    -title "dotfiles drift" \
-    -subtitle "$subtitle" \
-    -message "🤖 詳細を開く" \
-    -execute "/opt/homebrew/bin/code -n $DETAIL_FILE" \
-    -sound Pop \
-    >/dev/null 2>&1 || true
-  echo "[$(date)] notified: $subtitle (詳細: $DETAIL_FILE)"
+if command -v osascript >/dev/null 2>&1; then
+  dialog_msg="${subtitle}
+
+「詳細を開く」で対応コマンド付きレポートを表示します。"
+  btn=$(osascript <<OSA 2>/dev/null
+display dialog "${dialog_msg}" with title "⚠ dotfiles drift" buttons {"閉じる", "詳細を開く"} default button "詳細を開く" with icon caution
+OSA
+) || true
+  case "$btn" in
+    *"詳細を開く"*)
+      /opt/homebrew/bin/code -n "$DETAIL_FILE" >/dev/null 2>&1 \
+        || open "$DETAIL_FILE" >/dev/null 2>&1 || true
+      ;;
+  esac
+  echo "[$(date)] notified (dialog): $subtitle (詳細: $DETAIL_FILE)"
 else
-  echo "[$(date)] terminal-notifier not found, drift logged only: $subtitle (詳細: $DETAIL_FILE)"
+  echo "[$(date)] osascript not found, drift logged only: $subtitle (詳細: $DETAIL_FILE)"
 fi


### PR DESCRIPTION
## 概要
drift 通知を **terminal-notifier(banner) → osascript display dialog(画面中央ウィンドウ)** に差し替える。

## 動機
terminal-notifier は通知許可がデフォ OFF で、新 PC では「通知許可を手動 ON」する人手が1回必要だった。osascript の `display dialog` は**アプリ自身のダイアログ＝TCC 対象外で許可ゲートが無い**ため、環境構築 (install.sh → switch) だけで通知が機能する（人手ゼロ）。再現性の北極星に沿う。

## 変更（3ファイル・全部 osascript 移行で一貫）
- **check-dotfiles-drift.sh**: 通知を `osascript display dialog` に。timeout 無し（押すまで残る）、「詳細を開く」→ `code -n` で detail md、「閉じる」。`GROUP` 定義と clean 時の `terminal-notifier -remove` を除去。設計方針コメント（「全ての穴をチェック化しない」）も同梱。
- **launchd-drift.nix**: `notifyPermissionHint`（通知許可を促す初回 hint）を削除。`username` 不要化で `{ ... }` に。ヘッダを osascript 前提に更新。
- **homebrew.nix**: `terminal-notifier` brew 宣言を削除（手動 uninstall 済みと一致 → drift 出ない）。

## 仕組み
LaunchAgent は `gui/<uid>` セッションで動くため dialog を描画できる。画面ロック中/ログイン前はセッションが有効になった時に出る（launchd catch-up）。

## 検証
- ✅ shellcheck clean
- ✅ nix flake check pass
- ✅ 実ダイアログ動作（「閉じる」「詳細を開く」両分岐）確認

## 反映条件
LaunchAgent/スクリプトは Nix store 経由のため、**マージ後 `darwin-rebuild switch` で有効化**される。

🤖 Generated with [Claude Code](https://claude.com/claude-code)