### PR TITLE
:construction_worker: ci: run macOS reproduction jobs post-merge/nightly, not per-PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  schedule:
+    # 毎日 15:00 UTC = 00:00 JST。cold な再現検証を定期実行し upstream drift
+    # (flake.lock 不変でも nix-darwin/master・cask tap・substituter が動いた等) を拾う。
+    - cron: '0 15 * * *'
   workflow_dispatch:
 
 concurrency:
@@ -12,8 +16,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # ── 軽量チェック（Linux・毎 PR/push で必ず走る = PR の実質ゲート）────────────
   # nix の評価チェック。--no-build で darwin 固有のビルドはせず eval のみ。
-  # Linux runner で十分速く取れる構造検証。
   nix-flake-check:
     name: nix flake check (eval only)
     runs-on: ubuntu-latest
@@ -25,85 +29,6 @@ jobs:
 
       - name: nix flake check --no-build
         run: nix flake check --no-build --show-trace
-
-  # macOS 実機相当(arm64)で darwin-rebuild build を回し、Determinate Nix 環境で
-  # flake が活性化可能かを End-to-end に近い形で証明する。
-  # switch はしない(非破壊)。本機の動作は影響を受けない。
-  darwin-build:
-    name: darwin-rebuild build (macOS)
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v7
-
-      - name: Install Nix (Determinate)
-        uses: DeterminateSystems/nix-installer-action@main
-
-      - name: nix-darwin build (default host alias)
-        run: nix run nix-darwin/master#darwin-rebuild -- build --flake .#default --show-trace
-
-  # 実 switch によるスモークテスト。新PCで install.sh を回した時の挙動を
-  # macos-latest runner で再現する(masApps だけ App Store サインイン不要のため空)。
-  # runner は ephemeral なので副作用 OK。
-  darwin-switch-smoke:
-    name: darwin-rebuild switch smoke (macOS)
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v7
-
-      - name: Install Nix (Determinate)
-        uses: DeterminateSystems/nix-installer-action@main
-
-      - name: Make way for nix-homebrew (remove preinstalled Homebrew)
-        # GitHub の macos ランナーは /opt/homebrew を preinstall するが、
-        # イメージ更新 (20260610 → 20260623) で git checkout でなくなり、
-        # nix-homebrew (autoMigrate=true) の移管が
-        # "/opt/homebrew does not looks like a Homebrew checkout" で失敗する。
-        # CI では preinstalled brew を退け、nix-homebrew にクリーンに入れさせる。
-        run: sudo rm -rf /opt/homebrew /usr/local/Homebrew /usr/local/bin/brew
-
-      - name: darwin-rebuild switch (CI variant, masApps 空)
-        run: sudo nix run nix-darwin/master#darwin-rebuild -- switch --flake .#ci --show-trace
-
-      - name: Verify CLI on PATH（home.packages 経由）
-        # GitHub Actions の step shell は login shell ではないので
-        # /etc/zshenv 経由の nix path がロードされない。明示的に追加する。
-        run: |
-          export PATH="/etc/profiles/per-user/runner/bin:/run/current-system/sw/bin:/nix/var/nix/profiles/default/bin:$PATH"
-          for c in docker docker-compose colima op gh chezmoi ghq jq mas; do
-            path=$(which "$c" || true)
-            if [ -n "$path" ]; then
-              echo "  ✓ $c -> $path"
-            else
-              echo "  ✗ $c (not found)"; exit 1
-            fi
-          done
-
-      - name: Verify casks installed
-        # macos-latest には /usr/local/bin/brew (旧 x86) と /opt/homebrew/bin/brew
-        # (arm64・nix-darwin が使う方) の両方があり PATH 先頭の brew が違うのを引くと
-        # 別の Caskroom を見て missing 判定になる。明示的に Apple Silicon 側を使う。
-        run: |
-          /opt/homebrew/bin/brew list --cask | sort > /tmp/installed_casks.txt
-          echo "--- installed casks (Apple Silicon brew) ---"
-          cat /tmp/installed_casks.txt
-          echo "--- 期待リストとの照合 ---"
-          fail=0
-          # ⚠️ この期待リストは system/modules/homebrew.nix の casks と手動同期すること
-          #    （cask を増減したら両方直す。drift すると本ジョブが false fail する）
-          for c in 1password appcleaner azookey google-chrome the-unarchiver visual-studio-code vlc popclip alt-tab font-hack-nerd-font linearmouse via transmission; do
-            if grep -qx "$c" /tmp/installed_casks.txt; then
-              echo "  ✓ $c"
-            else
-              echo "  ✗ $c (missing)"
-              fail=1
-            fi
-          done
-          exit $fail
-
-      - name: chezmoi apply (dot_claude / VSCode 拡張 / 他)
-        run: |
-          export PATH="/etc/profiles/per-user/runner/bin:/run/current-system/sw/bin:/nix/var/nix/profiles/default/bin:$PATH"
-          chezmoi --source ./chezmoi apply --verbose
 
   # シェルスクリプトの静的解析（install.sh のみ。.tmpl は chezmoi 構文が混ざるので除外）
   shellcheck:
