### PR TITLE
:sparkles: feat(stale-check): warn (cd + Claude SessionStart) when a repo is behind upstream

### DIFF
--- a/chezmoi/dot_local/bin/executable_git-stale-check
+++ b/chezmoi/dot_local/bin/executable_git-stale-check
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# git-stale-check — warn (one line) when the cwd's git repo is behind its upstream.
+#
+# The behind check is LOCAL and instant (compares HEAD to the last-fetched
+# remote-tracking ref). The `git fetch` that refreshes that ref is THROTTLED
+# (~600s/repo) and runs DETACHED in the background, so this never blocks the
+# shell prompt or a Claude session. Silent when: not a git repo / no upstream /
+# detached HEAD. Always exits 0 (advisory only, never an error).
+#
+# Owned by dotfiles (chezmoi → ~/.local/bin/git-stale-check). Wired from the zsh
+# chpwd hook (humans) and the Claude SessionStart hook (agents). The warning is
+# printed to STDOUT on purpose so it lands in the agent's session-start context.
+# See furrow t-5rgs.
+set -u
+
+# 0) must be inside a work tree (else silent)
+repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || exit 0
+[ -n "$repo_root" ] || exit 0
+
+# 1) must have an upstream (skips detached HEAD / no-upstream silently)
+upstream=$(git rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>/dev/null) || exit 0
+[ -n "$upstream" ] || exit 0
+
+# 2) throttled, backgrounded fetch — refreshes the remote-tracking ref so the
+#    LOCAL check below is current on a later invocation. Keyed per repo.
+throttle_secs=600
+cache_dir="${XDG_CACHE_HOME:-$HOME/.cache}/git-stale-check"
+key=${repo_root//\//_}            # pure-bash, no subprocess (chpwd hot path)
+stamp="$cache_dir/${key:-root}"
+now=$(date +%s)
+last=0
+[ -f "$stamp" ] && last=$(cat "$stamp" 2>/dev/null || printf 0)
+case "$last" in *[!0-9]*|'') last=0 ;; esac
+if [ "$(( now - last ))" -ge "$throttle_secs" ]; then
+  if mkdir -p "$cache_dir" 2>/dev/null; then
+    printf '%s' "$now" >"$stamp" 2>/dev/null || true
+  fi
+  # detach: subshell + background so neither prompt nor agent session waits
+  ( git -C "$repo_root" fetch --quiet >/dev/null 2>&1 & ) >/dev/null 2>&1
+fi
+
+# 3) local behind-count (no network) against the last-known upstream ref
+behind=$(git rev-list --count 'HEAD..@{upstream}' 2>/dev/null) || exit 0
+case "$behind" in ''|0) exit 0 ;; esac
+
+printf '⚠️  git-stale-check: %s is %s commit(s) behind %s — run: git pull --rebase\n' \
+  "${repo_root##*/}" "$behind" "$upstream"
+exit 0

--- a/chezmoi/private_dot_claude/modify_settings.json
+++ b/chezmoi/private_dot_claude/modify_settings.json
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# chezmoi modify_ script for ~/.claude/settings.json.
+#
+# chezmoi pipes the CURRENT settings.json on stdin; our stdout becomes the new
+# file. We ensure exactly ONE thing: a SessionStart hook that runs
+# git-stale-check (so an agent sees a behind-warning in its opening context —
+# furrow t-5rgs ③). Everything else (permissions, plugins, env, other hooks) is
+# passed through untouched.
+#
+# Idempotent: if the hook is already present we emit the input unchanged, so the
+# file does not drift and the user's / Claude's own edits are preserved. The
+# command is stored literally as `$HOME/...` and shell-expands when the hook
+# runs, so it stays correct per machine.
+#
+# Fail-safe: with no jq, or on unparseable input, we pass stdin through verbatim
+# rather than risk corrupting a security-relevant file.
+set -u
+
+# shellcheck disable=SC2016  # $HOME must stay literal — Claude expands it at hook run
+cmd='$HOME/.local/bin/git-stale-check'
+
+input=$(cat)
+[ -n "$input" ] || input='{}'
+
+if ! command -v jq >/dev/null 2>&1 || ! printf '%s' "$input" | jq -e . >/dev/null 2>&1; then
+  printf '%s' "$input"
+  exit 0
+fi
+
+printf '%s\n' "$input" | jq --arg cmd "$cmd" '
+  def present: [ (.hooks.SessionStart // [])[]?.hooks[]?.command ] | any(. == $cmd);
+  if present then .
+  else
+      (.hooks //= {})
+    | (.hooks.SessionStart //= [])
+    | (.hooks.SessionStart += [ { hooks: [ { type: "command", command: $cmd } ] } ])
+  end
+'

--- a/home/modules/zsh.nix
+++ b/home/modules/zsh.nix
@@ -4,4 +4,15 @@
   # フェーズ3: バニラ zsh のみ有効化。
   # プラグイン/プロンプト/エイリアスは後続フェーズで段階的に育てる。
   programs.zsh.enable = true;
+
+  # cd するたびに、いる repo が upstream より behind なら 1 行警告（furrow t-5rgs ②）。
+  # 判定は dotfiles 管理の ~/.local/bin/git-stale-check（chezmoi）に委譲。重い処理
+  # （fetch）は script 側で ~600s throttle + background 化済みなので chpwd は軽い。
+  programs.zsh.initContent = ''
+    autoload -Uz add-zsh-hook
+    _git_stale_check_chpwd() {
+      [[ -x "$HOME/.local/bin/git-stale-check" ]] && "$HOME/.local/bin/git-stale-check"
+    }
+    add-zsh-hook chpwd _git_stale_check_chpwd
+  '';
 }


### PR DESCRIPTION
Implements furrow **t-5rgs** ①②③ — defend against acting on a stale checkout.

- **① `~/.local/bin/git-stale-check`** (chezmoi `executable_`): one-line warning when the cwd repo is behind its upstream. Behind check is local/instant; the refreshing `git fetch` is throttled (~600s/repo) and detached. Silent on non-repo / detached HEAD / no upstream; always exits 0.
- **② zsh `chpwd` hook** (`home/modules/zsh.nix`): runs ① on every `cd` (the human path).
- **③ chezmoi `modify_settings.json`** (jq): idempotently ensures a Claude `SessionStart` hook running ① in `~/.claude/settings.json` (the agent path), preserving permissions/plugins/env. Re-applying is a fixed point → no drift; fail-safe passthrough if jq missing/input unparseable.

**Verification done**: shellcheck clean (both scripts); behavioral test of ① (behind→warn, up-to-date/no-upstream/non-repo→silent); `nix flake check` ✓; `darwin-rebuild build` ✓; ③ idempotency + raw-diff (only the hook added) + empty/broken-stdin safety.

**Operator step (part ⑤, not in this PR)**: after merge, `chezmoi apply` + `darwin-rebuild switch`, then confirm a behind repo warns on `cd` (②) and in a new Claude session (③). Footer is reference-only on purpose — t-5rgs stays in-progress until that live check passes.

SetStatus-task: https://github.com/akira-toriyama/projects/blob/main/.furrow/bodies/t-5rgs.md