### PR TITLE
:sparkles: feat(furrow): migrate global board config to v2 [[board]] + scopes + auto_filter

### DIFF
--- a/home/modules/furrow.nix
+++ b/home/modules/furrow.nix
@@ -11,14 +11,19 @@
   # 中央 projects ボードへ自動で繋がり、scope ラベルは「最も近い git repo の
   # dir 名」＝ projects のラベルと一致するものを auto 導出する。
   #
-  #   [board].path  … 中央ボード（projects/.furrow）の実体。
-  #   [board].scope … この dir 配下にいる時だけ有効（他 org・無関係 dir では不活性）。
-  #   [board].label … "auto" = cwd から最も近い `.git` を持つ dir の basename
-  #                    （`git` 起動も GHQ_ROOT 参照もしない純粋 walk）。
-  #                    ※ git worktree は **その worktree dir 名**が basename になる
-  #                      （例: `chord` の worktree `chord-fix-y` → label=`chord-fix-y`）。
-  #                      元 repo 名で絞りたい worktree では `-l <repo>` を明示する
-  #                      （実効ラベルは stderr の banner に必ず出る）。
+  # furrow v2 の `[[board]]` 配列形（単一 `[board]` は廃止＝破壊的。~v0.2.1 の旧形）:
+  #   [[board]].path        … 中央ボード（projects/.furrow）の実体。
+  #   [[board]].scopes      … この dir 配下にいる時だけ有効な dir の**配列**（他 org・
+  #                            無関係 dir では不活性。複数書ける・最長一致が勝つ）。
+  #   [[board]].label       … "auto" = cwd から最も近い `.git` を持つ dir の basename
+  #                            （`git` 起動も GHQ_ROOT 参照もしない純粋 walk）。
+  #                            ※ git worktree は **その worktree dir 名**が basename に
+  #                              なる（例: `chord` の worktree `chord-fix-y` →
+  #                              label=`chord-fix-y`）。元 repo 名で絞りたい worktree
+  #                              では `-l <repo>` を明示する。
+  #   [[board]].auto_filter … true=ls/next/revisit を label で自動フィルタ（既定 true・
+  #                            明示）。false=ボード全部を表示しつつ add は label でタグ付け。
+  #                            PR2 で scope banner は廃止＝フィルタは静か（stdout は純データ）。
   #
   # 優先順位（furrow の discovery）: FURROW_DIR > local `.furrow/`
   #   > per-repo `.furrow-pointer.toml` > **この global 既定ボード** > `furrow init`。
@@ -27,9 +32,10 @@
   # 上書きする一時手段（同 slot＝local `.furrow`／pointer よりは下のまま）。
   home.file.".config/furrow/config.toml".text = ''
     # Managed by home-manager (home/modules/furrow.nix). Do not edit by hand.
-    [board]
-    path  = "/Volumes/workspace/github.com/akira-toriyama/projects/.furrow"
-    scope = "/Volumes/workspace/github.com/akira-toriyama"
-    label = "auto"
+    [[board]]
+    path        = "/Volumes/workspace/github.com/akira-toriyama/projects/.furrow"
+    scopes      = ["/Volumes/workspace/github.com/akira-toriyama"]
+    label       = "auto"
+    auto_filter = true
   '';
 }


### PR DESCRIPTION
## Rollout — migrate the global furrow board config to v2 `[[board]]`

The final step of *furrow global config v2* (furrow #36/#37/#38 all merged). furrow v2 retired the single `[board]` table for a `[[board]]` array (breaking), so regenerate `~/.config/furrow/config.toml` in the new form.

**Why now:** a v2 binary reads the old `[board]` as a scope-less entry and clamps it away — so the central `projects` board is currently **inert** under the akira-toriyama tree (`furrow lint` / `furrow config path` would warn). This PR + `home-manager switch` restores it.

### Change
```diff
-[board]
-path  = "…/projects/.furrow"
-scope = "…/akira-toriyama"
-label = "auto"
+[[board]]
+path        = "…/projects/.furrow"
+scopes      = ["…/akira-toriyama"]
+label       = "auto"
+auto_filter = true
```
- `scope` (string) → `scopes` (array); `[board]` → `[[board]]`.
- `auto_filter = true` explicit (v2 default): `ls`/`next`/`revisit` filter by label **silently** — the scope banner was retired in v2. Set `false` to show the whole board while `add` still tags.
- Doc comments in `furrow.nix` updated to the v2 schema.

### Verified
Against the v2 binary (built from furrow `main`): loads the generated config with **no clamp warnings**, and the board **activates** under `…/akira-toriyama` (tasks list). Only a `.nix` string changed, so nix eval / flake build is unaffected.

### To apply (yours — live system)
After merge: `home-manager switch` (builds this config into `~/.config/furrow/config.toml`). Until then the global board stays inert (the accepted rollout window).

SetStatus-task: https://github.com/akira-toriyama/projects/blob/main/.furrow/bodies/t-qs7e.md in-progress

🤖 Generated with [Claude Code](https://claude.com/claude-code)
