### PR TITLE
:recycle: refactor(nix): consolidate claude-code onto mise npm backend + drop container stack

### DIFF
--- a/home/modules/mise.nix
+++ b/home/modules/mise.nix
@@ -26,6 +26,18 @@
       # rundiff の adapter fixture（cargo test キャプチャ）等で使う。↑方針の
       # とおり言語ランタイムは mise（cargo/rustc とも mise 管理）。
       rust = "latest";
+
+      # Claude Code CLI 本体 — npm backend で宣言（node/npm 依存）。この形にする理由:
+      # ① 主力ツールで currency が要る（毎日出る）。npm install は書き込み可なので
+      #    claude 自身の自己アップデータが効き、"latest" 宣言＋自己更新で常に最新に
+      #    張り付く。Nix store は immutable・cask も upgrade=false で、どちらも自己更新が
+      #    空振りして構造的に版が遅れる（実測 Nix 2.1.141 / cask 2.1.197 / npm 2.1.212）。
+      # ② それでも再現可能: install ステップ自体が宣言されるので、新 Mac でも
+      #    darwin-rebuild switch → mise install で入る。旧来の「node global へ手 npm i -g」
+      #    （宣言外＝再現しない）と Nix pkg / cask 二重宣言を、この 1 本に集約して置換した。
+      # claude-maint.nix の launchd 月次ジョブは mise shim（~/.local/share/mise/shims/claude）
+      # 経由でこれを引く（launchd PATH に shims が入っている）。
+      "npm:@anthropic-ai/claude-code" = "latest";
     };
   };
 }

--- a/home/modules/packages.nix
+++ b/home/modules/packages.nix
@@ -29,11 +29,9 @@
     git-filter-repo
 
     # === Claude Code を快適にする CLI ===
-    # Claude Code CLI（headless `claude -p` も含む）。claude-maint.nix の月次保守ジョブが
-    # launchd から呼ぶため、再現可能に Nix で宣言する（mise の node global ではなく）。
-    # nix store は immutable なので自己アップデータは空振り＝版は flake で一元管理。
-    # 更新は `nix flake update` 時。VSCode 拡張 anthropic.claude-code とは別物（あれは拡張）。
-    claude-code
+    # Claude Code CLI 本体は mise の npm backend へ移設（home/modules/mise.nix）。npm 自己
+    # 更新で最新に張り付くため（旧: Nix pkg + cask の二重宣言＋宣言外の node global＝3系統
+    # 並存で最古の Nix 版が shadow され動かなかった）。ここは Claude が Bash で多用する周辺 CLI。
     # ripgrep / fd: Claude Code が Bash で多用する高速検索・ファイル探索。
     # 特に rg は非対話 PATH に無く `rg ...` が落ちていたので宣言して常用可能にする。
     ripgrep
@@ -59,11 +57,6 @@
     # until+sleep の手書きループ撲滅（projects t-v1t1）。使い方の正典は
     # ~/.claude/skills/condition-wait/SKILL.md（exec の footgun 3 点もそこに記載）。
     wait4x
-
-    # === コンテナ stack（docker CLI + macOS 上の Linux VM 提供 colima）===
-    docker
-    docker-compose
-    colima  # docker CLI を動かす実行基盤(Lightweight Linux VM)。drop すると docker が無効化
 
     # === 再現テスト基盤（roadmap Phase 6: 新 PC install.sh 自動検証）===
     # Tart: Apple Silicon ネイティブの macOS/Linux 仮想化。

--- a/system/modules/claude-maint.nix
+++ b/system/modules/claude-maint.nix
@@ -12,7 +12,8 @@
   #
   # 手動実行: bash <repo>/system/modules/scripts/claude-maint.sh [--dry-run]
   #
