### PR TITLE
:bug: docs(macos-gui-verify): correct peekaboo JSON schema to match v3.5.2

### DIFF
--- a/chezmoi/private_dot_claude/skills/macos-gui-verify/SKILL.md
+++ b/chezmoi/private_dot_claude/skills/macos-gui-verify/SKILL.md
@@ -20,19 +20,24 @@ description: Use when verifying macOS app GUI behavior end-to-end — dump an ap
 peekaboo see --app "MyApp" --json          # 大きい tree は --max-depth / --max-elements
 # スクリーンショット不要なら: peekaboo inspect-ui --json
 
-# 2) jq で要素を選ぶ（.data.ui_elements[] の .label / .description / .identifier で絞る）
+# 2) jq で要素を選ぶ。要素は .data.ui_elements[]、各要素のキーは
+#    { id, role, label, role_description, bounds, is_actionable }。id は "elem_8" 形式。
+#    操作対象は is_actionable=true で絞るのが速い:
+peekaboo see --app "MyApp" --json | jq -r '.data.ui_elements[] | select(.is_actionable) | "\(.id)\t\(.role)\t\(.label)"'
+#    snapshot は .data.snapshot_id、ウィンドウ名は .data.window_title。
 
-# 3) 別プロセスからでも ID で操作できる（snapshot 経由で live 再解決）
-peekaboo click --on <ID> [--snapshot <snapshot-id>]
+# 3) 別プロセスからでも id で操作できる（snapshot 経由で live 再解決）
+peekaboo click --on elem_8 [--snapshot <snapshot-id|latest>]   # --on は .data.ui_elements[].id の値
 peekaboo type "text" --app MyApp
 peekaboo press return / peekaboo hotkey cmd,s / peekaboo set-value / peekaboo perform-action / peekaboo menu
 ```
 
 - 既定は background 配送（フォーカスを奪わない）。key window が要るときだけ `--foreground`。
 - snapshot が期限切れなら `SNAPSHOT_NOT_FOUND` → `see` を撮り直す。
+- `see` が `WINDOW_NOT_FOUND` を返すのはそのアプリに実ウィンドウが無いとき（Finder のデスクトップのみ等）。エラーでなく状態 — 対象アプリのウィンドウを開いてから撮る。
 
 ## 注意
 
 - **exit code は素の 0/1**（house の 0/1/2/3 ではない）。エラー詳細が要るときは必ず `--json` を付けて stderr でなく JSON エラーを読む。
-- 要素指定は ID か属性ベース（label/identifier）で。`button 1 of window 1` 式の位置 index は tree 変化で壊れるので使わない。
+- 要素指定は `see` が返す `.id`（+ 必要なら `--snapshot`）で。`button 1 of window 1` 式の位置 index は tree 変化で壊れるので使わない。
 - Peekaboo が重い/変化が速すぎる等の実害が出たら fallback（facet の AX モジュールで薄い Swift CLI を自作）の仕様スケッチが `~/claude-cli-tools-memo.md` #2 節にある。


### PR DESCRIPTION
PR #179 で追加した macos-gui-verify skill の jq フィールド名を、実機（peekaboo 3.5.2 インストール後）で確認した実スキーマに合わせる修正。

## 検証（実機）

- `peekaboo see --app Code --json` → `.data.ui_elements[]`（501 要素）。各要素キー = `{ id (例 elem_8), role, label, role_description, bounds, is_actionable }`
- click 対象 = その `.id` を `--on` に渡す。snapshot = `.data.snapshot_id` を `--snapshot` に
- 訂正前は推測の `.description`/`.identifier` で絞る記述だった
- `WINDOW_NOT_FOUND`（実ウィンドウの無いアプリ）状態も明記
- wait4x / peekaboo とも実バイナリで動作確認済み（wait4x 0/124 契約、peekaboo AX tree 取得 + actionable 要素）

docs のみ・機能変更なし。

SetStatus-task: https://github.com/akira-toriyama/projects/blob/main/.furrow/bodies/t-c0s2.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)