### PR TITLE
chore: Claude docs maintenance 2026-07

### DIFF
--- a/docs/claude-maint-reports/2026-07.md
+++ b/docs/claude-maint-reports/2026-07.md
@@ -1,0 +1,58 @@
+# Claude ドキュメント保守レポート — 2026-07
+
+観測期間: 2026-05-28 〜 2026-06-30
+
+## 概要
+
+今月は archive・修正ともに **変更なし**。参照 URL / パスは全て live であり、
+使用回数 0 の skill も domain-narrow なため keep。
+
+## 使用統計サマリ
+
+明示起動回数のみ（description トリガーの自動ロードは計上されない）。
+
+| 種別 | 名前 | 回数 | 最終起動 |
+|---|---|---:|---|
+| skill | github-practices | 4 | 2026-06-30 |
+| skill | cli-app-dev | 2 | 2026-06-29 |
+| skill | mac-app-dev | 0 | — |
+| skill | software-architecture | 0 | — |
+
+- commands: `chezmoi/private_dot_claude/commands/` は現状存在しない（対象 0 件）。
+
+## 適用した更新
+
+なし。各 doc の参照リンク / ローカルパスを走査したが、以下の通り全て live で
+確実な不具合は検出されなかった。
+
+- `CLAUDE.md` 内 URL
+  - `https://github.com/akira-toriyama/.github/blob/main/CONTRIBUTING.md` → live
+    （`gh api repos/akira-toriyama/.github/contents/CONTRIBUTING.md` OK）
+  - `https://github.com/akira-toriyama/projects/blob/main/CLAUDE.md` → live
+    （`gh api repos/akira-toriyama/projects/contents/CLAUDE.md` OK）
+  - `projects/.furrow/bodies/<id>.md` パターンの上位 dir `.furrow/bodies/` → 存在確認
+- `skills/github-practices/SKILL.md` の 10 本の docs.github.com リンク → 全て
+  redirect 無しで live（WebFetch でタイトル取得成功）。
+- `skills/cli-app-dev/SKILL.md` / `skills/mac-app-dev/SKILL.md` /
+  `skills/software-architecture/SKILL.md` → 外部 URL / repo 内相互参照なし。
+
+## archive
+
+`.claude-maint-archive.list` は **空**（候補 0 件）。
+
+## 要確認（人手）
+
+なし。
+
+## keep 理由
+
+- **CLAUDE.md** — `.maint-ignore` で pin。索引本体、常時ロード。
+- **skills/github-practices** — 起動 4 回、最直近 6/30。active に利用中。
+- **skills/cli-app-dev** — 起動 2 回、最直近 6/29。facet の CLI 面 / cli-migration
+  由来の house 知見で他に正本なし。
+- **skills/mac-app-dev** — 起動 0 だが description トリガー狭 (macOS Swift app 開発)
+  で、`facet` は開発中プロジェクト（memory `project-facet-active-dev.md`）。
+  積極的な陳腐化 / 置換の根拠なし。低回数のみを理由に archive しない方針に従い keep。
+- **skills/software-architecture** — 起動 0 だが上と同様に facet 設計時の auto 発火が
+  期待される domain-narrow skill。mac-app-dev の実装メカニクスと二重管理を避けて
+  設計面を集約する明示的な役割分担があり、archive すると分担が崩れる。keep。


### PR DESCRIPTION
# Claude ドキュメント保守レポート — 2026-07

観測期間: 2026-05-28 〜 2026-06-30

## 概要

今月は archive・修正ともに **変更なし**。参照 URL / パスは全て live であり、
使用回数 0 の skill も domain-narrow なため keep。

## 使用統計サマリ

明示起動回数のみ（description トリガーの自動ロードは計上されない）。

| 種別 | 名前 | 回数 | 最終起動 |
|---|---|---:|---|
| skill | github-practices | 4 | 2026-06-30 |
| skill | cli-app-dev | 2 | 2026-06-29 |
| skill | mac-app-dev | 0 | — |
| skill | software-architecture | 0 | — |

- commands: `chezmoi/private_dot_claude/commands/` は現状存在しない（対象 0 件）。

## 適用した更新

なし。各 doc の参照リンク / ローカルパスを走査したが、以下の通り全て live で
確実な不具合は検出されなかった。

- `CLAUDE.md` 内 URL
  - `https://github.com/akira-toriyama/.github/blob/main/CONTRIBUTING.md` → live
    （`gh api repos/akira-toriyama/.github/contents/CONTRIBUTING.md` OK）
  - `https://github.com/akira-toriyama/projects/blob/main/CLAUDE.md` → live
    （`gh api repos/akira-toriyama/projects/contents/CLAUDE.md` OK）
  - `projects/.furrow/bodies/<id>.md` パターンの上位 dir `.furrow/bodies/` → 存在確認
- `skills/github-practices/SKILL.md` の 10 本の docs.github.com リンク → 全て
  redirect 無しで live（WebFetch でタイトル取得成功）。
- `skills/cli-app-dev/SKILL.md` / `skills/mac-app-dev/SKILL.md` /
  `skills/software-architecture/SKILL.md` → 外部 URL / repo 内相互参照なし。

## archive

`.claude-maint-archive.list` は **空**（候補 0 件）。

## 要確認（人手）

なし。

## keep 理由

- **CLAUDE.md** — `.maint-ignore` で pin。索引本体、常時ロード。
- **skills/github-practices** — 起動 4 回、最直近 6/30。active に利用中。
- **skills/cli-app-dev** — 起動 2 回、最直近 6/29。facet の CLI 面 / cli-migration
  由来の house 知見で他に正本なし。
- **skills/mac-app-dev** — 起動 0 だが description トリガー狭 (macOS Swift app 開発)
  で、`facet` は開発中プロジェクト（memory `project-facet-active-dev.md`）。
  積極的な陳腐化 / 置換の根拠なし。低回数のみを理由に archive しない方針に従い keep。
- **skills/software-architecture** — 起動 0 だが上と同様に facet 設計時の auto 発火が
  期待される domain-narrow skill。mac-app-dev の実装メカニクスと二重管理を避けて
  設計面を集約する明示的な役割分担があり、archive すると分担が崩れる。keep。