-  # 前提: claude CLI (packages.nix で宣言) / gh が auth 済 / dotfiles に
+  # 前提: claude CLI (mise の npm backend で宣言, home/modules/mise.nix。launchd PATH の
+  #   ~/.local/share/mise/shims 経由で解決) / gh が auth 済 / dotfiles に
   #   chezmoi/private_dot_claude (or dot_claude) が commit 済であること。
   launchd.user.agents.claude-maint = {
     serviceConfig = {

--- a/system/modules/homebrew.nix
+++ b/system/modules/homebrew.nix
@@ -35,7 +35,8 @@
     ];
 
     casks = [
-      "claude-code"  # Terminal-based AI coding assistant
+      # Claude Code CLI は mise の npm backend へ集約（home/modules/mise.nix）。cask は
+      # upgrade=false で自己更新も空振りし版が遅れるため、この cask 宣言は撤去した。
       "obsidian"  # Knowledge base that works on top of a local folder of plain text Markdown files
       # 1Password 8 デスクトップ。SSH エージェント / op CLI 連携の前提
       "1password"


### PR DESCRIPTION
## Context

Pre-wipe dotfiles review (about to rebuild on a fresh Mac). This PR lands the two config decisions that are unambiguous; doc cleanup and the remaining drops are tracked separately as furrow tasks.

## 1. claude-code: three declarations, both declared owners inert

Live-machine inventory found claude-code installed **three ways at once**:

| channel | version | actually runs? | declared? |
|---|---|---|---|
| mise npm global | **2.1.212** | ✅ interactive | ❌ nowhere (manual `npm i -g`) |
| Homebrew cask | 2.1.197 | via launchd PATH | homebrew.nix |
| Nix package | 2.1.141 | ❌ always shadowed | packages.nix |

Only the npm install stays current, because Claude Code's self-updater needs a **writable** install — it's a no-op against the immutable Nix store, and the cask is pinned by `upgrade = false`. So the two *declared* owners were structurally doomed to lag the tool actually in use, and the tool actually in use didn't reproduce at all.

**Fix:** collapse to one owner that is both reproducible and current — declare it through mise's npm backend (`npm:@anthropic-ai/claude-code = "latest"`). The install step is declarative (fresh Mac gets it via `switch` → `mise install`); the self-updater keeps it on latest thereafter.

### Verified on the live machine
- `mise x "npm:@anthropic-ai/claude-code@latest" -- claude --version` → installs cleanly, `2.1.212`.
- `mise which claude` (with the tool declared) → `~/.local/share/mise/installs/npm-anthropic-ai-claude-code/latest/bin/claude`.
- `~/.local/share/mise/shims/claude` (what claude-maint's launchd job resolves) already exists and is on that job's PATH.
- Built `mise-config` store output contains `"npm:@anthropic-ai/claude-code" = "latest"`.
- `nix flake check --no-build` ✅ and `darwin-rebuild build .#default` ✅.

Drops the redundant Nix package + Homebrew cask, and corrects the claude-maint prerequisite comment.

## 2. Drop the container stack (docker / docker-compose / colima)

Zero interactive-history use, not a Claude-Bash reflex. A fresh-Mac rebuild is the moment to shed it — one line brings it back if a container workflow materializes.

## Not in this PR (tracked as furrow tasks)
- Pre-wipe user checklist (1Password Emergency Kit, GitHub PAT, dirty/unpushed sweep, fresh SSH key).
- `homebrew.onActivation.cleanup` `none` → `zap` — deliberately **not** flipped here; on *this* machine it would zap ~90 undeclared brews. Belongs to the fresh Mac.
- Legacy doc cleanup (system-inventory / roadmap museums, mas-1.8.6 freeze narrative, the `reproduction-architecture.md` claim of an op-template secret pipeline that does not exist in code) and the dead `rift-cli` chord bindings.
- Tier-1 unused package drops pending explicit confirmation (aria2/xcodes/hyperfine/git-filter-repo/ast-grep/mas).

SetStatus-task: https://github.com/akira-toriyama/projects/blob/main/.furrow/bodies/t-x3j7.md in-progress

🤖 Generated with [Claude Code](https://claude.com/claude-code)
