### PR TITLE
:sparkles: feat(packages): add pare dev-wrapper (always-fresh-from-source)

### DIFF
--- a/home/modules/packages.nix
+++ b/home/modules/packages.nix
@@ -102,5 +102,22 @@
       fi
       exec "$bin" "$@"
     '')
+
+    # pare: same always-fresh-from-source wrapper as furrow, for pare's manual-
+    # pipe adoption phase (tuning defaults before any auto-apply hook). pare is a
+    # pure stdin→stdout filter, so the (cd src) subshell only scopes the build;
+    # the exec runs in the caller's cwd. Rebuilds only when cmd/internal/go.*
+    # change; atomic mv so a concurrent invocation never execs a half-built bin.
+    (writeShellScriptBin "pare" ''
+      set -eu
+      src=/Volumes/workspace/github.com/akira-toriyama/pare
+      cache="''${XDG_CACHE_HOME:-$HOME/.cache}/pare"
+      bin="$cache/pare"
+      if [ ! -x "$bin" ] || [ -n "$(find "$src/cmd" "$src/internal" "$src/go.mod" "$src/go.sum" -newer "$bin" 2>/dev/null)" ]; then
+        mkdir -p "$cache"
+        ( cd "$src" && GOTOOLCHAIN=local ${pkgs.go}/bin/go build -o "$bin.tmp.$$" ./cmd/pare && mv -f "$bin.tmp.$$" "$bin" ) >&2
+      fi
+      exec "$bin" "$@"
+    '')
   ];
 }


### PR DESCRIPTION
Adds a `pare` shell wrapper alongside the existing `furrow` one, so the just-shipped [pare](https://github.com/akira-toriyama/pare) CLI is on PATH built fresh from its local source clone — the house pattern for a tool still in its manual-pipe adoption / defaults-tuning phase (before any auto-apply hook).

- Identical structure to the `furrow` wrapper: rebuild only when `cmd`/`internal`/`go.*` change, output to `~/.cache/pare`, atomic `mv`, `GOTOOLCHAIN=local`, build with the pinned `${pkgs.go}`.
- pare is a pure stdin→stdout filter, so the `(cd src)` subshell only scopes the build; the `exec` runs in the caller's cwd.

pare also ships as a Homebrew cask (`brew install akira-toriyama/tap/pare`); this wrapper is the from-source dev channel for iterating on defaults.

SetStatus-task: https://github.com/akira-toriyama/projects/blob/main/.furrow/bodies/t-g7qd.md