### PR TITLE
:sparkles: feat(agent-tools): adopt wait4x + peekaboo with agent recipes

### DIFF
--- a/chezmoi/private_dot_claude/CLAUDE.md
+++ b/chezmoi/private_dot_claude/CLAUDE.md
@@ -20,6 +20,17 @@
   - 中断時: body のチェックを更新し、必要なら「次は X から」を 1 行残す。
 - **code repo の PR 本文に footer を1行**: `SetStatus-task: https://github.com/akira-toriyama/projects/blob/main/.furrow/bodies/<id>.md <lane>`（PR open→in-progress / merge→`<lane>` 適用。lane 省略で参照のみ。非ブロッキング）。
 
+## Repo 現在地ワンショット（セッション途中の把握用）
+
+- branch / ahead-behind / dirty / 直近 commit / worktree / stash を 1 ターンで:
+
+  ```sh
+  git status --porcelain=v2 --branch --show-stash; echo ---; git log --format='%h|%cs|%s' -5; echo ---; git worktree list --porcelain
+  ```
+
+- 読み方: `# branch.ab +A -B`=ahead/behind ／ `# stash <N>` は非ゼロ時のみ（無ければ 0、別途 `git stash list` 不要）／ 行頭 `1/2/u/?/!`=dirty 種別。大 repo は `--untracked-files=no`。
+- 条件待ち（ログ行/port/HTTP/プロセス）は until+sleep を書かず **condition-wait skill**（wait4x）、macOS アプリの GUI 検証は **macos-gui-verify skill**（peekaboo）。
+
 # akira-toriyama 以外のリポジトリに対して
 
 ## Rule

--- a/chezmoi/private_dot_claude/skills/condition-wait/SKILL.md
+++ b/chezmoi/private_dot_claude/skills/condition-wait/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: condition-wait
+description: Use when waiting for a condition — a log line to appear (regex), a TCP port to open, an HTTP endpoint to become healthy, a file to exist, or a process to exit — instead of hand-writing until/sleep polling loops. wait4x recipes with a clean exit-code contract and known footguns.
+---
+
+# 条件待ちは wait4x（until+sleep を手書きしない）
+
+> 出典: エージェント向け CLI 調査（2026-07-03、実機検証済み。詳細 = `~/claude-cli-tools-memo.md` #4 節、task = projects t-v1t1）。wait4x は nix 宣言済み（packages.nix）。
+
+## exit code 契約
+
+`0` = 条件成立 ／ **`124` = timeout**（coreutils 互換・判別確実）／ `1` = その他（usage エラー含む点だけ house 規約と違う）。
+
+## ⚠️ footgun 3 点（全て実機で再現確認済み）
+
+1. **`-t` を必ず明示する** — 既定 timeout はたった **10s**。
+2. **exec の文字列に `$` を入れない** — wait4x が parse 時に**空 env で展開**して消える。`$PID` 等は呼び出しシェル側で展開させる（下のレシピ 5 の形は安全）。
+3. **exec と `-- 後続コマンド` を併用しない** — 引数が二重使用されるバグがある。後続は shell の `&&` で。`--` が使えるのは tcp/http のみ。
+
+## レシピ
+
+```sh
+# 1) ログに regex が現れるまで（+ マッチ行を表示）。rotation-safe（毎 poll でファイルを開き直す）
+wait4x exec 'grep -qE "READY" /path/app.log' -q -t 60s -i 500ms && grep -m1 -E "READY" /path/app.log
+
+# 2) TCP ポート（tcp/http は `-- 後続` OK）
+wait4x tcp 127.0.0.1:5432 -q -t 60s
+
+# 3) HTTP 健全性（--expect-body-regex / --expect-header / --expect-body-json も可）
+wait4x http http://127.0.0.1:8080/health --expect-status-code 200 -q -t 60s
+
+# 4) ファイル存在/非空
+wait4x exec 'test -s /path/artifact' -q -t 30s
+
+# 5) プロセス終了待ち（$PID はこのシェルが展開するので安全）
+wait4x exec "kill -0 $PID" --invert-check -q -t 300s
+
+# 6) AND 結合は && 連結（CLI の 1 呼び出し AND は同型マルチターゲットのみ）
+wait4x tcp 127.0.0.1:8080 -q -t 60s && wait4x exec 'grep -q ready /path/app.log' -q -t 60s
+```
+
+古い定石 `timeout 60 tail -F | grep -m1` は使わない: 素の macOS に `timeout(1)` が無く、match 後も tail が生き続けて pipeline が終わらない（SIGPIPE 不発を実証済み）。
+
+## watch
+
+upstream PR wait4x#506（`wait4x file FILE --expect-content-regex`）が merge されたらレシピ 1 は 1 コマンドに畳める。

