### PR TITLE
:arrow_up: nix: full flake update — unbreak brew 6 formula parsing + PR-gate flake changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,18 +151,50 @@ jobs:
           exit $failed
 
   # ── フル再現検証（macOS・cold・重い）─────────────────────────────────────────
-  # Opt 1': PR では走らせず(if 参照)、merge 後の main push / nightly / 手動でのみ。
+  # Opt 1'': 通常 PR では走らせず、merge 後の main push / nightly / 手動で実行。
+  # ただし flake 入力・nix モジュールを触る PR は activation を壊し得る
+  # (2026-07-06〜18 の brew 6 skew を 13 夜見逃した実績、t-8qqz/t-j09q) ので、
+  # flake-changes 判定で PR でも実行して merge 前に検出する。
   # 「install.sh が新 Mac で cold bootstrap を通す」保証の enforce がこの2ジョブ。
   # ★ キャッシュは意図的に使わない ── warm cache は cold fetchability
   #   (消えた substituter / fixed-output の hash drift / 死んだ cask tap / 404 flake input)
   #   の検証を痩せさせる。速度は「頻度を下げる」(per-PR から外す) で稼ぐ。
   # ★ build(.#default) と switch(.#ci) は別 attr(username/masApps が違う)なので両方要る。
 
+  # PR が flake 入力・nix モジュールを触ったかの判定。checkout 不要 (PR files API)。
+  # push/schedule では skip され、darwin ジョブ側の `!cancelled() && (非PR || hit)`
+  # 条件が従来どおり無条件実行に解決する。
+  flake-changes:
+    name: detect flake-affecting changes
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      hit: ${{ steps.diff.outputs.hit }}
+    steps:
+      - name: Check changed files via PR files API
+        id: diff
+        # zizmor template-injection 対策: 参照はすべて env 経由 (#193 と同方針)
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          files=$(gh api "repos/$REPO/pulls/$PR/files" --paginate --jq '.[].filename')
+          hit=false
+          if printf '%s\n' "$files" | grep -qE '^(flake\.(nix|lock)$|system/|home/)'; then
+            hit=true
+          fi
+          echo "hit=$hit" >> "$GITHUB_OUTPUT"
+          printf 'hit=%s\nchanged files:\n%s\n' "$hit" "$files"
+
   # macOS 実機相当(arm64)で darwin-rebuild build を回し、flake が活性化可能かを
   # End-to-end に近い形で証明する。switch はしない(非破壊)。
   darwin-build:
     name: darwin-rebuild build (macOS)
-    if: github.event_name != 'pull_request'
+    needs: [flake-changes]
+    if: ${{ !cancelled() && (github.event_name != 'pull_request' || needs.flake-changes.outputs.hit == 'true') }}
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v7
@@ -181,7 +213,8 @@ jobs:
   # runner は ephemeral なので副作用 OK。
   darwin-switch-smoke:
     name: darwin-rebuild switch smoke (macOS)
-    if: github.event_name != 'pull_request'
+    needs: [flake-changes]
+    if: ${{ !cancelled() && (github.event_name != 'pull_request' || needs.flake-changes.outputs.hit == 'true') }}
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v7
@@ -257,6 +290,7 @@ jobs:
       - convention-executable-prefix
       - convention-command-prefix
       - chezmoi-templates
+      - flake-changes
       - darwin-build
       - darwin-switch-smoke
     runs-on: ubuntu-latest
@@ -272,3 +306,40 @@ jobs:
           echo "$NEEDS_JSON"
           exit 1
       - run: echo "All required jobs passed or were intentionally skipped."
+
+  # ── 赤 main の強制可視化（t-j09q）────────────────────────────────────────────
+  # schedule/push の failure は PR の視界に入らず、2026-07-06〜18 の 13 夜連続
+  # failure を見逃した。main が赤くなったら固定タイトルの issue に集約して
+  # 通知を発生させる（issue の新規作成/コメントはデフォルトで通知が飛ぶ）。
+  notify-red-main:
+    name: notify red main
+    if: always() && github.event_name != 'pull_request' && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled'))
+    needs:
+      - nix-flake-check
+      - shellcheck
+      - convention-executable-prefix
+      - convention-command-prefix
+      - chezmoi-templates
+      - darwin-build
+      - darwin-switch-smoke
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Create or comment on the red-main issue
+        # zizmor template-injection 対策: 参照はすべて env 経由 (#193 と同方針)
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          EVENT: ${{ github.event_name }}
+        run: |
+          title="CI red on main"
+          num=$(gh issue list --repo "$REPO" --state open \
+            --search "in:title \"$title\"" --json number --jq '.[0].number // empty')
+          body="\`$EVENT\` run failed: $RUN_URL"
+          if [ -n "$num" ]; then
+            gh issue comment "$num" --repo "$REPO" --body "$body"
+          else
+            gh issue create --repo "$REPO" --title "$title" --body "$body"
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,9 +239,13 @@ jobs:
       - name: Verify CLI on PATH（home.packages 経由）
         # GitHub Actions の step shell は login shell ではないので
         # /etc/zshenv 経由の nix path がロードされない。明示的に追加する。
+        # ★ このリストは home/modules/packages.nix の宣言に追従させること。
+        #   手書きリストは drift する: #212 が docker/docker-compose/colima を
+        #   drop した際ここが未追従で、brew 6 修正後の初 smoke が落ちた
+        #   (07-06〜18 は switch が先に死んでいて検出不能だった)。
         run: |
           export PATH="/etc/profiles/per-user/runner/bin:/run/current-system/sw/bin:/nix/var/nix/profiles/default/bin:$PATH"
