### PR TITLE
:fire: chore(chord): remove IST trackball vkey aliases and placeholder bindings

### DIFF
--- a/chezmoi/dot_config/chord/private_config.toml
+++ b/chezmoi/dot_config/chord/private_config.toml
@@ -167,12 +167,6 @@ TU_RR_M = 0x8A
 TU_RR_X2 = 0x8B
 TU_RR_X3 = 0x8C
 TU_RR_X4 = 0x8D
-# ist (ble_hid_host_receiver) トラックボールボタン (band 0xA0..0xBF) — canon/vkey-aliases.toml と一致
-IST_BTN5 = 0xA0
-IST_BTN6 = 0xA1
-IST_TILT_L = 0xA2
-IST_TILT_R = 0xA3
-
 
 # =====================================================================
 # Bindings — 各 binding 直前の `# doc: <動作>` は docs/chord.md の
@@ -363,25 +357,3 @@ name = "ULTRA_LL + l → Backspace (in j-layer)"
 input = "TU_LL_L"
 when-var = "jlayer"
 action-keys = "backspace"
-
-
-# ist (ble_hid_host_receiver) トラックボールボタン → a/b/c/d
-[[bindings]]
-name = "ist btn5 → a"
-input = "IST_BTN5"
-action-keys = "a"
-
-[[bindings]]
-name = "ist btn6 → b"
-input = "IST_BTN6"
-action-keys = "b"
-
-[[bindings]]
-name = "ist tilt-left → c"
-input = "IST_TILT_L"
-action-keys = "c"
-
-[[bindings]]
-name = "ist tilt-right → d"
-input = "IST_TILT_R"
-action-keys = "d"


### PR DESCRIPTION
Remove the IST trackball block from `chezmoi/dot_config/chord/private_config.toml`:

- `[v-key-aliases]` IST entries (`IST_BTN5/BTN6/TILT_L/TILT_R`, 0xA0..0xA3)
- the placeholder bindings mapping them to `a`/`b`/`c`/`d` (they referenced the deleted aliases and would fail strict validation if left dangling)

The vkey id assignment will be owned by canon: once the receiver keymap (`zip_btn_remap`) is extended and `config/vkey-aliases.toml` regenerated there, the block gets re-pasted here together with real bindings. Live `~/.config/chord/config.toml` is already synced via targeted `chezmoi apply`.

---（和訳）

IST トラックボール関連を削除。alias（0xA0..0xA3）と、それを参照していた仮 binding（a/b/c/d）を両方落とした（alias だけ消すと未定義参照で strict 検証が落ちるため）。採番は canon 側で確定させ、受信側 keymap 拡張 + vkey-aliases.toml 再生成後にここへ貼り直す。live へは選択 apply 済み。

SetStatus-task: https://github.com/akira-toriyama/projects/blob/main/.furrow/bodies/t-rgky.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)