### PR TITLE
:sparkles: feat(brew): add claude-code cask

### DIFF
--- a/system/modules/homebrew.nix
+++ b/system/modules/homebrew.nix
@@ -35,6 +35,7 @@
     ];
 
     casks = [
+      "claude-code"  # Terminal-based AI coding assistant
       "obsidian"  # Knowledge base that works on top of a local folder of plain text Markdown files
       # 1Password 8 デスクトップ。SSH エージェント / op CLI 連携の前提
       "1password"


### PR DESCRIPTION
Declares the `claude-code` cask in `system/modules/homebrew.nix` (change was already staged locally by the user; this PR lands it through the normal gate).

- `nix flake check --no-build` ✅
- non-destructive `darwin-rebuild build` ✅ (exit 0)

Actual install happens at the next `darwin-rebuild switch` (user-run, sudo).

SetStatus-task: https://github.com/akira-toriyama/projects/blob/main/.furrow/bodies/t-h8gg.md done

🤖 Generated with [Claude Code](https://claude.com/claude-code)