### PR TITLE
:recycle: install the claude-code CLI via the official native installer

### DIFF
--- a/chezmoi/run_onchange_after_install-claude-code.sh
+++ b/chezmoi/run_onchange_after_install-claude-code.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+# Claude Code CLI (claude) の宣言的インストール。入れ方は公式 native installer に一本化する。
+#
+# なぜ native か:
+# ・claude は毎日のように更新が出る主力ツールで、常に最新へ張り付きたい。native バイナリは
+#   起動時/定期にバックグラウンドで自己更新するので "入れておけば最新" になる。
+# ・cask(upgrade=false) / nix store(immutable) / mise npm(自己更新しない) は、いずれも
+#   構造的に版が遅れる。なので「版まで宣言して pin」せず、"存在" だけここで保証し、更新は
+#   ツール本体に委ねる（= reproducibility と currency を両立させる唯一の形）。
+# ・claude-maint.nix の月次 launchd ジョブは ~/.local/bin/claude を PATH 経由で引く
+#   (home/modules/default.nix の home.sessionPath にも ~/.local/bin を追加済み)。
+#
+# 冪等: 既に ~/.local/bin/claude があれば何もしない（installer 自体も再実行安全）。
+# 実行契機: このスクリプト本文の hash が変わると chezmoi が再実行する（run_onchange）。
+#   新 Mac では install.sh の `chezmoi apply` ステップで初回実行され、自動導入される。
+set -e
+
+if [ -x "$HOME/.local/bin/claude" ]; then
+  echo "claude-code 既にインストール済み ($HOME/.local/bin/claude) → skip"
+  exit 0
+fi
+
+echo "==> Claude Code CLI を公式 native installer で導入"
+curl -fsSL https://claude.ai/install.sh | bash

--- a/home/modules/default.nix
+++ b/home/modules/default.nix
@@ -17,7 +17,9 @@
   # nix-darwin の set-environment が作る PATH には /opt/homebrew/bin が無く、
   # chord 等が叩く `/bin/zsh -l -c` で brew 製コマンド (facet / rift-cli 等) が
   # command-not-found になる。hm-session-vars.sh 経由で全 shell に効かせる。
-  home.sessionPath = [ "/opt/homebrew/bin" "/opt/homebrew/sbin" ];
+  # ~/.local/bin: 公式 native installer が入れる claude 本体の場所（自己更新もここを更新）。
+  # home.sessionPath は double-quoted で書き出されるので $HOME は shell 展開される。
+  home.sessionPath = [ "/opt/homebrew/bin" "/opt/homebrew/sbin" "$HOME/.local/bin" ];
 
   # ghq の clone 先を case-sensitive APFS Volume に固定。
   # install.sh の §1.5 で作成される。$GHQ_ROOT は ghq が `git config ghq.root`

--- a/home/modules/mise.nix
+++ b/home/modules/mise.nix
@@ -26,18 +26,10 @@
       # rundiff の adapter fixture（cargo test キャプチャ）等で使う。↑方針の
       # とおり言語ランタイムは mise（cargo/rustc とも mise 管理）。
       rust = "latest";
-
-      # Claude Code CLI 本体 — npm backend で宣言（node/npm 依存）。この形にする理由:
-      # ① 主力ツールで currency が要る（毎日出る）。npm install は書き込み可なので
-      #    claude 自身の自己アップデータが効き、"latest" 宣言＋自己更新で常に最新に
-      #    張り付く。Nix store は immutable・cask も upgrade=false で、どちらも自己更新が
-      #    空振りして構造的に版が遅れる（実測 Nix 2.1.141 / cask 2.1.197 / npm 2.1.212）。
-      # ② それでも再現可能: install ステップ自体が宣言されるので、新 Mac でも
-      #    darwin-rebuild switch → mise install で入る。旧来の「node global へ手 npm i -g」
-      #    （宣言外＝再現しない）と Nix pkg / cask 二重宣言を、この 1 本に集約して置換した。
-      # claude-maint.nix の launchd 月次ジョブは mise shim（~/.local/share/mise/shims/claude）
-      # 経由でこれを引く（launchd PATH に shims が入っている）。
-      "npm:@anthropic-ai/claude-code" = "latest";
+      # 注: Claude Code CLI (claude) はここ(mise)では入れない。cask/mise-npm/nix は
+      # いずれも自己更新が構造的に効かず版が遅れるため、公式 native installer に一本化
+      # （起動時/定期に自己更新して最新に張り付く）。実体は
+      # chezmoi/run_onchange_after_install-claude-code.sh、~/.local/bin/claude に入る。
     };
   };
 }

