### PR TITLE
:sparkles: feat(packages): declare 6 Claude Code helper CLIs in nixpkgs

### DIFF
--- a/home/modules/packages.nix
+++ b/home/modules/packages.nix
@@ -38,6 +38,23 @@
     # 特に rg は非対話 PATH に無く `rg ...` が落ちていたので宣言して常用可能にする。
     ripgrep
     fd
+    # yq-go (バイナリ名 yq): YAML 版 jq。GitHub Actions workflow 等の YAML を
+    # 確実にパース・編集する（Python 版 `yq` ではなく mikefarah の Go 版）。
+    yq-go
+    # actionlint: GitHub Actions workflow の静的チェック。push して CI が落ちる前に
+    # ローカルで定義ミスを検出する。
+    actionlint
+    # xcbeautify: xcodebuild / swift build ログの整形。Swift repo のビルドエラーを
+    # 機械的に拾いやすくする。
+    xcbeautify
+    # shellcheck: シェルスクリプトの lint。system/modules/scripts/*.sh 等を
+    # 書いた際の自己検証に使う。
+    shellcheck
+    # ast-grep (バイナリ名 ast-grep / sg): 構文木ベースのコード検索・書き換え。
+    # テキスト置換 (rg + sed) では危険な一括リファクタを構造的に安全に行う。
+    ast-grep
+    # hyperfine: コマンドベンチマーク。自作 CLI の性能比較を体感でなく数字で出す。
+    hyperfine
 
     # === コンテナ stack（docker CLI + macOS 上の Linux VM 提供 colima）===
     docker


### PR DESCRIPTION
## What

Claude Code が非対話 Bash で常用する補助 CLI 6 種を `home/modules/packages.nix`（「Claude Code を快適にする CLI」節）に宣言。nixpkgs にある CLI は home-manager 管理の鉄則どおりで、別 PC でも `install.sh` 一発で同じセットが再現される。

- **yq-go**（バイナリ名 `yq`）: YAML 版 jq。GitHub Actions workflow 等の YAML を確実にパース・編集（Python 版 `yq` でなく mikefarah の Go 版）
- **actionlint**: GitHub Actions workflow の静的チェック。push して CI が落ちる前にローカル検出
- **xcbeautify**: xcodebuild / swift build ログ整形。Swift repo のビルドエラーを機械的に拾いやすく
- **shellcheck**: シェルスクリプト lint。※ #176 で未宣言 brew 版を削除したばかりだが、Claude Code の自己検証用途で必要と判断し **nix 宣言として復帰**（drift ではなく宣言済みになる）
- **ast-grep**（バイナリ名 `ast-grep` / `sg`）: 構文木ベースのコード検索・書き換え。rg+sed では危険な一括リファクタを構造的に安全に
- **hyperfine**: コマンドベンチマーク。自作 CLI の性能比較を数字で

## Verification

- 全 attr が pinned nixpkgs (`d233902`) に存在することを `nix eval` で確認 ✅
- 非破壊 `darwin-rebuild build --flake .#default --impure` ✅
- 実機で `sudo darwin-rebuild switch` 適用済み → 6 コマンドとも `/etc/profiles/per-user/tommy/bin` から PATH 解決・バージョン表示まで動作確認 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)