### PR TITLE
:sparkles: feat(mise): add rust to the global runtime set

### DIFF
--- a/home/modules/mise.nix
+++ b/home/modules/mise.nix
@@ -23,6 +23,9 @@
       # dev go（furrow の `go run`/`go test` 等）。build go は別管理＝packages.nix の
       # furrow ラッパが `${pkgs.go}` を内部固定で使う（PATH には出さない）。
       go = "latest";
+      # rundiff の adapter fixture（cargo test キャプチャ）等で使う。↑方針の
+      # とおり言語ランタイムは mise（cargo/rustc とも mise 管理）。
+      rust = "latest";
     };
   };
 }


### PR DESCRIPTION
`mise use -g rust@latest` dead-ends on this machine: `~/.config/mise/config.toml` is a read-only home-manager-generated file, so mise cannot write it (Permission denied). The mise.nix policy comment already names rust as a mise-managed runtime — only the declaration was missing.

## What

- `home/modules/mise.nix`: add `rust = "latest"` to `programs.mise.globalConfig.tools`.

## Verification

- `nix flake check --no-build` green.
- `nix run nix-darwin#darwin-rebuild -- build --flake .#default --impure` green; the generated `.config/mise/config.toml` in the build output carries `rust = "latest"`.
- rust 1.97.0 is already in mise's store (installed while capturing rundiff's real cargo fixtures), so activation is config-only.

## After merge

Owner runs the switch (rule ②):

```sh
sudo /run/current-system/sw/bin/darwin-rebuild switch --flake .#default --impure
```

Then `cargo --version` resolves via mise with no `mise x` prefix.

Note: the working tree also has an uncommitted `homebrew.nix` edit (claude-code cask) — untouched here, left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)