### PR TITLE
:wrench: chore(githooks): relax pre-push to warn-only for Claude-driven ops

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,21 +1,20 @@
 #!/bin/sh
-# pre-push guard — chezmoi の source ↔ live が乖離していたら push を止める。
-# ただし *この push が chezmoi/ を変更する時だけ* 検査する (over-guard 回避)。
+# pre-push notice — chezmoi の source ↔ live に乖離があれば **警告** する
+# (warn-only)。以前は push を止めていたが、この repo は Claude Code 主導で
+# 運用するため 2026-07-03 に「止めない」へ緩めた。
 #
-# なぜスコープを絞るか: 公開されるのは commit 済み source。守るべきは「chezmoi/ を
-# 含む push を未 apply のまま出す」事故。chezmoi/ に無関係な push (nix/ や docs/ のみ)
-# まで止めると、facet 等の開発中ツールが live を書き換えて生む常時乖離に巻き込まれ、
-# 関係ない作業まで push できなくなる。よって push 範囲が chezmoi/ を触る時だけ verify。
+# なぜ warn-only か:
+#   - source を編集 → chezmoi apply → push という Claude 主導フローでは、人間の
+#     「~/.config 直編集 → re-add → apply 忘れ」型の事故が起きにくい。
+#   - facet 等 開発中ツールが live を書き換えて生む恒常 drift で、無関係な chezmoi/
+#     push まで止まる誤発火 (false positive) の摩擦が実害だった (PR #185 で --no-verify
+#     を強いた実績)。止めずに「apply 忘れかも」の気づきだけ残す方が総合的に良い。
+#   - 恒久ゲートは CI (darwin build/switch smoke + chezmoi apply + templates render) と
+#     main のブランチ保護が担う。ローカル live の追従は各自 chezmoi apply で。
 #
-# 防ぐ事故: 「~/.config を直接編集 → chezmoi re-add → chezmoi apply を忘れて
-# git push」。apply 忘れは「リポは新しいのに自分のマシンは古い」「検証ゲート
-# (chord-validate 等) が未実行のまま push」を招く。
-#
-# 判定: chezmoi verify は live が target state と一致しないと非0を返す
-# (run_onchange の保留 = chezmoi status の "R" でも非0)。--source でこのリポに
-# 固定し、グローバル設定に依存せず fresh clone でも同じ挙動にする。
-#
-# 抜け道: どうしても乖離のまま push したいときは `git push --no-verify`。
+# スコープ: この push が chezmoi/ を変更する時だけ検査する (無関係な nix/docs の
+# push では黙って通す)。判定は chezmoi verify (source ↔ live 不一致、run_onchange
+# 保留 = chezmoi status "R" でも非0)。--source でこのリポに固定し fresh clone でも同挙動。
 # chezmoi 未導入 (CI / bootstrap 途中) では何もせず通す。
 
 set -eu
@@ -40,9 +39,9 @@ if chezmoi --source "$repo_root/chezmoi" verify; then
     exit 0
 fi
 
-echo "✗ pre-push 中止: chezmoi の source ↔ live に乖離があります。" >&2
-echo "  apply 忘れの可能性。次で確認・解消してから push してください:" >&2
-echo "    chezmoi status        # 乖離一覧" >&2
-echo "    chezmoi apply -v      # live に反映 + run_onchange 検証 (R を消す)" >&2
-echo "  どうしても push する場合のみ: git push --no-verify" >&2
-exit 1
+# 乖離検知。warn-only: push は止めない (exit 0)。
+echo "⚠ pre-push notice: chezmoi の source ↔ live に乖離あり (push は継続)。" >&2
+echo "  apply 忘れなら次で追従できます (今回の push はブロックしません):" >&2
+echo "    chezmoi status        # 乖離一覧 (run_onchange 保留 R も)" >&2
+echo "    chezmoi apply -v      # live に反映 + run_onchange 検証" >&2
+exit 0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,7 @@ flowchart TD
   - `chezmoi templates render` — 全 `.tmpl` の `execute-template` 検証
 - **CI green を確認してからマージ**。失敗したら**新規コミットで修正**（push 済みへの `--amend` は使わない）。
 - **`--force` push / 履歴改変は禁止**（ユーザー明示指示がある場合のみ）。
