### PR TITLE
:bug: fix(chord): update facet invocation to space-separated flags and loading 5000

### DIFF
--- a/chezmoi/dot_config/chord/private_config.toml
+++ b/chezmoi/dot_config/chord/private_config.toml
@@ -314,7 +314,7 @@ action-keys = "return"
 [[bindings]]
 name = "space-right + facet tree"
 input = "ctrl + fn - right"
-action-shell = "facet --view=tree --loading=2000"
+action-shell = "facet --view tree --loading 5000"
 action-keys = "ctrl + fn - right"
 
 # doc: スペース左へ移動しつつ facet tree 表示（ctrl+←）
@@ -322,7 +322,7 @@ action-keys = "ctrl + fn - right"
 [[bindings]]
 name = "space-left + facet tree"
 input = "ctrl + fn - left"
-action-shell = "facet --view=tree --loading=2000"
+action-shell = "facet --view tree --loading 5000"
 action-keys = "ctrl + fn - left"
 
 


### PR DESCRIPTION
Update the two `facet` bindings in `chezmoi/dot_config/chord/private_config.toml` from the stale `--view=tree --loading=2000` form to the current facet CLI syntax `--view tree --loading 5000` (space-separated flags, loading 5000ms).

- Applied to live `~/.config/chord/config.toml` via targeted `chezmoi apply` (facet config drift left untouched as expected dev noise).
- chord hot-reloads its config (Controller.swift config watcher), so no restart needed.

---（和訳）

`private_config.toml` の facet 呼び出し 2 箇所を旧形式 `--view=tree --loading=2000` から現行 facet CLI 文法 `--view tree --loading 5000` に更新。live へは chord config のみ選択 apply 済み（facet 側乖離は想定内ノイズのため据え置き）。chord は config watcher で hot-reload するため再起動不要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)