### PR TITLE
:memo: docs(claude): sharpen per-session work-granularity rule

### DIFF
--- a/chezmoi/private_dot_claude/CLAUDE.md
+++ b/chezmoi/private_dot_claude/CLAUDE.md
@@ -14,10 +14,10 @@
 - **着手前に `projects` を最新化**: `furrow sync`（`.furrow/` 限定 auto-commit→pull --rebase→push）を読む前・書いた後に回す（古い body で判断する事故を防ぐ。conflict は exit 3 `sync-conflict`）。
 - **タスクの帰属は一級の `repos` フィールド**（`owner/repo`、0..N、`[]`=draft。repos-pivot／furrow v0.6.0・flag-day t-3bmm 以降）。**ラベルは純粋タグ**（repo をラベルに書かない）。`…/github.com/akira-toriyama/` 配下の code repo の中では global 既定ボードが **`repo="auto"`** で自動作用（`~/.config/furrow/config.toml`＝home-manager 生成。`projects/CLAUDE.md` の board 節）：`add` は cwd の git origin から導出した owner/repo を `repos` へ union（`--draft` で抑止・明示 `-r` は追加）、`ls/next/revisit` はその repo で silent に自動フィルタ（per-board `auto_filter`・既定 true、`-r ''` で全件・明示 `-r` は上書き）。導出は **worktree-aware**（gitdir→commondir 追跡。旧 label=auto の「worktree dir 名ズレ」問題は解消済み — `-l` 明示の worktree 運用は不要）。tracker 自身の作業は `-r projects`（projects checkout 内なら auto）。自前 `.furrow`／per-repo `.furrow-pointer.toml` を持つ repo はそちらが優先（近い方が勝つ）。旧習慣の `-l <repo>` は did-you-mean ガードが exit 2＋`candidates` で受け止める。
 - **進捗の正本はそのタスク body 一本**。「どこまで終わったか／次に何をするか」は `projects/.furrow/bodies/<id>.md` のチェックリストに記録し、**memory やブランチ上のファイルに複製しない**（2重管理＝剥離を避ける）。
-- **1 セッションで完結しなくてよい**。1 回に詰め込んで急ぐより、論理単位で区切って body に進捗を残し次セッションへ継ぐ方を優先する（品質 > 一気の完了。中断は失敗でなく既定運用）。継続に要る情報は body に集約する（↑の正本一本に同じ）。
+- **1 セッションの作業粒度は「Claude が無理なく・品質を保って完了できる単位」に区切る**（効率よく＝詰め込む、ではない。品質 > 一気の完了）。1 単位が収まらないなら分割し、やり残しは少なめに。残るものは暗黙に流さず task 化する（中断は失敗でなく既定運用 —— task 化してあれば止めてよい）。継続に要る情報は body に集約する（↑の正本一本に同じ）。
 - セッションの作法:
   - 開始時: `furrow next -r <repo>`（or `furrow show <id>`）で現在地を把握してから着手。
-  - 中断時: body のチェックを更新し、必要なら「次は X から」を 1 行残す。
+  - 中断時: body のチェックを更新し、次セッションにやってほしいこと（希望）を 1 行明言する。
 - **code repo の PR 本文に footer を1行**: `SetStatus-task: https://github.com/akira-toriyama/projects/blob/main/.furrow/bodies/<id>.md <lane>`（PR open→in-progress / merge→`<lane>` 適用。lane 省略で参照のみ。非ブロッキング）。
 - **遠慮なく task 化する（取りこぼさない・暗黙にしない）**: 不満・仕様の曖昧・やる/やらない判断・気づいた罠やツール案は、記憶や口頭でなく task に上げる（曖昧は「仕様確認」自体を task 化して詰まりを先に解く）。body 一項目で足りるものは body へ。詳細規約は [`projects/CLAUDE.md`](https://github.com/akira-toriyama/projects/blob/main/CLAUDE.md) の「何を task にするか」節。
 


### PR DESCRIPTION
## What

Rewrite the per-session work-granularity bullet in the global `~/.claude/CLAUDE.md` (chezmoi source: `chezmoi/private_dot_claude/CLAUDE.md`) so Claude parses the intended unit unambiguously.

## Why

The old wording ("1 セッションで完結しなくてよい … 論理単位で区切って") left "efficient unit" open to the mis-read where *efficient* pulls toward cramming more into a session — the opposite of the quality-first intent.

## Changes

- **Define the unit** as "Claude が無理なく・品質を保って完了できる単位" and pin **効率 ≠ 詰め込み** so the guardrail against over-stuffing is explicit.
- **Explicit hand-off**: fold "state what the next session should do (希望)" into the 中断時 ritual, replacing the softer "次は X から".
- **Loose ends → task**: minimize leftovers and task-ify the rest; keep "中断は失敗でなく既定運用" so this doesn't tip into no-loose-ends cram pressure.

## Validation

- `chezmoi apply` done; `chezmoi diff ~/.claude/CLAUDE.md` is empty (source == live, no drift).
- Doc-only change to a chezmoi-managed dotfile; no Nix/template surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)