--- a/chezmoi/private_dot_claude/skills/macos-gui-verify/SKILL.md
+++ b/chezmoi/private_dot_claude/skills/macos-gui-verify/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: macos-gui-verify
+description: Use when verifying macOS app GUI behavior end-to-end — dump an app's accessibility (AX) tree as JSON, query elements, and click/type/press via the peekaboo CLI. For "did my UI change actually work" checks on Swift/AppKit/SwiftUI apps.
+---
+
+# macOS GUI 検証は peekaboo（AX ツリー JSON + UI 操作）
+
+> 出典: エージェント向け CLI 調査（2026-07-03。詳細 = `~/claude-cli-tools-memo.md` #2 節、task = projects t-c0s2）。peekaboo = openclaw/Peekaboo（MIT）、homebrew.nix で宣言済み（`steipete/tap/peekaboo`）。
+
+## 前提（TCC）
+
+- Accessibility + Screen Recording の許可は **CLI 本体でなくホストアプリ（Terminal / IDE）に付与**する（TCC の responsible-code）。ローカルで再ビルドしたバイナリでも同じホストから動く限り再付与不要。
+- 確認: `peekaboo permissions status --all-sources`。未付与ならユーザーに System Settings での付与を依頼する（GUI 操作なので自分ではできない）。
+- AI-provider 設定（API key）は自動化用途には不要。
+
+## 基本ループ（見る → 選ぶ → 押す）
+
+```sh
+# 1) AX ツリーを JSON で見る（要素に opaque ID が振られ、snapshot が永続化される）
+peekaboo see --app "MyApp" --json          # 大きい tree は --max-depth / --max-elements
+# スクリーンショット不要なら: peekaboo inspect-ui --json
+
+# 2) jq で要素を選ぶ（.data.ui_elements[] の .label / .description / .identifier で絞る）
+
+# 3) 別プロセスからでも ID で操作できる（snapshot 経由で live 再解決）
+peekaboo click --on <ID> [--snapshot <snapshot-id>]
+peekaboo type "text" --app MyApp
+peekaboo press return / peekaboo hotkey cmd,s / peekaboo set-value / peekaboo perform-action / peekaboo menu
+```
+
+- 既定は background 配送（フォーカスを奪わない）。key window が要るときだけ `--foreground`。
+- snapshot が期限切れなら `SNAPSHOT_NOT_FOUND` → `see` を撮り直す。
+
+## 注意
+
+- **exit code は素の 0/1**（house の 0/1/2/3 ではない）。エラー詳細が要るときは必ず `--json` を付けて stderr でなく JSON エラーを読む。
+- 要素指定は ID か属性ベース（label/identifier）で。`button 1 of window 1` 式の位置 index は tree 変化で壊れるので使わない。
+- Peekaboo が重い/変化が速すぎる等の実害が出たら fallback（facet の AX モジュールで薄い Swift CLI を自作）の仕様スケッチが `~/claude-cli-tools-memo.md` #2 節にある。

--- a/home/modules/packages.nix
+++ b/home/modules/packages.nix
@@ -55,6 +55,10 @@
     ast-grep
     # hyperfine: コマンドベンチマーク。自作 CLI の性能比較を体感でなく数字で出す。
     hyperfine
