### PR TITLE
:recycle: chore(mise): manage go via mise, drop homebrew go (reverts #174)

### DIFF
--- a/home/modules/mise.nix
+++ b/home/modules/mise.nix
@@ -14,6 +14,9 @@
       node = "lts";
       python = "3.13";
       deno = "latest";
+      # dev go（furrow の `go run`/`go test` 等）。build go は別管理＝packages.nix の
+      # furrow ラッパが `${pkgs.go}` を内部固定で使う（PATH には出さない）。
+      go = "latest";
     };
   };
 }

--- a/home/modules/mise.nix
+++ b/home/modules/mise.nix
@@ -8,6 +8,12 @@
   # プロジェクトに `.mise.toml` が無い時のグローバルデフォルトとして効く。
   # プロジェクト個別バージョンは `mise use node@20` 等で `.mise.toml` を
   # 自動生成して上書きする (リポジトリ管理対象外)。
+  #
+  # 【方針】言語ランタイム（go / node / python / deno / rust 等）は **mise に一元化**する。
+  # ・per-project の版切替は mise の本領。nix `home.packages` は非ランタイムの CLI 用、
+  #   homebrew は GUI/cask + nixpkgs 未収録の例外 CLI 用（言語ランタイムは置かない）。
+  # ・go の build 用トグルは別物: packages.nix の furrow ラッパが `${pkgs.go}` を内部固定で
+  #   使う（PATH 非公開）。ここ(mise)の go は手元の dev go（`go run`/`go test` 等）。
   programs.mise = {
     enable = true;
     globalConfig.tools = {

--- a/home/modules/packages.nix
+++ b/home/modules/packages.nix
@@ -1,7 +1,8 @@
 { pkgs, ... }:
 
 {
-  # home-manager 管理のユーザーパッケージ（CLI）。
+  # home-manager 管理のユーザーパッケージ（**非ランタイムの CLI**）。
+  # 言語ランタイム（go/node/python/deno 等）は mise に一元化（home/modules/mise.nix の方針）。
   # cask / GUI / カスタム tap は nix-darwin の homebrew モジュール側で管理する。
   home.packages = with pkgs; [
     # === secret / GitHub 基盤（フェーズ2）===

--- a/system/modules/homebrew.nix
+++ b/system/modules/homebrew.nix
@@ -21,7 +21,7 @@
     # 削除した。残りの brew は WM と無関係なユーティリティのみ。
     taps = [ ];
     brews = [
-      "go"  # Open source programming language to build simple/reliable/efficient software
+      # go は mise 管理へ移行（home/modules/mise.nix）。dev runtime は mise に一元化。
       "git-cliff"  # Highly customizable changelog generator
       "gifski"  # Highest-quality GIF encoder based on pngquant
       "cliclick"  # Tool for emulating mouse and keyboard events


### PR DESCRIPTION
Move `go` from Homebrew to **mise**, reverting the homebrew half of #174.

### Why mise (consistency)
Dev runtimes here are all mise-managed via nix `programs.mise.globalConfig`
(`node`/`python`/`deno`) — and `home/modules/packages.nix` deliberately keeps the
furrow **build** go internal (`${pkgs.go}`, off-PATH) "so as not to pollute mise's
dev go". So a **dev go on PATH belongs to mise**, not Homebrew:
- `go` is a dev runtime → mise (joins node/python/deno), the layer that already
  owns them. Config stays nix-declared (`home/modules/mise.nix`), reproducible.
- Homebrew go (#174) was the outlier: a CLI runtime in the GUI/cask layer,
  unpinned, and a *second* independent go alongside the wrapper's `${pkgs.go}`.

Net: `go = "latest"` added to `programs.mise.globalConfig.tools`; `"go"` removed
from `system/modules/homebrew.nix` brews.

### After merge (manual)
1. `sudo darwin-rebuild switch --flake .#default --impure` — regenerate the mise
   global config (adds go) and stop managing go via brew.
2. `mise install` (or `mise install go`) — install the mise-managed go.
3. `brew uninstall go` — remove the Homebrew go. (`homebrew.onActivation.cleanup
   = "none"` means dropping it from `brews` does NOT auto-uninstall it, so both
   would otherwise sit on PATH.)
4. Verify: `which go` → `~/.local/share/mise/shims/go`.

task: https://github.com/akira-toriyama/projects/blob/main/.furrow/bodies/t-bs9n.md in-progress
