### PR TITLE
:sparkles: chezmoi: declare GitHub host keys to kill the TOFU prompt

### DIFF
--- a/chezmoi/private_dot_ssh/create_known_hosts
+++ b/chezmoi/private_dot_ssh/create_known_hosts
@@ -1,0 +1,8 @@
+# GitHub host keys — install.sh の無人実行で TOFU プロンプト
+# ("Are you sure you want to continue connecting?") を出さないための事前宣言。
+# 出典: https://api.github.com/meta の .ssh_keys[]（非秘密・公開情報）
+# 更新: 鍵ローテーション時に上記 API から手動で取り直す（生成パイプラインは持ち込まない）。
+# create_ 接頭辞 = 存在しない時のみ作成。ssh が追記した既存 known_hosts は上書きしない。
+github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl
+github.com ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrYMjNuG5N87uRgg6CLrbo5wAdT/y6v0mKV0U2w0WZ2YB/++Tpockg=
+github.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCj7ndNxQowgcQnjshcLrqPEiiphnt+VTTvDP6mHBL9j1aNUkY4Ue1gvwnGLVlOhGeYrnZaMgRK6+PKCUXaDbC7qtbW8gIkhL7aGCsOr/C56SJMy/BCZfxd1nWzAOxSDPgVsmerOBYfNqltV9/hWCqBywINIR+5dIg6JTJ72pcEpEjcYgXkE2YEFXV1JHnsKgbLWNlhScqb2UmyRkQyytRLtL+38TGxkxCflmO+5Z8CSSNY7GidjMIZ7Q4zMjA2n1nGrlTDkzwDCsw+wqFPGQA179cnfGWOWRVruj16z6XyvxvjJwbz0wQZ75XK5tKSb7FNyeIEs4TT4jk+S4dhPeAUC5y+bDYirYgM4GC7uEnztnZyaVWQ7B381AK4Qdrwt51ZqExKbQpTUNn+EjqoTwvqNj4kqx5QUCI0ThS/YkOxJCXmPUWZbhjpCg56i+2aB6CmK2JGhn57K5mj0MNdBXA4/WnwH6XoPWJzK5Nyu2zB3nAZp+S5hpQs+p1vN1/wsjk=


### PR DESCRIPTION
## Why

Unattended `install.sh` hangs forever at GitHub's host-key TOFU prompt ("Are you sure you want to continue connecting?") on a fresh Mac — proven in the 2026-07-18 run 2 log (log.txt:3321). This violates the zero-interaction MUST (t-8qqz).

## What

`chezmoi/private_dot_ssh/create_known_hosts` — GitHub's host keys as a **static file** (source: `https://api.github.com/meta` `.ssh_keys[]`, public/non-secret).

- `create_` prefix: created only when absent; never clobbers keys ssh appends later
- `~/.ssh` declared `private_` → 0700 on a fresh Mac; file lands 0644
- No generation pipeline (house rule); manual refresh on GitHub key rotation
- Ownership split per t-py7m: private key = 1Password / `~/.ssh/config` = 1Password / **known_hosts = chezmoi** (non-secret)

## Verified

- `chezmoi --source ./chezmoi diff ~/.ssh` on this machine → no-op (file already exists)
- dry-run against an empty destination → creates `.ssh` (40700) + `known_hosts` (100644) with this content
- `ssh -o StrictHostKeyChecking=yes -o UserKnownHostsFile=<this file> -o IdentityAgent=none -T git@github.com` → reaches auth (`Permission denied (publickey)`) with **no TOFU prompt**

SetStatus-task: https://github.com/akira-toriyama/projects/blob/main/.furrow/bodies/t-py7m.md done

🤖 Generated with [Claude Code](https://claude.com/claude-code)