@@ -204,3 +129,116 @@ jobs:
             echo "::endgroup::"
           done < <(find . -path ./.git -prune -o -name '*.tmpl' -print | grep -v '^./.git/')
           exit $failed
+
+  # ── フル再現検証（macOS・cold・重い）─────────────────────────────────────────
+  # Opt 1': PR では走らせず(if 参照)、merge 後の main push / nightly / 手動でのみ。
+  # 「install.sh が新 Mac で cold bootstrap を通す」保証の enforce がこの2ジョブ。
+  # ★ キャッシュは意図的に使わない ── warm cache は cold fetchability
+  #   (消えた substituter / fixed-output の hash drift / 死んだ cask tap / 404 flake input)
+  #   の検証を痩せさせる。速度は「頻度を下げる」(per-PR から外す) で稼ぐ。
+  # ★ build(.#default) と switch(.#ci) は別 attr(username/masApps が違う)なので両方要る。
+
+  # macOS 実機相当(arm64)で darwin-rebuild build を回し、flake が活性化可能かを
+  # End-to-end に近い形で証明する。switch はしない(非破壊)。
+  darwin-build:
+    name: darwin-rebuild build (macOS)
+    if: github.event_name != 'pull_request'
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install Nix (Determinate)
+        uses: DeterminateSystems/nix-installer-action@main
+
+      - name: nix-darwin build (default host alias)
+        run: nix run nix-darwin/master#darwin-rebuild -- build --flake .#default --show-trace
+
+  # 実 switch によるスモークテスト。新PCで install.sh を回した時の挙動を
+  # macos-latest runner で再現する(masApps だけ App Store サインイン不要のため空)。
+  # runner は ephemeral なので副作用 OK。
+  darwin-switch-smoke:
+    name: darwin-rebuild switch smoke (macOS)
+    if: github.event_name != 'pull_request'
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install Nix (Determinate)
+        uses: DeterminateSystems/nix-installer-action@main
+
+      - name: Make way for nix-homebrew (remove preinstalled Homebrew)
+        # GitHub の macos ランナーは /opt/homebrew を preinstall するが、
+        # イメージ更新 (20260610 → 20260623) で git checkout でなくなり、
+        # nix-homebrew (autoMigrate=true) の移管が
+        # "/opt/homebrew does not looks like a Homebrew checkout" で失敗する。
+        # CI では preinstalled brew を退け、nix-homebrew にクリーンに入れさせる。
+        run: sudo rm -rf /opt/homebrew /usr/local/Homebrew /usr/local/bin/brew
+
+      - name: darwin-rebuild switch (CI variant, masApps 空)
+        run: sudo nix run nix-darwin/master#darwin-rebuild -- switch --flake .#ci --show-trace
+
+      - name: Verify CLI on PATH（home.packages 経由）
+        # GitHub Actions の step shell は login shell ではないので
+        # /etc/zshenv 経由の nix path がロードされない。明示的に追加する。
+        run: |
+          export PATH="/etc/profiles/per-user/runner/bin:/run/current-system/sw/bin:/nix/var/nix/profiles/default/bin:$PATH"
+          for c in docker docker-compose colima op gh chezmoi ghq jq mas; do
+            path=$(which "$c" || true)
+            if [ -n "$path" ]; then
+              echo "  ✓ $c -> $path"
+            else
+              echo "  ✗ $c (not found)"; exit 1
+            fi
+          done
+
+      - name: Verify casks installed（flake から自動導出 = drift しない）
+        # 期待リストは homebrew.nix を単一ソースに flake config から導出する。
+        # 手書きリストは drift する実績あり (obsidian/monodraw が欠落し under-verify した)。
+        # Apple Silicon 側 brew を明示 (PATH 先頭が旧 x86 brew を引くと別 Caskroom を見て
+        # missing 誤判定になる)。
+        run: |
+          export PATH="/etc/profiles/per-user/runner/bin:/run/current-system/sw/bin:/nix/var/nix/profiles/default/bin:$PATH"
+          nix eval --impure --json ".#darwinConfigurations.ci.config.homebrew.casks" \
+            | jq -r '.[] | if type=="string" then . else .name end' | sort > /tmp/expected_casks.txt
+          echo "--- 期待 casks（flake 由来・単一ソース）---"; cat /tmp/expected_casks.txt
+          /opt/homebrew/bin/brew list --cask | sort > /tmp/installed_casks.txt
+          echo "--- installed casks (Apple Silicon brew) ---"; cat /tmp/installed_casks.txt
+          missing=$(comm -23 /tmp/expected_casks.txt /tmp/installed_casks.txt)
+          if [ -n "$missing" ]; then
+            echo "::error::declared cask(s) not installed:"
+            echo "$missing" | sed 's/^/  - /'
+            exit 1
+          fi
+          echo "✅ 全 declared cask が install 済み"
+
+      - name: chezmoi apply (dot_claude / VSCode 拡張 / 他)
+        run: |
+          export PATH="/etc/profiles/per-user/runner/bin:/run/current-system/sw/bin:/nix/var/nix/profiles/default/bin:$PATH"
+          chezmoi --source ./chezmoi apply --verbose
+
+  # ── ゲート（branch protection の唯一の必須チェック）──────────────────────────
+  # always() で常に走り全ジョブを needs。macOS が PR で skip されても skip は
+  # 「非 failure」なので緑を通し、必須チェックが deadlock しない (GitHub 公式の
+  # skipped-but-required 回避パターン)。実 failure/cancelled のみ落とす。
+  # ★ branch protection の required status checks は「ci-gate」1本だけにすること。
+  #   個別ジョブを required に残すと、PR で skip された macOS が pending 化し得る。
+  ci-gate:
+    name: ci-gate
+    if: always()
+    needs:
+      - nix-flake-check
+      - shellcheck
+      - convention-executable-prefix
+      - convention-command-prefix
+      - chezmoi-templates
+      - darwin-build
+      - darwin-switch-smoke
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fail if any required job failed or was cancelled
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
+        run: |
+          echo "A required upstream job failed:"
+          echo '${{ toJSON(needs) }}'
+          exit 1
+      - run: echo "All required jobs passed or were intentionally skipped."


