### PR TITLE
:sparkles: feat(packages): add revpost source-build wrapper (mirrors cifail)

### DIFF
--- a/home/modules/packages.nix
+++ b/home/modules/packages.nix
@@ -181,5 +181,22 @@
       fi
       exec "$bin" "$@"
     '')
+
+    # revpost: furrow と同型の source-build ラッパ。findings JSON（native / reviewdog
+    # rdjson・rdjsonl）を pipe して anchor 検証済みの inline PR review を一括投稿する
+    # CLI（422 根絶）。target は明示引数 `owner/repo#N` で cwd 非依存・auth は gh を
+    # 再利用 — (cd src) は build 用 subshell に閉じる（他 wrapper と同じ atomic mv）。
+    (writeShellScriptBin "revpost" ''
+      set -eu
+      src=/Volumes/workspace/github.com/akira-toriyama/revpost
+      cache="''${XDG_CACHE_HOME:-$HOME/.cache}/revpost"
+      bin="$cache/revpost"
+      if [ ! -x "$bin" ] || [ -n "$(find "$src/cmd" "$src/internal" "$src/go.mod" "$src/go.sum" -newer "$bin" 2>/dev/null)" ]; then
+        mkdir -p "$cache"
+        if command -v go >/dev/null 2>&1; then gobuild=go; else gobuild=${pkgs.go}/bin/go; fi
+        ( cd "$src" && env -u GOROOT GOTOOLCHAIN=local "$gobuild" build -o "$bin.tmp.$$" ./cmd/revpost && mv -f "$bin.tmp.$$" "$bin" ) >&2
+      fi
+      exec "$bin" "$@"
+    '')
   ];
 }


### PR DESCRIPTION
## What

Add a `revpost` source-build wrapper to `home/modules/packages.nix`, same shape as the furrow/pare/cifail wrappers: rebuild incrementally from the clone at `/Volumes/workspace/github.com/akira-toriyama/revpost` on every call (mise `go` with `env -u GOROOT`, output to XDG cache, atomic `mv`), then `exec`.

## Why

revpost (pipe findings JSON → one anchor-verified inline PR review; also accepts reviewdog rdjson/rdjsonl) is a Claude-Code-invoked CLI in the same category as furrow/pare/cifail, but grep found no `revpost` in any .nix — sessions had to `go run` or hand-build it. Source-first policy: no brew/tag needed once the wrapper exists (the repo has zero tags and no release workflow, which stays fine).

## Notes

- Target is an explicit `owner/repo#N` argument and auth reuses `gh`, so the wrapper is caller-cwd independent; the `(cd src)` subshell only scopes the build.
- Verified: `nix-instantiate --parse` passes; the wrapper body (simulated standalone) builds and `revpost --version` returns `revpost version dev (1bc8cfe, …)`.

SetStatus-task: https://github.com/akira-toriyama/projects/blob/main/.furrow/bodies/t-5d81.md done

🤖 Generated with [Claude Code](https://claude.com/claude-code)