### PR TITLE
:wrench: capture wand trash action + chord IST mouse bindings

### DIFF
--- a/chezmoi/dot_config/chord/private_config.toml
+++ b/chezmoi/dot_config/chord/private_config.toml
@@ -168,10 +168,20 @@ TU_RR_X2 = 0x8B
 TU_RR_X3 = 0x8C
 TU_RR_X4 = 0x8D
 
+# IST
+IST_BTN5 = 0xA0
+IST_BTN6 = 0xA1
+IST_TILT_L = 0xA2
+IST_TILT_R = 0xA3
+
 # =====================================================================
 # Bindings — 各 binding 直前の `# doc: <動作>` は docs/chord.md の
 # ショートカット表生成の唯一ソース（scripts/gen-chord-doc.py が読む）。
 # =====================================================================
+
+[[bindings]]
+input = "IST_BTN5"
+action-shell = "echo \"$(date '+%T') IST_BTN5\" >> /tmp/ist-vkey-test.log"
 
 # ---- ULTRA_LL レイヤ（ZMK 右側 ALT+SHIFT+CTRL チョード） ----
 

--- a/chezmoi/dot_config/wand/config.toml
+++ b/chezmoi/dot_config/wand/config.toml
@@ -960,8 +960,8 @@ action-cmd  = "open -na 'Google Chrome'"
 name = "Move to Trash"
 icon = "SF:trash"
 tint = "systemRed"
-action-type = "ax"
-action-verb = "AXDelete"
+action-type = "shell"
+action-cmd = "osascript -e 'tell application \"Finder\" to delete (selection as alias list)'"
 
 # Multi-colour palette — `tint-colors = [...]` applies SF Symbol's
 # hierarchical / multicolor palette. Wins over a single `tint`.


### PR DESCRIPTION
## What
Capture two hand-made config edits into the chezmoi source so they reproduce on a fresh machine:

- **wand** — "Move to Trash" action switched from AX (`action-type = "ax"` / `AXDelete`) to a shell `osascript` that tells Finder to delete the selection. The AX verb can silently no-op on some targets; the Finder route is reliable.
- **chord** — add IST PRO mouse bindings: `IST_BTN5` / `IST_BTN6` / `IST_TILT_L` / `IST_TILT_R` aliases plus the accompanying binding.

## Why
These were live-edited configs (`~/.config/{wand,chord}`) that had drifted from the tracked chezmoi source. Committing them here is what makes the edits survive a clean reinstall (`chezmoi apply` on a new Mac).

## Scope note
`chezmoi/dot_config/facet/config.toml` is **intentionally excluded** from this PR — it's still WIP (placeholder tags). It stays as local drift for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