+    # wait4x: 宣言的な条件待ち（tcp/http/exec 等、timeout つき・exit 124=timeout）。
+    # until+sleep の手書きループ撲滅（projects t-v1t1）。使い方の正典は
+    # ~/.claude/skills/condition-wait/SKILL.md（exec の footgun 3 点もそこに記載）。
+    wait4x
 
     # === コンテナ stack（docker CLI + macOS 上の Linux VM 提供 colima）===
     docker

--- a/system/modules/homebrew.nix
+++ b/system/modules/homebrew.nix
@@ -19,12 +19,19 @@
     # WM スタックは新PC でドロップ決定（t-e77z C-5）。borders / omniwm を落とした
     # ため、それ専用のカスタム tap（felixkratz/formulae・barutsrb/tap）も不要になり
     # 削除した。残りの brew は WM と無関係なユーティリティのみ。
-    taps = [ ];
+    taps = [
+      # steipete/tap: peekaboo（openclaw/Peekaboo の公式配布 tap）用
+      "steipete/tap"
+    ];
     brews = [
       # go は mise 管理へ移行（home/modules/mise.nix）。dev runtime は mise に一元化。
       "git-cliff"  # Highly customizable changelog generator
       "gifski"  # Highest-quality GIF encoder based on pngquant
       "cliclick"  # Tool for emulating mouse and keyboard events
+      # peekaboo: macOS AX ツリー JSON dump + UI 操作 CLI（Claude Code の GUI 検証自走用、
+      # projects t-c0s2）。nixpkgs に無く公式配布が tap のため brew 側で宣言。
+      # 使い方の正典は ~/.claude/skills/macos-gui-verify/SKILL.md（TCC 前提もそこに記載）。
+      "steipete/tap/peekaboo"
     ];
 
     casks = [


### PR DESCRIPTION
## What

エージェント向け CLI 調査（正本 = ローカル `~/claude-cli-tools-memo.md`）の adopt 群を dotfiles に宣言。自作なしで調査 5 候補のうち 3 つ（条件待ち / macOS AX / git 現在地）を解決する。

- **packages.nix**: wait4x（nixpkgs 3.6.0）— 宣言的条件待ち。exit 0=成立 / 124=timeout
- **homebrew.nix**: `steipete/tap` + **peekaboo** formula（openclaw/Peekaboo v3.5.2, MIT）— AX ツリー JSON dump + UI 操作。nixpkgs に無く公式配布が tap のため brew 側
- **新 skill `condition-wait`**: 実機検証済み wait4x レシピ 6 種 + exec の footgun 3 点（既定 timeout 10s / parse 時 `$` 展開 / exec+`--` バグ）
- **新 skill `macos-gui-verify`**: peekaboo の see→jq→click 基本ループ + TCC（責任コード=ホストアプリに付与）前提 + exit code 注意
- **global CLAUDE.md**: git 現在地ワンライナー（porcelain v2 + 読み方）+ 両 skill へのポインタ

allowlist（git status/log/worktree list の 3 行）は auto モード分類器が自己権限変更としてブロックするため**意図的に含めていない** — owner が必要なら手動/対話で追加。

## Verification

- 非破壊 `darwin-rebuild build --flake .#default --impure` ✅
- `chezmoi apply` 済み（pre-push の source↔live 乖離ゲート通過 = 検証済み）✅
- wait4x レシピは調査時に go-install 版で全パターン実機検証済み（詳細は調査メモ）
- peekaboo の実インストールと TCC 確認は merge 後の `darwin-rebuild switch`（要 sudo・owner）→ System Settings 付与後に実施

SetStatus-task: https://github.com/akira-toriyama/projects/blob/main/.furrow/bodies/t-v1t1.md
SetStatus-task: https://github.com/akira-toriyama/projects/blob/main/.furrow/bodies/t-c0s2.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)