-- **push は pre-push フック（[.githooks/pre-push](.githooks/pre-push)）が `chezmoi verify` で apply 忘れを検知して止める**。乖離（`chezmoi status` の `R` 含む）があれば `chezmoi apply` してから push する。緊急時のみ `git push --no-verify`。詳細 → [docs/operations.md §5.11](docs/operations.md)。
+- **push 時、pre-push フック（[.githooks/pre-push](.githooks/pre-push)）は chezmoi/ を触る push で `chezmoi verify` を実行し、乖離があれば警告するが止めない（warn-only、2026-07-03〜。Claude 主導運用のため）**。気づいたら `chezmoi apply` で live を追従する。恒久ゲートは CI（darwin build/switch smoke + chezmoi apply + templates render）と main のブランチ保護が担う。詳細 → [docs/operations.md §5.11](docs/operations.md)。
 
 ## シークレット取扱（YOU MUST）
 
@@ -97,6 +97,7 @@ flowchart TD
 2. **`switch` は sudo パスワード入力が要るので、コマンドを提示してユーザーに実行させる**（このセッションからは sudo を直接呼ばない）。
 3. **生成パイプラインを再導入しない**。設定は静的ファイルとして表現する。
 4. **破壊的 git 操作を避ける**: `--force` push / 履歴改変 / `--amend`（push 済みコミットへ）はユーザー明示指示なしに禁止。
+5. **この repo は Claude 主導運用（2026-07-03〜）**: 通常の git / gh / chezmoi / PR 操作（branch 作成・commit・push・PR open/merge・`chezmoi diff/apply`）は都度ユーザー確認を取らず実行してよい。例外は上のルールが押さえる: ① `darwin-rebuild switch`（sudo）はルール 2 のとおりコマンド提示してユーザーに実行させる ② 破壊的 git はルール 4 のとおりユーザー明示指示時のみ ③ 検証ゲート（ルール 1）は「聞く」のでなく「自分で通す」。
 
 ## 既知の落とし穴（読まずに「修正」を試みない）
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -39,7 +39,7 @@ git status
 git checkout -b chore/sync-chord-config
 git add chezmoi/dot_config/chord/private_config.toml
 git commit -m ":memo: chore(dotfiles): chord 設定を source に反映"
