### PR TITLE
:heavy_plus_sign: chore(homebrew): add go toolchain to brews

### DIFF
--- a/system/modules/homebrew.nix
+++ b/system/modules/homebrew.nix
@@ -21,6 +21,7 @@
     # 削除した。残りの brew は WM と無関係なユーティリティのみ。
     taps = [ ];
     brews = [
+      "go"  # Open source programming language to build simple/reliable/efficient software
       "git-cliff"  # Highly customizable changelog generator
       "gifski"  # Highest-quality GIF encoder based on pngquant
       "cliclick"  # Tool for emulating mouse and keyboard events


### PR DESCRIPTION
Adds the Go toolchain to the Homebrew `brews` list.

**Why:** furrow is a Go project developed from a source checkout. The Nix
wrapper builds a pinned furrow binary, but iterating on *uncommitted*
furrow changes uses `go run ./cmd/furrow`, which needs a system Go on PATH.

---（和訳）
Homebrew の `brews` に Go ツールチェーンを追加する。

**理由:** furrow は source checkout で開発する Go プロジェクト。Nix wrapper は
pin された furrow バイナリをビルドするが、未コミットの furrow 変更を試す際は
`go run ./cmd/furrow` を使うため PATH 上に system の Go が必要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
