### PR TITLE
:sparkles: feat(home): manage git identity via home-manager programs.git

### DIFF
--- a/home/modules/default.nix
+++ b/home/modules/default.nix
@@ -2,8 +2,8 @@
 
 {
   # home-manager ユーザー環境の集約点。
-  # 後続フェーズで git.nix / packages.nix を追加していく。
   imports = [
+    ./git.nix
     ./zsh.nix
     ./packages.nix
     ./mise.nix

--- a/home/modules/git.nix
+++ b/home/modules/git.nix
@@ -1,0 +1,44 @@
+{ ... }:
+
+{
+  # git 本体（nixpkgs 版に pin）＋ グローバル設定を home-manager の DSL で宣言。
+  # アーキ規約「DSL のある設定 → programs.*」に従い、手編集の生 ~/.gitconfig
+  # 管理から脱却する。programs.git は ~/.config/git/config を生成し、git 本体も
+  # home profile に載せて Xcode CLT 同梱 git を PATH 上で置き換える（version を
+  # 再現可能に固定する）。
+  #
+  # identity は単一アカウント (akira-toriyama)。旧環境は bird-studio を
+  # `includeIf gitdir:` でディレクトリ別に使い分けていたが、新 PC では使わない
+  # 方針のため取り込まない（負債削減）。既定と同値だった akira-toriyama 用の
+  # include も冗長なので落とし、トップレベルの user.* 一本に集約した。
+  #
+  # NOTE: 旧 ~/.gitconfig には url.insteadOf による per-account SSH host 別名
+  # （`ssh://git@github.com.akira-toriyama/…` 等）があったが、これは
+  # ~/.ssh/config 側の別名定義が前提で、単体では clone を壊す。SSH 鍵まわり
+  # （1Password SSH agent）を扱うタスクとセットで再導入する想定なので、ここには
+  # 入れない。単一アカウントなら既定鍵で素の github.com 経由で通る。
+  programs.git = {
+    enable = true;
+
+    # settings は git config をそのまま写したフリーフォーム attrset。
+    # 新しい home-manager では旧 userName / userEmail / extraConfig が
+    # この settings.* に統合された（旧名は deprecation 警告になる）。
+    settings = {
+      user.name = "akira-toriyama";
+      user.email = "92862731+akira-toriyama@users.noreply.github.com";
+
+      # push 時は同名の upstream branch へ（現行 ~/.gitconfig 踏襲）。
+      push.default = "current";
+      # macOS の case-insensitive FS でも大文字小文字違いを別ファイル扱いに。
+      core.ignorecase = false;
+      # ghq の clone 先。env の GHQ_ROOT が優先するが faithful 再現として残す。
+      ghq.root = "/Volumes/workspace/";
+    };
+
+    # グローバル無視パターン（旧 ~/.config/git/ignore 相当）。
+    ignores = [
+      ".DS_Store"
+      "**/.claude/settings.local.json"
+    ];
+  };
+}


### PR DESCRIPTION
## 概要
手編集だった生 `~/.gitconfig` を home-manager の `programs.git`（新 `settings` スキーマ）で宣言化。`home/modules/git.nix` を新規追加し `home/modules/default.nix` の imports に配線。

## 決定（t-e77z 由来）
- **単一アカウント化**: 旧環境の per-directory 使い分け（bird-studio）の includeIf を削除。冗長だった akira-toriyama の include も削除し、トップレベル `user.*` 一本に集約。
- **git 本体も nix 所有**: Xcode CLT 同梱 git を home profile 上で置き換え、version を再現可能に固定。
- **url.insteadOf は移送**: per-account SSH host 別名（`github.com.akira-toriyama` 等）は `~/.ssh/config` 前提で単体だと clone を壊すため、本 PR には入れず 1Password SSH agent を扱うタスク（t-e77z B-6）とセットで再導入する。

## 検証
- `nix flake check --no-build` ✅（deprecation 警告なし）
- 非破壊 `darwin-rebuild build --flake .#default --impure` ✅

## 適用時の注意（非破壊）
git は読み込み順で旧 `~/.gitconfig` が新 `~/.config/git/config` より後勝ち。switch 後もこのマシンは旧設定のまま動き、管理版を効かせたい時に `rm ~/.gitconfig`（＋孤児の `~/.config/git/user/`・`ignore`）を撤去すればよい。新 Mac には旧 gitconfig が無いので自動で新設定が効く。

SetStatus-task: https://github.com/akira-toriyama/projects/blob/main/.furrow/bodies/t-e77z.md in-progress

🤖 Generated with [Claude Code](https://claude.com/claude-code)