### PR TITLE
:memo: docs(claude): guide agents to `pare --profile test` for test runs

### DIFF
--- a/chezmoi/private_dot_claude/CLAUDE.md
+++ b/chezmoi/private_dot_claude/CLAUDE.md
@@ -41,6 +41,9 @@ source-build wrapper＝呼ぶたび変更検知で rebuild）。**作って終�
 - **pare** — 長くなりがちな Bash 出力の切り詰め。blind `| tail` はエラー中盤を落とすので、
   代わりに `<cmd> 2>&1 | pare`（head+error-match+tail を予算内に。full は `--tee FILE`）。
   `set -o pipefail` 併用。既定 8KB・`--head/--tail/--match/--context` で調整。
+  **test 実行は `<runner> 2>&1 | pare --profile test`**（失敗 assertion ブロックを丸ごと保持・
+  成功は畳む。汎用 pare は多行 assertion の expected/actual を落とすが profile は残す。
+  go test / swift test / vitest / jest / pytest）。
 - **cifail** — CI 失敗の要点抽出。生 run ログを漁らず `cifail`（cwd の remote/現 branch から推定。
   `--pr N` / `--branch B` / `--run ID` / `--json`）。job ゼロの失敗 run（workflow 文法エラー等）も拾う。
 - **furrow** — タスク管理（↑ Workflow 節が正典）。

--- a/chezmoi/private_dot_claude/skills/go-dev/SKILL.md
+++ b/chezmoi/private_dot_claude/skills/go-dev/SKILL.md
@@ -57,6 +57,7 @@ description: Use when writing or modifying a Go CLI/tool (furrow・cifail・pare
 - **golden test は `testdata/*.golden.json` に byte 一致**、`var update = flag.Bool("update",…)` で再生成（`go test ./pkg -update`）。golden と対で determinism test（marshal→parse→re-marshal が byte 一致）＋fixture を意図的に unsorted / CJK / nil-vs-populated で adversarial に。
 - **pure core は `FuzzXxx`** で invariant（never panic・budget 厳守・出力は入力の verbatim subset・count 非負）を検証、`f.Add` で代表 corpus を seed、fuzzed int は production reachable 範囲に clamp。CI で bounded `-fuzztime`（15–30s）を Ubuntu-only で。
 - 常に **`-race`**（coverage gate 時は `-covermode=atomic`＋`go tool cover -func | tail -1` を summary に。数値 threshold gate は張らず informational）。
+- **test 出力を読む時は `<runner> 2>&1 | pare --profile test`**（`go test`/`swift test` の失敗 assertion ブロックを予算内に丸ごと保持・成功は畳む＝再実行を減らす。正典は CLAUDE.md「自作 CLI」節の pare bullet — ここは point-of-use の pointer）。
 - **mock より real dependency**: git は `os/exec` で本物＋`gitOrSkip`（不在は `t.Skip`）＋pinned committer identity。GitHub API は `httptest.Server` を client struct の base/http field に注入。bubbletea は teatest で headless に本物を driving し frame＋store 副作用の両方を assert。exit-code は string でなく typed sentinel＋`errors.As`（`assertExitCode`）で見る。
 
 ## build / release / distribution ※ 運用面は github-practices


### PR DESCRIPTION
Propagate the shipped `pare --profile test` (ea5670c, PR #8) into house guidance so agents reach for it on test runs.

- CLAUDE.md「自作 CLI」pare bullet: one line for `<runner> 2>&1 | pare --profile test` (keeps whole failing-assertion blocks, collapses success; go test / swift test / vitest / jest / pytest).
- go-dev skill testing section: a point-of-use pointer (CLAUDE.md stays canonical — no duplication).
- Propagated to the live `~/.claude` copies via scoped `chezmoi apply`.

The optional auto-detect hook is deferred: cross-runner test-command detection is fragile, so lead with guidance + agent habit first (the same "manual → hook once stable" path pare/cifail themselves shipped on).

SetStatus-task: https://github.com/akira-toriyama/projects/blob/main/.furrow/bodies/t-qxy8.md done

🤖 Generated with [Claude Code](https://claude.com/claude-code)
