### PR TITLE
:lock: ci: fix template injection + least-privilege permissions + SHA-pin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,11 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
+# Least privilege, made explicit — closes zizmor's excessive-permissions
+# finding ahead of the fleet-wide zizmor gate (akira-toriyama/.github t-qbp1).
+permissions:
+  contents: read
+
 jobs:
   # nix の評価チェック。--no-build で darwin 固有のビルドはせず eval のみ。
   # Linux runner で十分速く取れる構造検証。
@@ -21,7 +26,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install Nix (Determinate)
-        uses: DeterminateSystems/nix-installer-action@main
+        uses: DeterminateSystems/nix-installer-action@a7ad9c4f0c65208097f4d34f3cfa1913b80cce5c # main
 
       - name: nix flake check --no-build
         run: nix flake check --no-build --show-trace
@@ -36,7 +41,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install Nix (Determinate)
-        uses: DeterminateSystems/nix-installer-action@main
+        uses: DeterminateSystems/nix-installer-action@a7ad9c4f0c65208097f4d34f3cfa1913b80cce5c # main
 
       - name: nix-darwin build (default host alias)
         run: nix run nix-darwin/master#darwin-rebuild -- build --flake .#default --show-trace
@@ -51,7 +56,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install Nix (Determinate)
-        uses: DeterminateSystems/nix-installer-action@main
+        uses: DeterminateSystems/nix-installer-action@a7ad9c4f0c65208097f4d34f3cfa1913b80cce5c # main
 
       - name: Make way for nix-homebrew (remove preinstalled Homebrew)
         # GitHub の macos ランナーは /opt/homebrew を preinstall するが、
@@ -113,7 +118,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Run shellcheck on install.sh
-        uses: ludeeus/action-shellcheck@master
+        uses: ludeeus/action-shellcheck@00b27aa7cb85167568cb48a3838b75f4265f2bca # master
         with:
           scandir: '.'
           additional_files: 'install.sh'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,9 +28,14 @@ jobs:
 
       - name: 解決した tag 名
         id: tag
+        # 経由 env で受ける: `${{ github.event.inputs.tag }}` を run: に直接展開すると
+        # 悪意ある tag 入力で shell injection になる（zizmor template-injection）。
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_TAG: ${{ github.event.inputs.tag }}
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "name=${{ github.event.inputs.tag }}" >> "$GITHUB_OUTPUT"
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "name=$INPUT_TAG" >> "$GITHUB_OUTPUT"
           else
             echo "name=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
           fi

--- a/.github/workflows/verify-chord-doc.yml
+++ b/.github/workflows/verify-chord-doc.yml
@@ -21,6 +21,11 @@ on:
       - scripts/gen-chord-doc.py
   workflow_dispatch:
 
+# Least privilege, made explicit — closes zizmor's excessive-permissions
+# finding ahead of the fleet-wide zizmor gate (akira-toriyama/.github t-qbp1).
+permissions:
+  contents: read
+
 jobs:
   verify:
     runs-on: ubuntu-latest

--- a/.github/workflows/verify-chord-validate.yml
+++ b/.github/workflows/verify-chord-validate.yml
@@ -30,6 +30,11 @@ on:
       - .github/workflows/verify-chord-validate.yml
   workflow_dispatch:
 
+# Least privilege, made explicit — closes zizmor's excessive-permissions
+# finding ahead of the fleet-wide zizmor gate (akira-toriyama/.github t-qbp1).
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: macos-15


### PR DESCRIPTION
Pre-emptive hardening ahead of the fleet-wide **zizmor** gate (akira-toriyama/.github t-qbp1).

- **release.yml (template-injection, High)** — `github.event.inputs.tag` was interpolated straight into a `run:` script; a crafted `workflow_dispatch` tag could inject shell. Now passed via `env: INPUT_TAG` and referenced as `$INPUT_TAG`.
- **ci.yml** — explicit top-level `contents: read` (every job is a build/lint/check).
- **verify-chord-doc / verify-chord-validate** — explicit `contents: read`.
- **SHA-pin** `DeterminateSystems/nix-installer-action` + `ludeeus/action-shellcheck`.

Verified: `zizmor .github/workflows` (fleet config) → 0 findings.

SetStatus-task: https://github.com/akira-toriyama/projects/blob/main/.furrow/bodies/t-qbp1.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)