### PR TITLE
:sparkles: feat(glossary): deploy to Pages + Obsidian-friendly markdown

### DIFF
--- a/.github/workflows/glossary.yml
+++ b/.github/workflows/glossary.yml
@@ -1,0 +1,35 @@
+name: Deploy glossary site
+
+# 本リポの docs/glossary.md から専用 SPA を生成し、
+# https://akira-toriyama.github.io/dotfiles/ に公開する。
+# 実体 (builder + viewer) は akira-toriyama/glossary-site の reusable workflow に委譲。
+#
+# - push to main → build + deploy
+# - pull_request → build のみ (artifact から成果物確認可、deploy なし)
+# - workflow_dispatch → build + deploy
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - docs/glossary.md
+      - .github/workflows/glossary.yml
+  pull_request:
+    paths:
+      - docs/glossary.md
+      - .github/workflows/glossary.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  # PR と main を別グループに (PR build が main deploy を巻き込まない)
+  group: pages-${{ github.event.number || github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    uses: akira-toriyama/glossary-site/.github/workflows/deploy.yml@main

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,3 +1,10 @@
+---
+title: dotfiles 用語集
+tags: [glossary, macos, nix, chezmoi]
+repo: dotfiles
+aliases: []
+---
+
 # 用語集 — dotfiles のユビキタス言語
 
 dotfiles を構成する各パーツの **正規の呼び名** をまとめた規範ドキュメント。
@@ -102,7 +109,7 @@ flowchart TD
 ## ビルド / 適用
 
 ### `flake.nix`
-リポジトリ直下の Nix flake エントリ。nix-darwin / home-manager / nix-homebrew
+リポジトリ直下の Nix flake エントリ。[[nix-darwin]] / [[home-manager]] / nix-homebrew
 を組合せる。
 - **Don't call it:** nix entry, ニックスエントリ
 
@@ -121,7 +128,7 @@ switch ...` で呼ぶ。
 - **Don't call it:** preview, dry-run, プレビュー
 
 ### `chezmoi apply`
-chezmoi 管理ファイルを `$HOME` に書き出す **実適用**。
+[[chezmoi]] 管理ファイルを `$HOME` に書き出す **実適用**。
 - **Don't call it:** sync, deploy, 適用
 
 ### `chezmoi re-add`
@@ -135,13 +142,13 @@ chezmoi 管理ファイルを `$HOME` に書き出す **実適用**。
 ## chezmoi 規約
 
 ### `executable_` prefix
-**chezmoi 配下のスクリプトに +x を再現するための prefix**。CI が強制
+**[[chezmoi]] 配下のスクリプトに +x を再現するための prefix**。CI が強制
 （[`.github/workflows/ci.yml`](../.github/workflows/ci.yml)）。`run_*` と
 `.chezmoiscripts/` 配下は例外（chezmoi 自身が実行するので prefix 不要）。
 - **Don't call it:** exec prefix, x prefix, 実行プレフィックス
 
 ### `private_` prefix
-**chezmoi で権限 600 を再現する prefix**。secret ファイルに必須。
+**[[chezmoi]] で権限 600 を再現する prefix**。secret ファイルに必須。
 - **Don't call it:** secret prefix, restricted prefix, 機密プレフィックス
 
 ### `encrypted_` prefix
@@ -149,17 +156,17 @@ chezmoi 管理ファイルを `$HOME` に書き出す **実適用**。
 - **Don't call it:** crypt prefix, secure prefix
 
 ### `.tmpl` + `onepasswordRead`
-chezmoi テンプレに secret を **参照** として埋め込む正規パターン。
+[[chezmoi]] テンプレに secret を **参照** として埋め込む正規パターン。
 リテラル値は書かない。前提: `op signin` 済み。
 - **Don't call it:** secret template, op template, シークレットテンプレ
 
 ### `run_once_` / `run_onchange_`
-chezmoi の **scripts 発火ポリシー**。`run_onchange_` が既定（idempotent）。
+[[chezmoi]] の **scripts 発火ポリシー**。`run_onchange_` が既定（idempotent）。
 `run_once_` は本当に一度きりの bootstrap でのみ使う。
 - **Don't call it:** init script, setup hook, 初期化スクリプト
 
 ### `mkOutOfStoreSymlink`
-**AI / ユーザーが直接編集する dotfile** を nix store 外へ逃がす home-manager
+**AI / ユーザーが直接編集する dotfile** を nix store 外へ逃がす [[home-manager]]
 イディオム。直書きすると `/nix/store` は immutable なので編集できない。
 - 適用例: `~/.claude/settings.json`
 - **Don't call it:** writable symlink, out-of-store link, 書き換え可能リンク


### PR DESCRIPTION
## Summary

[akira-toriyama/glossary-site](https://github.com/akira-toriyama/glossary-site) の reusable workflow を呼び出し、本リポの `docs/glossary.md` から専用 SPA を自動生成して GitHub Pages に公開する。

公開予定 URL: `https://akira-toriyama.github.io/dotfiles/`

## 変更点

### `.github/workflows/glossary.yml` (新規)

- `uses: akira-toriyama/glossary-site/.github/workflows/deploy.yml@main`
- トリガ:
  - `push to main` → build + deploy
  - `pull_request` → build only (artifact 経由で成果物確認可)
  - `workflow_dispatch` → 手動実行
- concurrency group は PR/main で別 (PR build が main deploy を巻き込まない)
- Node 依存はリポに残らない (CI で都度フェッチ)

### `docs/glossary.md` (Obsidian friendly 化)

- 冒頭に YAML frontmatter: `title` / `tags` / `repo` / `aliases`
- 用語間クロス参照を `[[wikilink]]` に保守的変換
  - skip: 4 文字未満 / コードスパン / 既存 wikilink / `Don't call it:` 行 / 自己参照
  - 1 body あたり同じ用語は 1 回のみ
- Obsidian で `docs/` を vault として開けば即引ける

## マージ後の手順

1. リポ Settings → Pages → **Source: GitHub Actions** に変更 (人手必要、私が gh api で自動化予定)
2. workflow が自動実行 → デプロイ完了後 URL を Repo の Website にセット
3. https://akira-toriyama.github.io/dotfiles/ にアクセスして cmdk 検索 UI を確認

## Test plan

- [x] reusable workflow 側 (glossary-site) は green
- [ ] この PR で build job のみ走り deploy job は skip される (PR trigger 動作確認)
- [ ] マージ後の自動デプロイで URL が 200 を返す
- [ ] cmdk 検索 UI が動く、`Don't call it:` 同義語マッチが効く

🤖 Generated with [Claude Code](https://claude.com/claude-code)