### PR TITLE
:memo: docs(claude): grant full operation inside Tart VMs

### DIFF
--- a/chezmoi/private_dot_claude/CLAUDE.md
+++ b/chezmoi/private_dot_claude/CLAUDE.md
@@ -2,8 +2,8 @@
 
 ## Commits message style
 
-- **gitmoji + Conventional Commits**。**commit の type が git-cliff 経由で release の semver と notes を駆動する**（gitmoji は装飾で版に影響しない）。
-- 版を動かす type: `feat`→minor ／ `fix`・`perf`・`revert`→patch ／ breaking（`!` or `BREAKING CHANGE:`）→major ／ `docs`・`chore` 等→bump なし。
+- **gitmoji-driven**（エンジン = 自作 [glyph](https://github.com/akira-toriyama/glyph)。lint も semver も notes も glyph）。**先頭の `:code:` が type**＝release の semver と notes を駆動する。形式は `<:gitmoji:>[(<scope>)][!] <subject>`（Conventional の `<type>` 語は退役。legacy `<type>(scope)!:` token は lint が accept-and-ignore するので旧履歴はそのまま通る）。
+- 版を動かす gitmoji: `:boom:`・`!`・`BREAKING CHANGE:` footer→major（非抑制） ／ `:sparkles:`→minor（唯一の minor） ／ 出荷挙動を変える code（`:bug:` `:zap:` `:lock:` `:arrow_up:` 等）→patch ／ 内部・meta（`:memo:` `:recycle:` `:wrench:` 等）→bump なし。全75 code の機械正本は `glyph rules`（`--md` で表）。unknown code は lint hard error。
 - subject も body も英語。body を書く時は後半に `---（和訳）` 区切りで subject と body の和訳を付ける（subject だけなら不要）。
 - **全文（厳格仕様・例つき）**: https://github.com/akira-toriyama/.github/blob/main/CONTRIBUTING.md
 

--- a/chezmoi/private_dot_claude/CLAUDE.md
+++ b/chezmoi/private_dot_claude/CLAUDE.md
@@ -36,7 +36,10 @@
   headless で検証できる CLI / ログ経路を用意し、GUI しか確認手段がない状態を避ける。
   verbose ログ・デバッグ出力は恐れず足す。
 - **調査時**: 関連アプリ・ライブラリの clone、ドキュメントのダウンロードは自由に行ってよい。
-- **検証環境**: Tart VM での検証 OK（作成・破棄も自由）。
+- **検証環境**: Tart VM での検証 OK（作成・破棄も自由）。**VM の中では全操作 OK** —
+  sudo・TCC/AX の許可付与・システム設定の変更まで、確認を取らず実行してよい
+  （壊しても捨てて作り直せるのが VM の存在理由）。ホスト側の sudo は対象外
+  （dotfiles の `darwin-rebuild switch` 等は従来どおりユーザーに実行してもらう）。
 - **配布**: [GitHub Packages](https://github.com/akira-toriyama?tab=packages) への追加 OK。
 
 ## Mac アプリ（Swift）


### PR DESCRIPTION
## What

Two changes to the global agent instruction file (`chezmoi/private_dot_claude/CLAUDE.md`), in the order they must land.

### 1. Rescue the glyph commit-style policy (drift repair)

The Commits message style section was rewritten in the **live** `~/.claude/CLAUDE.md` when the release engine moved from git-cliff to glyph — but it was never `chezmoi re-add`-ed. `git log -S glyph` over this path was empty; the source still described `feat`/`fix` Conventional types driving semver via git-cliff.

This is a reproduction hazard, not a cosmetic one: `chezmoi apply` resolves **source → live**, so the next apply here — or the first apply on a new Mac, where live starts empty — would have silently reinstated the retired git-cliff policy as the authoritative instruction file. Found while preparing change 2, which touches the same file and would have triggered exactly that apply.

### 2. Grant full operation inside Tart VMs

The dev-policy section already blessed Tart VMs as a verification environment and allowed free create/destroy, but was silent on what may be done *inside* one — so an agent still stopped at the guest's sudo and TCC/AX consent prompts, the two things a throwaway VM exists to absorb.

The grant is stated on the bullet that already owns the topic rather than in a new location, and is scoped explicitly to the guest. **Host sudo is untouched**: the dotfiles rule that `darwin-rebuild switch` is handed to the user still holds. Without that clause the grant reads as a blanket sudo relaxation, which it is not.

## Verification

- `chezmoi diff` after the re-add showed only the intended Tart hunk — the glyph hunk was gone, confirming the rescue.
- `chezmoi apply` clean; live `~/.claude/CLAUDE.md:39-42` carries the new wording and retains glyph.
- Source and live are byte-identical.

## Note

Bundled as one PR because change 1 is a prerequisite for safely touching this file — landing 2 without 1 reverts the glyph policy on apply.