--- a/system/hosts/generic.nix
+++ b/system/hosts/generic.nix
@@ -18,7 +18,6 @@
     builtins.elem (lib.getName pkg) [
       "1password-cli"
       "tart"  # macOS/Linux VM on Apple Silicon (Apple Virtualization framework 利用)
-      "claude-code"  # Claude Code CLI (claude-maint.nix の月次保守ジョブが headless 利用)
     ];
 
   users.users.${username} = {

--- a/system/modules/claude-maint.nix
+++ b/system/modules/claude-maint.nix
@@ -12,8 +12,8 @@
   #
   # 手動実行: bash <repo>/system/modules/scripts/claude-maint.sh [--dry-run]
   #
-  # 前提: claude CLI (mise の npm backend で宣言, home/modules/mise.nix。launchd PATH の
-  #   ~/.local/share/mise/shims 経由で解決) / gh が auth 済 / dotfiles に
+  # 前提: claude CLI (公式 native installer で導入, chezmoi/run_onchange_after_install-claude-code.sh。
+  #   launchd PATH の ~/.local/bin 経由で解決) / gh が auth 済 / dotfiles に
   #   chezmoi/private_dot_claude (or dot_claude) が commit 済であること。
   launchd.user.agents.claude-maint = {
     serviceConfig = {

--- a/system/modules/homebrew.nix
+++ b/system/modules/homebrew.nix
@@ -35,8 +35,9 @@
     ];
 
     casks = [
-      # Claude Code CLI は mise の npm backend へ集約（home/modules/mise.nix）。cask は
-      # upgrade=false で自己更新も空振りし版が遅れるため、この cask 宣言は撤去した。
+      # Claude Code CLI は cask/mise/nix いずれも自己更新が効かず版が遅れるため、
+      # 公式 native installer 経由に一本化（chezmoi/run_onchange_after_install-claude-code.sh。
+      # ~/.local/bin/claude が起動時/定期に自己更新して最新へ張り付く）。
       "obsidian"  # Knowledge base that works on top of a local folder of plain text Markdown files
       # 1Password 8 デスクトップ。SSH エージェント / op CLI 連携の前提
       "1password"

--- a/system/modules/scripts/claude-maint.sh
+++ b/system/modules/scripts/claude-maint.sh
@@ -34,7 +34,7 @@ DRY_RUN=0
 
 # --- launchd は PATH がほぼ空。必要な bin を明示注入する (drift script と同方針)。----
 NIX_PROFILE_BIN="/etc/profiles/per-user/$(id -un)/bin"
-PATH="/opt/homebrew/bin:${NIX_PROFILE_BIN}:${HOME}/.local/share/mise/shims:/run/current-system/sw/bin:/nix/var/nix/profiles/default/bin:/usr/bin:/bin"
+PATH="/opt/homebrew/bin:${NIX_PROFILE_BIN}:${HOME}/.local/bin:/run/current-system/sw/bin:/nix/var/nix/profiles/default/bin:/usr/bin:/bin"
 export PATH
 
 LOG_PREFIX="[$(date '+%F %T')] claude-maint:"


### PR DESCRIPTION
## What
Move the `claude-code` CLI off the Homebrew cask / mise-npm backend onto Anthropic's official **native installer**, and automate it for fresh machines.

## Why
cask (`upgrade=false`), the nix store (immutable) and mise (never bumps globals) all fail to self-update, so `claude-code` — a daily-moving primary tool — structurally lagged. The native binary auto-updates in the background, so we declare only its *presence* and let the tool own its version (pinning an AI CLI has no upside — you always want latest). Reverses #212 (mise npm): same currency goal, better mechanism.

## Changes
- **remove** the cask, the mise `npm:@anthropic-ai/claude-code` entry, and the now-dead `claude-code` `allowUnfree` predicate
- **add** `chezmoi/run_onchange_after_install-claude-code.sh` — idempotent native install; runs on `chezmoi apply`, so `install.sh` auto-installs it on a fresh Mac (← "新環境でも自動化")
- **repoint** the `claude-maint` monthly launchd job + `home.sessionPath` at `~/.local/bin` (native install location) instead of the mise shims dir

## Verified locally
- `nix eval .#darwinConfigurations.default.system.drvPath` → evaluates clean (the `allowUnfree` removal doesn't break eval)
- `sh -n` on the new script; `git grep` confirms zero stale mise-shim / cask / npm `claude-code` refs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