### PR DESCRIPTION
## 何を
ci.yml の macOS フル再現ジョブ (build 3.3min / switch-smoke 8.5min) を **per-PR から外し**、merge 後の main push・nightly・手動でのみ走らせる。PR は軽量 Linux チェックのみ (~1分)。

## なぜ
docs 1行の #192 でも毎回 8.5min のフルコース (Nix ゼロ install＋cask 全DL) が走っていた。macOS 2ジョブが唯一の重い部分で Linux は <0.5min。

## 設計 (Opt 1)
- macOS 2ジョブに `if: github.event_name != 'pull_request'`。
- **必須チェックを `ci-gate` 1本に付け替え** (always()＋needs 全ジョブ。skip された macOS が deadlock しない GitHub 公式パターン)。※ **この PR を merge 後、branch protection の required を ci-gate 1本へ更新する**。
- nightly cron (00:00 JST) で cold 再現検証 → upstream drift を拾う。
- **caching はしない** (warm cache は cold fetchability の証明を痩せさせる)。
- **cask verify を flake から自動導出** (`nix eval .#darwinConfigurations.ci.config.homebrew.casks`)。手書きリストが drift し obsidian/monodraw を under-verify していたのを恒久修正。

## トレードオフ (承認済)
bad な .nix/chezmoi は PR を緑で通り得る → merge 後 main が一時 red (revert/fix-forward)。「ほぼ再現保証・たまにケア」方針に一致。より強くするなら将来 merge queue (Opt 3)。

SetStatus-task: https://github.com/akira-toriyama/projects/blob/main/.furrow/bodies/t-qpwj.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)