### PR TITLE
:heavy_plus_sign: chore(homebrew): add obsidian cask

### DIFF
--- a/system/modules/homebrew.nix
+++ b/system/modules/homebrew.nix
@@ -30,6 +30,7 @@
     ];
 
     casks = [
+      "obsidian"  # Knowledge base that works on top of a local folder of plain text Markdown files
       # 1Password 8 デスクトップ。SSH エージェント / op CLI 連携の前提
       "1password"
 


### PR DESCRIPTION
## What

Add the **obsidian** Homebrew cask (Markdown knowledge base).

Verified `nix flake check --no-build` passes locally; the required
`darwin-rebuild build` / `switch smoke` CI jobs perform the real install.

---（和訳）

Homebrew cask に obsidian（Markdown ナレッジベース）を追加する。ローカルで
`nix flake check` 通過済み。実インストールは必須 CI（darwin build / switch smoke）で検証される。

🤖 Generated with [Claude Code](https://claude.com/claude-code)