-git push -u origin chore/sync-chord-config   # pre-push フックが chezmoi verify で apply 忘れを検知（§5.11）
+git push -u origin chore/sync-chord-config   # pre-push フックが chezmoi verify で乖離を警告（warn-only、§5.11）
 gh pr create --title "..." --body "..."
 gh pr merge --auto --squash
 ```
@@ -51,7 +51,7 @@ gh pr merge --auto --squash
 - `chezmoi apply` しても **git の差分は消えない**（apply は source→live の同期で、commit ではない）
 - `git commit` しても **`chezmoi status` の "R" は消えない**（commit は source を履歴に刻むだけ）
 
-両方やって初めてクリーン。**②③で実体を編集したら必ず apply してから push**（apply 忘れは §5.11 の pre-push フックが止める）。
+両方やって初めてクリーン。**②③で実体を編集したら必ず apply してから push**（apply 忘れは §5.11 の pre-push フックが警告する＝warn-only。乖離ゼロの恒久保証は CI）。
 
 </details>
 
@@ -357,9 +357,11 @@ chord --doctor
 
 正規 tap release が出たら `brew upgrade chord && chord --resign` で本来の運用に戻る。
 
-### 5.11 pre-push フック（apply 忘れ防止）
+### 5.11 pre-push フック（apply 忘れ warn-only 通知）
 
-`~/.config` を編集 → `chezmoi re-add` → **`chezmoi apply` を忘れて push** すると、「リポは新しいのに自分のマシンは古い」「run_onchange の検証ゲート（chord-validate 等）が未実行のまま push」といった事故になる。これを防ぐため [`.githooks/pre-push`](../.githooks/pre-push) が push 前に `chezmoi --source ./chezmoi verify` を実行し、source ↔ live に乖離があれば push を止める（`chezmoi status` の "R" 保留でも止まる）。
+`~/.config` を編集 → `chezmoi re-add` → **`chezmoi apply` を忘れて push** すると、「リポは新しいのに自分のマシンは古い」「run_onchange の検証ゲート（chord-validate 等）が未実行のまま push」といった事故になり得る。これに気づけるよう [`.githooks/pre-push`](../.githooks/pre-push) が push 前に `chezmoi --source ./chezmoi verify` を実行し、source ↔ live に乖離があれば**警告する（`chezmoi status` の "R" 保留も検知）**。
+
+**warn-only（2026-07-03〜）**: 以前は乖離で push を止めていたが、この repo は Claude Code 主導で運用するため「止めない（常に通す・警告のみ）」に緩めた。理由 = source 編集→apply→push の Claude 主導フローでは apply 忘れ型事故が起きにくく、facet 等 開発中ツールの恒常 drift で無関係な chezmoi/ push まで止まる誤発火（PR #185 で `--no-verify` を強いた）の摩擦が実害だったため。乖離ゼロの恒久保証は CI（darwin build/switch smoke + `chezmoi apply` + templates render）と main のブランチ保護が担う。ローカル live の追従は警告を見て `chezmoi apply` で。
 
 #### 有効化（`core.hooksPath` の設定）
 
@@ -375,9 +377,9 @@ git config core.hooksPath .githooks
 
 その他:
 
-- **迂回**: どうしても乖離のまま push する場合のみ `git push --no-verify`。
+- **警告のみ**: 乖離があっても push は止まらない（warn-only）。警告文も出したくない時だけ `git push --no-verify` でフック自体を skip。
 - chezmoi 未導入環境（CI / bootstrap 途中）ではフックは何もせず通す（`command -v chezmoi` で skip）。
-- **注意**: chezmoi 全体の乖離を見るので、dotfile 以外（`docs/` や `*.nix` だけ）の push でも保留中の chezmoi 差分があると止まる。その場合は先に `chezmoi apply` するか `--no-verify`。
+- **スコープ**: 検査するのは chezmoi/ を触る push だけ（`docs/` や `*.nix` のみの push は verify せず即通す）。旧仕様の「全乖離で無関係な push まで止まる」問題は解消済み。
 
 </details>
 


### PR DESCRIPTION
Request ④「dotfiles は Claude Code 経由で操作するからガードを外して」への対応。ガードを 3 層に分け、**摩擦源だけ緩め、再現性の砦は残す**。

## 変更
- **`.githooks/pre-push`**: chezmoi source↔live 乖離で **hard-fail していたのを warn-only に**（乖離は警告し常に `exit 0`）。chezmoi/ を触る push だけ検査するスコープ最適化と「apply 忘れ?」の気づきは維持。
- **`CLAUDE.md`**: 「作業時の絶対ルール」に **ルール 5** 追加 = この repo は Claude 主導運用（git/gh/chezmoi/PR を都度確認せず実行してよい）。ただし ① `switch`（sudo）はルール 2 でユーザー実行 ② 破壊的 git はルール 4 で明示指示時のみ ③ 検証ゲートはルール 1 で「自分で通す」。pre-push の記述も warn-only へ。
- **`docs/operations.md §5.11`**: warn-only を明文化＋stale な注記（「非 chezmoi push でも止まる」＝既に解消済み）を修正。

## なぜ全撤去でなく緩和か
`main` の CI 7 チェック必須（`darwin build/switch smoke` + `chezmoi apply` + `templates render`）と branch 保護が**再現性の北極星（新 Mac で install.sh 一発再現）を守る恒久ゲート**。ここは残す。緩めたのは人間向けのローカル摩擦（facet dev drift で無関係な push が止まり `--no-verify` を強いていた、PR #185 実績）だけ。

SetStatus-task: https://github.com/akira-toriyama/projects/blob/main/.furrow/bodies/t-ypr4.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)