### PR TITLE
:sparkles: feat(nix): add ghq-get-mine to bulk-clone own repos

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -180,6 +180,16 @@ switch ...` で呼ぶ。
 状態を維持する。
 - **Don't call it:** setup, bootstrap script, セットアップ
 
+### `ghq-get-mine`
+**自リポジトリ一括 clone コマンド**。GitHub 上の akira-toriyama の active
+（非 archived）repo を `GHQ_ROOT`（`/Volumes/workspace`）へ ghq レイアウトで
+SSH clone する。冪等（clone 済みは no-op）。install.sh §6.5 と日常の新 repo
+追従で使う。
+- 所在: [`home/modules/packages.nix`](../home/modules/packages.nix)
+  （`writeShellScriptBin`）/ 運用手順は
+  [operations.md §5.12](operations.md)
+- **Don't call it:** clone-all, repo 一括取得スクリプト, ghq sync
+
 ### `aarch64-darwin`
 唯一のサポート arch。flake はこの platform をターゲットする。
 - **Don't call it:** apple silicon, m1/m2, arm mac

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -308,6 +308,9 @@ chezmoi chattr +template <path>                                # .tmpl 化
 # 1Password
 op signin                                                      # まず最初に
 op read "op://Vault/Item/field"
+
+# リポジトリ
+ghq-get-mine                                                   # 自リポジトリ(active)を workspace へ一括 clone（冪等・§5.12）
 ```
 
 ### 5.9 トラブルシュート定番
@@ -380,6 +383,23 @@ git config core.hooksPath .githooks
 - **警告のみ**: 乖離があっても push は止まらない（warn-only）。警告文も出したくない時だけ `git push --no-verify` でフック自体を skip。
 - chezmoi 未導入環境（CI / bootstrap 途中）ではフックは何もせず通す（`command -v chezmoi` で skip）。
 - **スコープ**: 検査するのは chezmoi/ を触る push だけ（`docs/` や `*.nix` のみの push は verify せず即通す）。旧仕様の「全乖離で無関係な push まで止まる」問題は解消済み。
+
+### 5.12 自リポジトリ一括 clone（ghq-get-mine）
+
+GitHub 上の自分の active（非 archived）repo を `/Volumes/workspace` へ
+ghq レイアウトで一括 SSH clone するコマンド。fork・private を含む。
+
+```sh
+ghq-get-mine
+```
+
+- **いつ**: 新 repo を作った後の追従 / 新 Mac では install.sh §6.5 が自動実行
+  （対話モードのみ、CI は skip）
+- **冪等**: clone 済み repo は no-op（`-u` は付けない = working copy 不可侵）
+- **前提**: gh 認証（or `GITHUB_TOKEN`）+ GitHub への SSH 疎通。未整備なら
+  1 行 warn で fail-fast → 整備後に再実行すれば欠けた分だけ補完される
+- 実体: [home/modules/packages.nix](../home/modules/packages.nix) の
+  `writeShellScriptBin`
 
 </details>
 

--- a/home/modules/packages.nix
+++ b/home/modules/packages.nix
@@ -84,6 +84,33 @@
     (writeShellScriptBin "dotfiles-drift-check"
       (builtins.readFile ../../system/modules/scripts/check-dotfiles-drift.sh))
 
+    # ghq-get-mine: GitHub 上の自分の active(非 archived)repo を GHQ_ROOT
+    # (/Volumes/workspace) へ ghq レイアウトで一括 SSH clone。clone 済みは
+    # no-op(冪等・-u なし = 既存 working copy 不可侵)。新 repo 作成後の追従や
+    # 新 Mac ブートストラップ (install.sh §6.5) で実行。fork・private は含み
+    # archived は除外。前提 = gh 認証 (or GITHUB_TOKEN) + GitHub への SSH 疎通。
+    # 未整備なら 1 行 warn で fail-fast(SSH の 1Password 整備は projects t-eep4)。
+    (writeShellScriptBin "ghq-get-mine" ''
+      set -eu
+      if ! ${pkgs.gh}/bin/gh auth status >/dev/null 2>&1; then
+        echo "✘ gh 未認証。gh auth login するか GITHUB_TOKEN を設定して再実行" >&2
+        exit 1
+      fi
+      if ! ssh -o BatchMode=yes -o StrictHostKeyChecking=accept-new -o ConnectTimeout=5 -T git@github.com 2>&1 \
+          | grep -q "successfully authenticated"; then
+        echo "✘ GitHub への SSH 認証が未整備(~/.ssh の鍵 / agent を確認して再実行)" >&2
+        exit 1
+      fi
+      root="$(${pkgs.ghq}/bin/ghq root)"
+      if [ "$root" != "/Volumes/workspace" ]; then
+        echo "✘ ghq root が /Volumes/workspace でない ($root)。darwin-rebuild switch 済みか確認" >&2
+        exit 1
+      fi
+      ${pkgs.gh}/bin/gh repo list akira-toriyama --no-archived --limit 200 \
+        --json nameWithOwner --jq '.[].nameWithOwner' \
+        | ${pkgs.ghq}/bin/ghq get -p -P
+    '')
+
     # furrow: 開発中の source を常に最新ビルドして PATH のどこからでも叩くラッパ。
     # brew/go install のスナップショットは stale 化するので、呼ぶたびに source が
     # 変わっていれば incremental build（~/.cache に出力）して exec する。

