### PR TITLE
:sparkles: feat(git): enable Git LFS via home-manager (programs.git.lfs)

### DIFF
--- a/home/modules/git.nix
+++ b/home/modules/git.nix
@@ -20,6 +20,12 @@
   programs.git = {
     enable = true;
 
+    # Git LFS。filter.lfs.*（clean/smudge/process/required）を宣言的に生成し
+    # git-lfs 本体も home profile に載せる。~/.config/git/config は Nix store の
+    # read-only symlink なので `git lfs install --global` が書けない（Permission
+    # denied）。それをこの1行で解消する（imperative install は不要）。
+    lfs.enable = true;
+
     # settings は git config をそのまま写したフリーフォーム attrset。
     # 新しい home-manager では旧 userName / userEmail / extraConfig が
     # この settings.* に統合された（旧名は deprecation 警告になる）。


### PR DESCRIPTION
## What
Enable Git LFS declaratively via home-manager (`programs.git.lfs.enable = true`) in `home/modules/git.nix`.

## Why
`~/.config/git/config` is a read-only symlink into the Nix store, so imperative `git lfs install --global` fails with `could not lock config file: Permission denied` (and `--force` retries the same write). Declaring LFS through home-manager writes `filter.lfs.*` into the managed config and pulls `git-lfs` into the home profile.

## Verified
- `darwin-rebuild build` evaluates and builds.
- Generated config contains `[filter "lfs"]` (clean/smudge/process/required) pointing at the nix `git-lfs`.
- After `switch`: `git config --get-regexp '^filter\.lfs\.'` shows the entries; brew `git-lfs` removed as redundant.

Per-repo pre-push transfer hooks are set up separately when a repo first needs to push LFS content (e.g. the projects board, which uses `core.hooksPath = scripts/hooks`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)