-          for c in docker docker-compose colima op gh chezmoi ghq jq mas; do
+          for c in op gh chezmoi ghq jq mas; do
             path=$(which "$c" || true)
             if [ -n "$path" ]; then
               echo "  ✓ $c -> $path"

--- a/flake.lock
+++ b/flake.lock
@@ -3,16 +3,16 @@
     "brew-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1778427648,
-        "narHash": "sha256-pt9KaDGsMyYWB9JeHs4XGHs870f1lOZe3vx9LpVIhUE=",
+        "lastModified": 1784068757,
+        "narHash": "sha256-7KnV7rTlMpys+2J+TFVxUDDyKPLXFs4wIMtckMC72VM=",
         "owner": "Homebrew",
         "repo": "brew",
-        "rev": "6f293daa9f9f5832e13b497976335e90509886d7",
+        "rev": "6bd951d96e7ebc54787799dba77bfb26ec956c4c",
         "type": "github"
       },
       "original": {
         "owner": "Homebrew",
-        "ref": "5.1.11",
+        "ref": "6.0.11",
         "repo": "brew",
         "type": "github"
       }
@@ -24,11 +24,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779157263,
-        "narHash": "sha256-VbiyZkRf8/qr7ObmlyfOHJsNAW5tyZ4MB1+cUwAwdrw=",
+        "lastModified": 1784407317,
+        "narHash": "sha256-iZrxHToDJWnvt+5LGAtvuQMTy1NZYlNEKbKaVtBJNcc=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "866412a19866b4a8e32d2306a118040afa2b840c",
+        "rev": "39411a8e12a5526d992e65bc7e3dc9a4414d6713",
         "type": "github"
       },
       "original": {
@@ -44,11 +44,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1779036909,
-        "narHash": "sha256-zXcwYQGCT6pzinK+1dBB2ekTVtfxGZAapb3Evdcu4fY=",
+        "lastModified": 1784362797,
+        "narHash": "sha256-EP9b9b+OXDxHBPefFwMYCIaLq0fn3UkmrbfzbLUT7kQ=",
         "owner": "nix-darwin",
         "repo": "nix-darwin",
-        "rev": "56c666e108467d87d13508936aade6d567f2a501",
+        "rev": "b4cccbd4bc299c1f71ae185b79c3cf99aa82805c",
         "type": "github"
       },
       "original": {
@@ -63,11 +63,11 @@
         "brew-src": "brew-src"
       },
       "locked": {
-        "lastModified": 1778851564,
-        "narHash": "sha256-p8wzcnpB2Iys+QzAKM9/Eyw/pUyqCO3sw/NCnDH4dTE=",
+        "lastModified": 1784159664,
+        "narHash": "sha256-I/B6YoRLImHEqNWh8bs+tPjEDeteACeFhcLyoSMo1GE=",
         "owner": "zhaofengli",
         "repo": "nix-homebrew",
-        "rev": "b3a87b4793205cc111f3c61e25e018ffac3b8039",
+        "rev": "842eeb863ecca0eeb463f7a814cdc51e1d925776",
         "type": "github"
       },
       "original": {
@@ -78,11 +78,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1778869304,
-        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
+        "lastModified": 1784364478,
+        "narHash": "sha256-CdItYNdYUlm7NxqMVyQKqT2IxTwvapiPuRLWOyHTrbY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
+        "rev": "20535e48e12c86043b577b8518234ff5dbb26957",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Why

Root cause of the 2026-07-18 bootstrap failure and **13 consecutive red nightly runs** (2026-07-06 → 07-18, t-8qqz): nix-homebrew pinned **brew 5.1.11** while rolling homebrew-core moved to the Homebrew 6.x formula DSL. `brew bundle` died during nix-darwin activation (`FormulaUnreadableError` on openssl@3 / libssh2 → `Installing git-cliff has failed!`), and `set -e` killed activation **before** home-manager ever ran — wiping the entire user layer on the fresh Mac.

## What

1. **Full `nix flake update`** (all inputs — brew-src 5.1.11 → **6.0.11**, nix-darwin 56c666e → b4cccbd, nix-homebrew b3a87b4 → 842eeb8, nixpkgs, home-manager).
   - Full update is load-bearing: brew 6 enables **tap trust by default**, and only the newer nix-darwin emits `trusted: true` in the Brewfile. Bumping nix-homebrew alone would re-kill activation via `UntrustedTapError` on `steipete/tap/peekaboo`.
2. **ci: run the two macOS jobs on flake-touching PRs** (`flake-changes` detection via PR files API) — this PR itself gets the pre-merge `darwin-rebuild switch` smoke as proof.
3. **ci: `notify-red-main`** — schedule/push failures now create/append a fixed-title issue instead of failing silently out of sight (t-j09q: PR は常に緑・main だけ赤 で 13 夜見逃した).

## Verified locally

- `jq '.nodes["brew-src"].original.ref' flake.lock` → **6.0.11**
- Brewfile eval carries `trusted: true` on all 4 brews incl. `steipete/tap/peekaboo`
- `nix flake check --no-build` → green
- `nix run nix-darwin#darwin-rebuild -- build --flake .#default --impure` (non-destructive) → green (`darwin-system-26.11.b4cccbd`)

## Acceptance signal

- This PR's own `darwin-rebuild switch smoke (macOS)` job (now runs pre-merge via flake-changes)
- After merge: the nightly scheduled run goes green again

SetStatus-task: https://github.com/akira-toriyama/projects/blob/main/.furrow/bodies/t-8qqz.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)