### PR TITLE
:wrench: chore(git): auto-prune merged branch residue (fetch.prune + prune-gone alias)

### DIFF
--- a/home/modules/git.nix
+++ b/home/modules/git.nix
@@ -33,6 +33,16 @@
       core.ignorecase = false;
       # ghq の clone 先。env の GHQ_ROOT が優先するが faithful 再現として残す。
       ghq.root = "/Volumes/workspace/";
+
+      # merge 済みで remote が消えたブランチの残骸を local に溜めない。fetch の
+      # たびに削除された remote-tracking ref を自動 prune する（repo は
+      # delete_branch_on_merge=true なので merge で remote branch が消え、次の
+      # fetch でこの prune が効き、対応する local が `[gone]` として検出可能になる）。
+      fetch.prune = true;
+      # upstream が gone（＝merge 後に remote が消えた）の local ブランチを一括削除
+      # する 1 コマンド `git prune-gone`。squash merge は fast-forward でないため
+      # -D で消す。remote 側は上記 delete_branch_on_merge + fetch.prune が面倒を見る。
+      alias.prune-gone = "!git fetch --prune >/dev/null 2>&1; git branch -vv | grep ': gone]' | awk '{print $1}' | while read -r b; do git branch -D \"$b\"; done";
     };
 
     # グローバル無視パターン（旧 ~/.config/git/ignore 相当）。


### PR DESCRIPTION
## What

Adds two git settings to [`home/modules/git.nix`](home/modules/git.nix) so merged-and-deleted branches stop piling up locally (account-wide follow-up to a `.github` cleanup where 11 stale local branches had accumulated):

```nix
fetch.prune = true;
alias.prune-gone = "!git fetch --prune …; git branch -vv | grep ': gone]' | … git branch -D …";
```

- **`fetch.prune = true`** — every `fetch` prunes remote-tracking refs whose remote branch was deleted. Our repos already set `delete_branch_on_merge = true`, so a merge removes the remote branch; after the next fetch the local branch shows as `[gone]`.
- **`alias.prune-gone`** — `git prune-gone` deletes every local branch whose upstream is gone. Squash merges aren't fast-forward, so it uses `branch -D`.

Flow after this lands: merge a PR → remote branch auto-deleted → next `fetch`/`pull` prunes the tracking ref → `git prune-gone` clears the local residue.

## Why here (not chezmoi)

`~/.config/git/config` is a symlink into the Nix store — it's generated by home-manager's `programs.git`, **not** chezmoi (chezmoi manages other dotfiles/scripts in this repo but not the git config). So git config additions belong in this module.

## Verified

- `nix-instantiate --parse home/modules/git.nix` → OK.
- `nix eval` of both new attrs confirms the escaping renders the intended values (`fetch.prune = true`; the alias string is byte-correct).
- The alias's shell logic was smoke-tested as a clean no-op in another repo before landing.

## Apply

Takes effect after a home-manager / `darwin-rebuild switch` (regenerates `~/.config/git/config`). Not auto-applied by merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