--- a/home/modules/packages.nix
+++ b/home/modules/packages.nix
@@ -92,6 +92,10 @@
     # 未整備なら 1 行 warn で fail-fast(SSH の 1Password 整備は projects t-eep4)。
     (writeShellScriptBin "ghq-get-mine" ''
       set -eu
+      # pipefail はグローバルには効かせない: 前段の `ssh -T | grep` は ssh -T が
+      # 正常時でも exit 1(GitHub does not provide shell access)を返し、grep 一致
+      # での成功判定が pipefail だと ssh の非 0 に潰される。終端 fetch のみ変数捕捉で
+      # 守る(下記)。
       if ! ${pkgs.gh}/bin/gh auth status >/dev/null 2>&1; then
         echo "✘ gh 未認証。gh auth login するか GITHUB_TOKEN を設定して再実行" >&2
         exit 1
@@ -106,9 +110,17 @@
         echo "✘ ghq root が /Volumes/workspace でない ($root)。darwin-rebuild switch 済みか確認" >&2
         exit 1
       fi
-      ${pkgs.gh}/bin/gh repo list akira-toriyama --no-archived --limit 200 \
-        --json nameWithOwner --jq '.[].nameWithOwner' \
-        | ${pkgs.ghq}/bin/ghq get -p -P
+      # repo 一覧は一旦変数へ捕捉する。`gh … | ghq get` の直パイプだと終端 ghq の
+      # exit code しか見ず、gh が実行時失敗(5xx / rate limit / token 失効)して空
+      # stdout を吐いても ghq が空入力を no-op で exit 0 → 「1 件も clone せず成功」を
+      # 返し warn も出ない。変数捕捉なら set -e が command-substitution の失敗で中断する。
+      repos="$(${pkgs.gh}/bin/gh repo list akira-toriyama --no-archived --limit 200 \
+        --json nameWithOwner --jq '.[].nameWithOwner')"
+      if [ -z "$repos" ]; then
+        echo "✘ gh repo list が空を返した(GitHub API 不調の疑い)。再実行してください" >&2
+        exit 1
+      fi
+      printf '%s\n' "$repos" | ${pkgs.ghq}/bin/ghq get -p -P
     '')
 
     # furrow: 開発中の source を常に最新ビルドして PATH のどこからでも叩くラッパ。

--- a/install.sh
+++ b/install.sh
@@ -11,6 +11,7 @@
 #   4. (sudo) darwin-rebuild switch  ← brew/cask/mas/CLI/defaults を宣言通り一括適用
 #   5. (任意) 1Password.app をサインインし、op CLI 連携を有効化
 #   6. chezmoi apply  ← dot_claude/settings.json や VSCode 拡張 install など
+#   6.5. (対話モードのみ) ghq-get-mine で自リポジトリを workspace へ一括 clone
 #
 # 環境変数 / 引数:
 #   CI=true もしくは `--non-interactive`  ... 対話プロンプトを抑止し、CI で完走させる
@@ -185,6 +186,17 @@ fi
 echo "==> chezmoi apply（dot_claude / run_onchange 各種）"
 PATH="/etc/profiles/per-user/$USER/bin:/run/current-system/sw/bin:$PATH" \
   chezmoi --source "$REPO_DIR/chezmoi" apply --verbose
+
+# 6.5 自リポジトリを workspace へ一括 clone（ghq レイアウト）。
+# ghq-get-mine は §4 の switch で /etc/profiles/per-user/$USER/bin に入る。
+# gh / SSH 認証が未整備でも install.sh 全体は止めない（fail-fast + 後で
+# ghq-get-mine を再実行すれば冪等に補完される）。CI は clone する意味がなく
+# SSH 認証も無いので skip。
+if [ "$NON_INTERACTIVE" != "1" ]; then
+  echo "==> 自リポジトリを一括 clone (ghq-get-mine)"
+  PATH="/etc/profiles/per-user/$USER/bin:/run/current-system/sw/bin:$PATH" \
+    ghq-get-mine || echo "⚠ ghq-get-mine 失敗。gh auth login / SSH 鍵整備後に再実行してください" >&2
+fi
 
 echo
 echo "✓ 完了。新しいターミナルを開いて環境が揃っていることを確認してください。"


### PR DESCRIPTION
## Summary
- add `ghq-get-mine` (home-manager writeShellScriptBin): bulk-clone all active (non-archived) own repos into /Volumes/workspace via `gh repo list … | ghq get -p -P`, with fail-fast prechecks (gh auth / SSH to GitHub / ghq root)
- hook it into install.sh §6.5 (interactive mode only; best-effort, CI skips)
- document in operations.md §5.12 + §5.8 quick reference + glossary.md

## Test plan
- [x] nix flake check --no-build / darwin-rebuild build (non-destructive)
- [x] shellcheck install.sh + sh -n
- [x] script logic smoke-tested on this machine: 6 missing active repos cloned with SSH remotes, re-run is a full no-op (idempotent)
- [x] the nix-built store script itself re-run → exit 0, all repos "exists"
- [ ] post-switch: `ghq-get-mine` resolves on PATH

---（和訳）
自分の active repo を workspace へ一括 clone する ghq-get-mine を追加し、install.sh §6.5 にフック。docs（operations §5.12 / §5.8 / glossary）追記。実機で smoke 済み（未 clone 6 repo が SSH remote で入り、再実行は全件 no-op）。

SetStatus-task: https://github.com/akira-toriyama/projects/blob/main/.furrow/bodies/t-2hcy.md done