### PR TITLE
:memo: docs(claude): restructure CLAUDE.md by repo ownership, add Workflow and commit-style link

### DIFF
--- a/chezmoi/private_dot_claude/CLAUDE.md
+++ b/chezmoi/private_dot_claude/CLAUDE.md
@@ -1,8 +1,22 @@
-## Commits
+# emmett-lathrop-brown のリポジトリに対して
 
-- 対象は **emmett-lathrop-brown 配下**の repo。**外部 repo は相手の慣習を尊重**（この節は適用しない）。
-- Conventional Commits + gitmoji の「いいとこ取り」。gitmoji は全部 OK・**固定の対応表は持たない**（増えるため、必要時に参照）:
-  - https://www.conventionalcommits.org
-  - https://github.com/carloscuesta/gitmoji
-- 形: `:gitmoji: type(scope): subject`。**subject も body も英語**で書く。
-- body を書く時は、その後半に `---（和訳）` 区切りを置き、**subject と body の和訳**を同内容で付ける（長くなるのは許容）。subject だけの commit は和訳不要。
+## Commits message style
+
+- **gitmoji + Conventional Commits**。**commit の type が git-cliff 経由で release の semver と notes を駆動する**（gitmoji は装飾で版に影響しない）。
+- 版を動かす type: `feat`→minor ／ `fix`・`perf`・`revert`→patch ／ breaking（`!` or `BREAKING CHANGE:`）→major ／ `docs`・`chore` 等→bump なし。
+- subject も body も英語。body を書く時は後半に `---（和訳）` 区切りで subject と body の和訳を付ける（subject だけなら不要）。
+- **全文（厳格仕様・例つき）**: https://github.com/akira-toriyama/.github/blob/main/CONTRIBUTING.md
+
+## Workflow
+
+- 作業は **まず tracking issue を立ててから始める**のを既定にする（1 セッションで終わる見込みでも膨らむことがあり、サイズ判断で迷わないため）。issue 化が明らかに過剰な些末作業は除く。
+- **進捗の正本はその issue 一本**。「どこまで終わったか／次に何をするか」は issue 本文のチェックリストに記録し、**memory やブランチ上のファイルに複製しない**（2重管理＝剥離を避ける）。
+- セッションの作法:
+  - 開始時: 該当 issue を `gh issue view <N>` で読み、現在地を把握してから着手。
+  - 中断時: issue のチェックを更新し、必要なら「次は X から」を 1 行残す。
+
+# emmett-lathrop-brown 以外のリポジトリに対して
+
+## Rule
+
+- リポジトリの慣習にしたがう。


### PR DESCRIPTION
## What

Restructure the global `~/.claude/CLAUDE.md` (chezmoi source `private_dot_claude/CLAUDE.md`):

- Split by repo ownership with `#` headings (own repos vs. others → "follow the repo's conventions").
- **Commits message style**: keep only the core (type→semver, git-cliff drives the version, English + `---（和訳）`) and link to the canonical full spec at `akira-toriyama/.github/CONTRIBUTING.md`.
- **Workflow** (new): for own-repo work, the tracking issue is the single source of truth for progress (no duplicating progress in memory or branch files); read the issue at start, update it before pausing.

---（和訳）

グローバル CLAUDE.md を repo の所有で章立てし、Commits 節は核＋ `.github/CONTRIBUTING.md` への
リンクに絞り、Workflow 節（進捗の正本＝issue 一本）を追加する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)