### PR TITLE
:construction_worker: ci: make way for nix-homebrew on updated macos runner image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,14 @@ jobs:
       - name: Install Nix (Determinate)
         uses: DeterminateSystems/nix-installer-action@main
 
+      - name: Make way for nix-homebrew (remove preinstalled Homebrew)
+        # GitHub の macos ランナーは /opt/homebrew を preinstall するが、
+        # イメージ更新 (20260610 → 20260623) で git checkout でなくなり、
+        # nix-homebrew (autoMigrate=true) の移管が
+        # "/opt/homebrew does not looks like a Homebrew checkout" で失敗する。
+        # CI では preinstalled brew を退け、nix-homebrew にクリーンに入れさせる。
+        run: sudo rm -rf /opt/homebrew /usr/local/Homebrew /usr/local/bin/brew
+
       - name: darwin-rebuild switch (CI variant, masApps 空)
         run: sudo nix run nix-darwin/master#darwin-rebuild -- switch --flake .#ci --show-trace
 


### PR DESCRIPTION
## Why
`darwin-rebuild switch smoke` started failing on 2026-06-27. Root cause is the GitHub `macos-15-arm64` runner image bump (**20260610 → 20260623**): the new image's preinstalled `/opt/homebrew` is no longer a git "Homebrew checkout", so nix-homebrew (`autoMigrate = true`) aborts during activation with `/opt/homebrew does not looks like a Homebrew checkout`.

Repo was unchanged (flake.lock untouched since skeleton, ci.yml unchanged); `darwin-rebuild build` stays green so the config is valid — **CI-runner-only**.

## Fix
Remove the runner's preinstalled Homebrew before `darwin-rebuild switch` so nix-homebrew installs its own cleanly.

---（和訳）
`switch smoke` が 6/27 から赤。原因は macos-15-arm64 ランナーイメージ更新 (20260610→20260623) で preinstalled /opt/homebrew が git checkout でなくなり nix-homebrew の autoMigrate が失敗するため。repo 無変更・build は green＝CI 固有。switch 前に preinstalled brew を退け nix-homebrew をクリーンに入れさせる。