### PR TITLE
:memo: docs(claude): switch task-management rules from GitHub issues to furrow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,12 +130,17 @@ chezmoi add <path>                                                              
 op read "op://Vault/Item/field"
 ```
 
-## Roadmap board (GitHub Projects)
+## Roadmap board / task tracker
 
-この repo の issue は集約 Project「roadmap」(akira-toriyama #5・
-https://github.com/users/akira-toriyama/projects/5)で管理。Claude もこれに従う:
+dotfiles の作業タスク（バックログ・設計メモ・引き継ぎ）の**正本は furrow + private repo
+[`akira-toriyama/projects`](https://github.com/akira-toriyama/projects)**（label `dotfiles`）。
+`furrow ls -l dotfiles`（着手候補 = ready / in-progress）/ `furrow show <id>` / 起票は
+`furrow add "…" -l dotfiles`。運用ルールの正典は
+[`projects/CLAUDE.md`](https://github.com/akira-toriyama/projects/blob/main/CLAUDE.md)、
+全 repo 共通の作法は global `~/.claude/CLAUDE.md` の Workflow 節（furrow source を使う・
+着手前に projects 最新化・PR 本文に `SetStatus-task:` footer）。
 
-- 新規 issue は **Inbox** 既定。off-board の open issue を残さない(迷子を作らない)。
-- Status(single-select): `Inbox → Backlog → Ready → In Progress → Done` / `Icebox`=someday。Ready は 2〜3(WIP)。
-- PR 本文に `Closes #N` を必ず書く → merge で issue 自動 close → 自動 Done。
-- 詳細は Project の README。
+issue 運用（集約 Project「roadmap」#5・Inbox/Status フロー・`Closes #N`）は family 共通ポリシー
+の名残で、**task の正本は furrow に移行済み**。**Project #5 / 残 open issue は手動 mirror 扱い**
+（破壊しない）。dotfiles の PR は furrow task を `SetStatus-task:` footer で閉じる
+（`.github/workflows/task-status.yml` は fleet 同期済）。

--- a/chezmoi/private_dot_claude/CLAUDE.md
+++ b/chezmoi/private_dot_claude/CLAUDE.md
@@ -7,13 +7,17 @@
 - subject も body も英語。body を書く時は後半に `---（和訳）` 区切りで subject と body の和訳を付ける（subject だけなら不要）。
 - **全文（厳格仕様・例つき）**: https://github.com/akira-toriyama/.github/blob/main/CONTRIBUTING.md
 
-## Workflow
+## Workflow（タスク管理）
 
-- 作業は **まず tracking issue を立ててから始める**のを既定にする（1 セッションで終わる見込みでも膨らむことがあり、サイズ判断で迷わないため）。issue 化が明らかに過剰な些末作業は除く。
-- **進捗の正本はその issue 一本**。「どこまで終わったか／次に何をするか」は issue 本文のチェックリストに記録し、**memory やブランチ上のファイルに複製しない**（2重管理＝剥離を避ける）。
+- **タスク管理は furrow + `projects` repo に一本化**（GitHub issue ではない）。`projects` は全 repo 横断の private tracker（GitHub Projects #5 のローカル正本）。実体は plain text（`.furrow/index.json` + `bodies/<id>.md`）。**運用ルールの正典は [`projects/CLAUDE.md`](https://github.com/akira-toriyama/projects/blob/main/CLAUDE.md)** —— ここはその薄いポインタ。
+- **furrow は開発活発 → install 版でなく clone した source を使う**（install 版は stale 化・古い id 採番で並行 add が衝突した実績）。source = `…/github.com/akira-toriyama/furrow`、`go run ./cmd/furrow <args>`（or `go build -o /tmp/furrow-dev ./cmd/furrow`）。
+- **着手前に `projects` を最新化**: tracker は共有 checkout なので、読む前に fetch→behind なら pull（古い body で判断する事故を防ぐ）。
+- **全タスクに repo ラベル必須**（`furrow add … -l <repo>`、bare な repo 名。無いと exit 2）。tracker 自身の作業は `-l projects`。
+- **進捗の正本はそのタスク body 一本**。「どこまで終わったか／次に何をするか」は `projects/.furrow/bodies/<id>.md` のチェックリストに記録し、**memory やブランチ上のファイルに複製しない**（2重管理＝剥離を避ける）。
 - セッションの作法:
-  - 開始時: 該当 issue を `gh issue view <N>` で読み、現在地を把握してから着手。
-  - 中断時: issue のチェックを更新し、必要なら「次は X から」を 1 行残す。
+  - 開始時: `furrow next -l <repo>`（or `furrow show <id>`）で現在地を把握してから着手。
+  - 中断時: body のチェックを更新し、必要なら「次は X から」を 1 行残す。
+- **code repo の PR 本文に footer を1行**: `SetStatus-task: https://github.com/akira-toriyama/projects/blob/main/.furrow/bodies/<id>.md <lane>`（PR open→in-progress / merge→`<lane>` 適用。lane 省略で参照のみ。非ブロッキング）。
 
 # akira-toriyama 以外のリポジトリに対して
 


### PR DESCRIPTION
Rewrite the global `~/.claude/CLAUDE.md` "Workflow" section and this repo's
"Roadmap board" section from the legacy GitHub-issue + Projects #5 process to
**furrow + the projects tracker**, so every repo's Claude session reads one
consistent rule instead of the old "open an issue" instruction.

- Global file stays a **thin pointer**; `projects/CLAUDE.md` remains the single
  source of the detailed rules (DRY).
- New rules recorded: use furrow from its **source clone** (not the installed
  build), **refresh the projects checkout before starting**, repo label is
  mandatory, **progress lives in the task body**, code-repo PRs carry a
  `SetStatus-task:` footer.
- Projects #5 / leftover open issues are demoted to a **manual mirror**.
- Absorbs **t-5rgs item 4** (the fetch-before-start line), cross-referenced there.

Follows the established facet → chord (t-0047) pattern. Docs-only; no flake/eval impact.

SetStatus-task: https://github.com/akira-toriyama/projects/blob/main/.furrow/bodies/t-10h8.md done