### PR TITLE
:construction_worker:(ci) harden checkouts and release env for the zizmor low gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          # CI-only, never pushes — drop the persisted checkout token. t-yaxa
+          persist-credentials: false
 
       - name: Install Nix (Determinate)
         uses: DeterminateSystems/nix-installer-action@a7ad9c4f0c65208097f4d34f3cfa1913b80cce5c # main
@@ -41,6 +44,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          # CI-only, never pushes — drop the persisted checkout token. t-yaxa
+          persist-credentials: false
 
       - name: Run shellcheck on install.sh
         uses: ludeeus/action-shellcheck@00b27aa7cb85167568cb48a3838b75f4265f2bca # master
@@ -56,6 +62,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          # CI-only, never pushes — drop the persisted checkout token. t-yaxa
+          persist-credentials: false
       - name: Check shebang scripts under chezmoi/ have executable_ prefix
         run: |
           set -e
@@ -86,6 +95,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          # CI-only, never pushes — drop the persisted checkout token. t-yaxa
+          persist-credentials: false
       - name: Check self-made commands have my- prefix
         run: |
           set -e
@@ -113,6 +125,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          # CI-only, never pushes — drop the persisted checkout token. t-yaxa
+          persist-credentials: false
 
       - name: Install chezmoi
         run: |
@@ -151,6 +166,9 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          # CI-only, never pushes — drop the persisted checkout token. t-yaxa
+          persist-credentials: false
 
       - name: Install Nix (Determinate)
         uses: DeterminateSystems/nix-installer-action@a7ad9c4f0c65208097f4d34f3cfa1913b80cce5c # main
@@ -167,6 +185,9 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          # CI-only, never pushes — drop the persisted checkout token. t-yaxa
+          persist-credentials: false
 
       - name: Install Nix (Determinate)
         uses: DeterminateSystems/nix-installer-action@a7ad9c4f0c65208097f4d34f3cfa1913b80cce5c # main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,9 @@ jobs:
         with:
           # tag annotation の本文を読むため全履歴を取得
           fetch-depth: 0
+          # git only READS the tag annotation; the release is created via the
+          # gh API token, never git push — drop the checkout token. t-yaxa
+          persist-credentials: false
 
       - name: 解決した tag 名
         id: tag
@@ -41,8 +44,12 @@ jobs:
           fi
 
       - name: tag annotation を notes に展開
+        # steps.tag.outputs.name も run: へ直接展開せず env 経由で渡す
+        # (zizmor template-injection、上の INPUT_TAG と同方針)。t-yaxa
+        env:
+          TAG: ${{ steps.tag.outputs.name }}
         run: |
-          tag="${{ steps.tag.outputs.name }}"
+          tag="$TAG"
           # annotated tag なら本文を取得、lightweight tag なら commit message を fallback
           notes=$(git tag -l "$tag" --format='%(contents)')
           if [ -z "$notes" ]; then
@@ -55,8 +62,10 @@ jobs:
       - name: 既存 Release があれば skip、無ければ作成
         env:
           GH_TOKEN: ${{ github.token }}
+          # env 経由で受ける (zizmor template-injection、上と同方針)。t-yaxa
+          TAG: ${{ steps.tag.outputs.name }}
         run: |
-          tag="${{ steps.tag.outputs.name }}"
+          tag="$TAG"
           if gh release view "$tag" >/dev/null 2>&1; then
             echo "::notice::Release $tag は既に存在するため skip"
             exit 0

--- a/.github/workflows/verify-chord-doc.yml
+++ b/.github/workflows/verify-chord-doc.yml
@@ -31,6 +31,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          # Verify-only, never pushes — drop the persisted checkout token. t-yaxa
+          persist-credentials: false
       - uses: actions/setup-python@v6
         with:
           python-version: "3.x"

--- a/.github/workflows/verify-chord-validate.yml
+++ b/.github/workflows/verify-chord-validate.yml
@@ -40,6 +40,9 @@ jobs:
     runs-on: macos-15
     steps:
       - uses: actions/checkout@v7
+        with:
+          # Verify-only, never pushes — drop the persisted checkout token. t-yaxa
+          persist-credentials: false
 
       - name: Install chord + chezmoi from brew
         # chezmoi は runner image に既存だが念のため明示。


### PR DESCRIPTION
Prep for flipping the fleet zizmor gate from `min-confidence: medium` to `low` (plan A in t-yaxa): every checkout gets an explicit `persist-credentials` verdict, plus two low-confidence `template-injection` fixes that the low gate would also fail on (the reusable gate fails on ANY finding regardless of severity).

## Changes

- **ci.yml (7 checkouts)**: `persist-credentials: false` — flake check, shellcheck, convention checks, template render, darwin build/switch smoke are all CI-only and never push (zizmor `artipacked`).
- **release.yml checkout**: `persist-credentials: false` — git only reads the tag annotation; the release is created via the gh API token, never git push (zizmor `artipacked`).
- **verify-chord-doc.yml / verify-chord-validate.yml**: `persist-credentials: false` — verify only (zizmor `artipacked`).
- **release.yml × 2 run blocks**: `${{ steps.tag.outputs.name }}` no longer expands inline into `run:`; passed via `env` instead, same policy as the existing `INPUT_TAG` handling (zizmor `template-injection`, informational/low).

## Verification

Local `zizmor --config .github/zizmor.yml --min-confidence low --no-online-audits .github/workflows` (v1.25.2): **no findings** (12 suppressed). Authority is the CI check (v1.26.1) on this PR.

---（和訳）

fleet の zizmor ゲートを `medium`→`low` に切り替える下ごしらえ（t-yaxa 案A）。全 checkout に `persist-credentials` の明示判断を入れ、low 化で同じく落ちる template-injection（informational・reusable gate は severity 不問で fail）2 件も修正。

- ci.yml の 7 checkout: CI 検証のみで push しない → `false`
- release.yml の checkout: git は tag annotation を読むだけ・Release 作成は gh の API token 経由 → `false`
- verify-chord-doc / verify-chord-validate: verify のみ → `false`
- release.yml の run 2 箇所: `steps.tag.outputs.name` の inline 展開をやめ env 経由に（既存 INPUT_TAG と同方針）

ローカル zizmor（low）で findings ゼロ確認済み。権威は本 PR の CI check。

SetStatus-task: https://github.com/akira-toriyama/projects/blob/main/.furrow/bodies/t-yaxa.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)