### PR TITLE
:recycle: install: single-stage — front-load all GUI to pre-steps, clone included unattended

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,42 +1,41 @@
 # dotfiles
 
 
-## 環境再現コマンド（2 段階）
+## 環境再現コマンド
 
-### 事前準備（初期化直後・2 つだけ）
+### 事前準備（初期化直後・在席。GUI 操作はここに全部 front-load）
 
 1. システム設定 → プライバシーとセキュリティ → **フルディスクアクセス → Terminal を ON**
-   （実行中に macOS の管理ダイアログを出さないため。付与後 Terminal を Cmd-Q で再起動）
-2. ターミナルで `sudo -v`（このあとのワンライナーと同じターミナルで）
+   （付与後 Terminal を Cmd-Q で再起動。実行中に macOS の管理ダイアログを出さないため）
+2. **1Password.app を手動インストール** → **iPhone の QR でサインイン**（Secret Key 手打ち不要）→
+   設定 → 開発者 → **SSH agent を ON** → セキュリティ → **自動ロックのタイマーを OFF**
+   （スリープ時ロックは残す。実行中ロックで clone が止まるのを防ぐ）→
+   `ssh -o StrictHostKeyChecking=accept-new -T git@github.com` を 1 回実行し、
+   承認ダイアログで「**すべてのアプリで承認する**」+ 認証
+3. ターミナルで `sudo -v`（次のワンライナーと同じターミナルで）
 
-### stage 1（無人。パスワード入力・GUI 操作ゼロ）
+### 実行（ここから先はパスワード入力・GUI 操作ゼロ・無人で完走）
 
 ```sh
 sudo -v && sh -c "$(curl -fsLS https://raw.githubusercontent.com/akira-toriyama/dotfiles/main/install.sh)"
 ```
 
-流れ: Xcode CLT (headless) → **workspace volume (case-sensitive APFS) 作成** →
-Determinate Nix (.pkg) → リポジトリ clone → `darwin-rebuild switch`
-（brew/cask/CLI/macOS defaults を nix-darwin の宣言通りに一括適用）→
-`chezmoi apply` → **事後条件検証**（home-manager activation の実走・home files・
-ghq root・brew 宣言との一致）。終端は `STAGE1-OK`（まだ「✓ 完了」ではない）。
+流れ: Xcode CLT (headless) → **workspace volume (case-sensitive APFS)** →
+Determinate Nix (**.pkg**) → リポジトリ clone → `darwin-rebuild switch`
+（brew/cask/CLI/macOS defaults を nix-darwin の宣言どおり一括適用）→ `chezmoi apply`
+→ 1Password agent 経由の SSH 確認 → `ghq-get-mine`（全自リポジトリを
+`/Volumes/workspace` へ SSH clone）→ `link-claude-memory` → **事後条件検証**
+（home-manager activation の実走・home files・ghq root・brew 宣言との一致・
+clone 完全性・memory link）。
 
-### stage 2（在席で実行。1Password の GUI 操作 2 つの後）
+**`✓ 完了` は全 phase + 検証を通過した時だけ出る**（スキップ・失敗があれば必ず
+FAILED/PARTIAL になる）。
 
-1. 1Password.app（stage 1 の cask で導入済み）を起動 → **iPhone の QR でサインイン**
-2. 設定 → 開発者 → **SSH agent を ON**
+### リカバリ
 
-```sh
-sh ~/dotfiles/install.sh --phase2
-```
-
-1Password agent 経由の SSH を実署名で確認 → `ghq-get-mine`（全自リポジトリを
-`/Volumes/workspace` へ SSH clone）→ `link-claude-memory` → 事後条件検証。
-**`✓ 完了` はここでしか出ない**（clone と claude-memory link まで含めて「完了」）。
-
-2 段階の理由: 1Password がロック中だと SSH 署名が GUI ダイアログを出す（実機実証）。
-clone を無人 stage に置くと「実行中 GUI ゼロ」が破れるため、clone 以降を在席の
-stage 2 に分離している。
+- 途中で失敗したら**同じワンライナーを再実行**（全 phase 冪等。導入済みは skip）。
+- SSH gate（1Password）起因の失敗だけを直した後は近道がある:
+  `sh ~/dotfiles/install.sh --phase2`（clone 以降のみ実行）。
 
 ### ログと結果（機械可読）
 
@@ -47,8 +46,7 @@ stage 2 に分離している。
 - `events.tsv` — phase/step の開始・終了・exit code
 - `detail/<step>.log` — ノイズの多い step（chezmoi apply 等）の隔離出力
 
-`~/.dotfiles-install/latest` が最新 run を指す。失敗時は同じコマンドを再実行すれば
-冪等に続きから収束する。
+`~/.dotfiles-install/latest` が最新 run を指す。
 
 workspace volume は `/Volumes/workspace` に作られ、ghq の clone 先 (`GHQ_ROOT`) として
 home-manager から参照される。macOS デフォルト APFS は case-insensitive なため Linux

--- a/README.md
+++ b/README.md
@@ -10,9 +10,15 @@
 2. **1Password.app を手動インストール** → **iPhone の QR でサインイン**（Secret Key 手打ち不要）→
    設定 → 開発者 → **SSH agent を ON** → セキュリティ → **自動ロックのタイマーを OFF**
    （スリープ時ロックは残す。実行中ロックで clone が止まるのを防ぐ）→
+   **`~/.ssh/config` に IdentityAgent 行があることを確認**（1Password の設定画面が示す
+   snippet。無ければその内容で作る）→
    `ssh -o StrictHostKeyChecking=accept-new -T git@github.com` を 1 回実行し、
    承認ダイアログで「**すべてのアプリで承認する**」+ 認証
-3. ターミナルで `sudo -v`（次のワンライナーと同じターミナルで）
+3. **GitHub fine-grained PAT** を 1Password からコピーし、次のワンライナーと同じ
+   ターミナルで `export GH_TOKEN=<PAT>`（権限は All repositories / **Metadata:
+   Read-only** で足りる。`ghq-get-mine` の repo 一覧と clone 完全性検証が gh API を
+   使うため。無いと序盤の P1-ghtoken gate で即 fail する）
+4. ターミナルで `sudo -v`（次のワンライナーと同じターミナルで）
 
 ### 実行（ここから先はパスワード入力・GUI 操作ゼロ・無人で完走）
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -186,8 +186,9 @@ switch ...` で呼ぶ。
 
 ### `--phase2`
 install.sh の**リカバリ入口**。SSH gate（1Password）起因の失敗を直した後、
-前段 phase を再評価せず clone 以降（SSH gate → ghq-get-mine → link → 検証）
-だけを実行する。通常経路ではない（通常はワンライナー再実行 = 冪等）。
+導入系 phase（CLT/Nix/switch）を再評価せず、sudoers drop-in の self-heal →
+事後条件検証（システム層）→ clone 以降（SSH gate → ghq-get-mine → link →
+clone 検証）を実行する。通常経路ではない（通常はワンライナー再実行 = 冪等）。
 - **Don't call it:** stage 2, 後半モード, 対話モード
 
 ### `summary.txt`

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -177,16 +177,18 @@ switch ...` で呼ぶ。
 
 ### `install.sh`
 **新規 macOS の最終目標**: このスクリプト 1 つで同等環境を再現できる
-状態を維持する。**stage 1**（無人・パスワード/GUI ゼロ: CLT → workspace volume →
-Nix → clone → switch → chezmoi → 事後条件検証）と **stage 2**（在席・
-`--phase2`: 1Password agent の SSH 確認 → ghq-get-mine → claude-memory link →
-事後条件検証）の 2 段階。`✓ 完了` は stage 2 でしか出ない。
+状態を維持する。**単一ステージ・無人一気通貫**（CLT → workspace volume → Nix(.pkg)
+→ clone → switch → chezmoi → SSH gate → ghq-get-mine → claude-memory link →
+事後条件検証）。GUI 操作（FDA 付与・1Password サインイン/agent ON/鍵承認・
+自動ロックタイマー OFF）は**事前準備に front-load** する。`✓ 完了` は全 phase +
+検証を通過した時だけ出る。
 - **Don't call it:** setup, bootstrap script, セットアップ
 
-### `stage 1` / `stage 2`
-install.sh の実行区分。分離理由 = 1Password ロック中の SSH 署名は GUI
-ダイアログを出す（実機実証）ため、clone 以降を在席実行に隔離する。
-- **Don't call it:** phase A/B, 前半/後半, part 1/2（フラグ名だけ `--phase2`）
+### `--phase2`
+install.sh の**リカバリ入口**。SSH gate（1Password）起因の失敗を直した後、
+前段 phase を再評価せず clone 以降（SSH gate → ghq-get-mine → link → 検証）
+だけを実行する。通常経路ではない（通常はワンライナー再実行 = 冪等）。
+- **Don't call it:** stage 2, 後半モード, 対話モード
 
 ### `summary.txt`
 install.sh の各 run が `~/.dotfiles-install/<run-id>/` に残す機械可読サマリ

--- a/install.sh
+++ b/install.sh
@@ -1,28 +1,32 @@
 #!/bin/sh
-# 新 Mac の環境再現ブートストラップ（2 段階）。
+# 新 Mac の環境再現ブートストラップ（単一ステージ・無人一気通貫）。
 #
-# stage 1（初期化直後・無人。事前準備は「Terminal へフルディスクアクセス付与」と `sudo -v` のみ）:
+# 事前準備（初期化直後・在席。GUI 操作はここに全部front-load する）:
+#   1. システム設定 → プライバシーとセキュリティ → フルディスクアクセス → Terminal ON
+#      （付与後 Terminal を Cmd-Q で再起動）
+#   2. 1Password.app を手動インストール → iPhone の QR でサインイン → 設定 → 開発者 →
+#      SSH agent ON → セキュリティ → 自動ロックのタイマーを OFF（スリープ時ロックは残す）
+#      → `ssh -o StrictHostKeyChecking=accept-new -T git@github.com` を 1 回実行し、
+#      1Password の承認ダイアログで「すべてのアプリで承認する」+ 認証
+#   3. `sudo -v`（このあとのワンライナーと同じターミナルで）
+#
+# 実行（ここから先はパスワード入力・GUI 操作ゼロ。clone と claude-memory link まで完走）:
 #
 #   sudo -v && sh -c "$(curl -fsLS https://raw.githubusercontent.com/akira-toriyama/dotfiles/main/install.sh)"
 #
 #   CLT → workspace volume → Determinate Nix(.pkg) → repo clone → darwin-rebuild switch
-#   → chezmoi apply → 事後条件検証。終端は必ず「STAGE1-OK (phase 2 が残っている)」で、
-#   ここで ✓ 完了 とは言わない。
+#   → chezmoi apply → 1Password agent 経由 SSH 確認 → ghq-get-mine → claude-memory link
+#   → 事後条件検証。✓ 完了 は全 phase + 検証を通過した時だけ出る。
 #
-# stage 2（1Password の GUI 操作後・在席で実行）:
+# リカバリ入口（SSH gate で落ちた時など。前段 phase を再評価せず clone 以降だけ実行）:
 #
 #   sh ~/dotfiles/install.sh --phase2
 #
-#   1Password agent 経由の SSH を確認 → ghq-get-mine（全自リポジトリ clone）
-#   → claude-memory link → 事後条件検証。✓ 完了 はここでしか出ない。
-#
-# 2 段階の理由: 1Password がロック中だと SSH 署名が GUI ダイアログを出す（実機実証・
-# t-7h1t）。clone を無人 stage に置くと「実行中 GUI ゼロ」の MUST を破るため、
-# clone 以降を在席の stage 2 に分離する。
+# 同じワンライナーの再実行も安全（全 phase 冪等。導入済み部分は skip される）。
 #
 # 引数:
-#   --phase2       ... stage 2 を実行（stage 1 完了後・1Password サインイン + SSH agent ON 後）
-#   --skip-clone   ... (stage 2) ghq-get-mine を行わない。結果は必ず PARTIAL 止まり
+#   --phase2       ... clone 以降（SSH gate → ghq-get-mine → link → 検証）だけを実行
+#   --skip-clone   ... clone を行わない。結果は必ず PARTIAL 止まり（✓ 完了 は出ない）
 # 環境変数:
 #   BRANCH / REPO_DIR / FLAKE_USER / FLAKE_HOST / DOTFILES_LOG_DIR
 #   DOTFILES_SKIP_FDA_GATE=1 ... FDA preflight を飛ばす（VM 実験用）
@@ -38,11 +42,11 @@ FLAKE_HOST="${FLAKE_HOST:-default}"
 WORKSPACE_ROOT="/Volumes/workspace"
 HM_PATH="/etc/profiles/per-user/$USER/bin:/run/current-system/sw/bin:/nix/var/nix/profiles/default/bin"
 
-STAGE=1
+MODE=full
 SKIP_CLONE=0
 for arg in "$@"; do
   case "$arg" in
-    --phase2) STAGE=2 ;;
+    --phase2) MODE=phase2 ;;
     --skip-clone) SKIP_CLONE=1 ;;
     *)
       printf 'install.sh: 未知のオプション: %s (使えるのは --phase2 / --skip-clone のみ)\n' "$arg" >&2
@@ -57,7 +61,7 @@ done
 # - script(1) は pty を強制し nix 出力を ANSI/CR で汚す
 # → FIFO なら本体がトップレベルのまま = set -e / exit / trap がそのまま効く。
 DF_LOG_ROOT="${DOTFILES_LOG_DIR:-$HOME/.dotfiles-install}"
-DF_RUN_ID="$(date +%Y%m%d-%H%M%S)-stage$STAGE"
+DF_RUN_ID="$(date +%Y%m%d-%H%M%S)-$MODE"
 DF_RUN_DIR="$DF_LOG_ROOT/$DF_RUN_ID"
 DF_LOG="$DF_RUN_DIR/install.log"
 DF_EVENTS="$DF_RUN_DIR/events.tsv"
@@ -73,8 +77,8 @@ printf '#ts\ttype\tname\trc\n' >> "$DF_EVENTS"
 ln -sfn "$DF_RUN_ID" "$DF_LOG_ROOT/latest"
 
 # リダイレクト前に実端末へ出す（後段でハングしても在り処が分かる）
-echo "install.sh(stage $STAGE) log: $DF_LOG"
-echo "                     summary: $DF_LOG_ROOT/latest/summary.txt"
+echo "install.sh($MODE) log: $DF_LOG"
+echo "              summary: $DF_LOG_ROOT/latest/summary.txt"
 
 DF_FIFO_DIR="$(mktemp -d "${TMPDIR:-/tmp}/dfinstall.XXXXXX")"
 mkfifo -m 600 "$DF_FIFO_DIR/pipe"
@@ -160,8 +164,6 @@ df_finish() {
     df_verdict=ABORTED; df_rc=99
   elif [ "$DF_STEP_FAILURES" -gt 0 ]; then
     df_verdict=FAILED; df_rc=1
-  elif [ "$STAGE" = 1 ]; then
-    df_verdict=STAGE1-OK
   elif [ "$SKIP_CLONE" = 1 ]; then
     df_verdict=PARTIAL
   else
@@ -173,19 +175,14 @@ df_finish() {
   printf 'RESULT: %s (exit %s)\n' "$df_verdict" "$df_rc"
   awk -F'\t' '($2=="STEP"||$2=="CHECK") && $4!="0"{printf "FAIL %s\n", $3}' "$DF_EVENTS"
   case "$df_verdict" in
-    STAGE1-OK)
-      printf '%s\n' \
-        '' \
-        'stage 1 完了。まだ「✓ 完了」ではない。次の手動操作の後に stage 2 を実行:' \
-        '  1. 1Password.app を起動（switch で cask 導入済み）し、iPhone の QR でサインイン' \
-        '  2. 設定 → 開発者 → SSH agent を ON' \
-        "  3. sh $REPO_DIR/install.sh --phase2" ;;
     OK)
       printf '\n✓ 完了。全 phase + 事後条件検証を通過。新しいターミナルを開いて使用開始。\n' ;;
     PARTIAL)
       printf '\nPARTIAL: --skip-clone のため未完（ghq-get-mine と claude-memory link が残っている）\n' ;;
     *)
-      printf '\nNEXT: 上の FAIL を直し、同じコマンドを再実行（冪等）。詳細: %s\n' "$DF_SUMMARY" ;;
+      printf '\nNEXT: 上の FAIL を直し、同じコマンドを再実行（冪等）。\n'
+      printf '     SSH gate (P-onepassword) 起因なら 1Password の サインイン / SSH agent ON /\n'
+      printf '     鍵承認 を確認して "sh %s/install.sh --phase2" が最短。詳細: %s\n' "$REPO_DIR" "$DF_SUMMARY" ;;
   esac
   printf 'summary: %s\nlog:     %s\n' "$DF_SUMMARY" "$DF_LOG"
 
@@ -195,7 +192,7 @@ df_finish() {
   {
     echo "result=$df_verdict"
     echo "exit_code=$df_rc"
-    echo "stage=$STAGE"
+    echo "mode=$MODE"
     echo "step_failures=$DF_STEP_FAILURES"
     printf 'failed=%s\n' \
       "$(awk -F'\t' '($2=="STEP"||$2=="CHECK") && $4!="0"{printf "%s ", $3}' "$DF_EVENTS")"
@@ -204,7 +201,6 @@ df_finish() {
     echo "run_id=$DF_RUN_ID"
     echo "log=$DF_LOG"
     echo "events=$DF_EVENTS"
-    [ "$df_verdict" = STAGE1-OK ] && echo "next=phase2"
     echo "--- steps ---"
     awk -F'\t' '$2=="STEP"||$2=="CHECK"{printf "%-4s %s rc=%s\n", ($4=="0"?"ok":"FAIL"), $3, $4}' "$DF_EVENTS"
     awk -F'\t' '$2=="STEP" && $4!="0"{print $3}' "$DF_EVENTS" | while IFS= read -r df_f; do
@@ -217,7 +213,7 @@ df_finish() {
     tail -n 40 "$DF_LOG" 2>/dev/null
   } > "$DF_SUMMARY" 2>&1
 
-  printf 'install.sh(stage %s): RESULT %s (exit %s) — %s\n' "$STAGE" "$df_verdict" "$df_rc" "$DF_SUMMARY" >&3
+  printf 'install.sh(%s): RESULT %s (exit %s) — %s\n' "$MODE" "$df_verdict" "$df_rc" "$DF_SUMMARY" >&3
   exit "$df_rc"
 }
 trap df_finish EXIT
@@ -225,23 +221,30 @@ trap 'exit 130' INT
 trap 'exit 143' TERM
 # ===== logging prelude ここまで =====
 
-# ── stage 2 ──────────────────────────────────────────────────────────────────
-if [ "$STAGE" = 2 ]; then
+# ── clone 以降（full の終盤 と --phase2 の両方から呼ぶ）───────────────────────────
+run_clone_phases() {
   df_phase onepassword
-  # ssh-add -l はロック中でも成功する偽陽性なので使わない（t-7h1t）。
-  # 実署名で判定する。ロック中なら 1Password が解錠ダイアログを出す —— stage 2 は
-  # 在席実行が前提なのでそれで良い（無人の stage 1 に GUI を出さないための分離）。
+  # ssh-add -l はロック中でも成功する偽陽性なので使わない。実署名で判定する。
+  # agent がロック中だと ssh は GUI 承認待ちで無期限ブロックし得るため、watchdog で
+  # 75 秒に制限する（ConnectTimeout は TCP にしか効かない。timeout(1) は macOS に無い）。
   OP_SOCK="$HOME/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock"
   if [ ! -S "$OP_SOCK" ]; then
-    df_check_fail P2-agent-sock "1Password SSH agent socket が無い。設定 → 開発者 → SSH agent を ON にすること"
+    df_check_fail P-onepassword "1Password SSH agent socket が無い（設定 → 開発者 → SSH agent を ON に）"
     exit 1
   fi
-  df_check_ok P2-agent-sock "agent socket あり"
-  if df_step ssh-github plain sh -c \
-      'ssh -o ConnectTimeout=15 -T git@github.com 2>&1 | grep -q "successfully authenticated"'; then
-    df_check_ok P2-ssh "1Password agent 経由で GitHub 認証成功"
+  gate_out="$DF_RUN_DIR/ssh-gate.out"
+  ssh -o StrictHostKeyChecking=accept-new -o ConnectTimeout=15 -T git@github.com \
+    > "$gate_out" 2>&1 &
+  gate_pid=$!
+  ( sleep 75; kill "$gate_pid" 2>/dev/null ) &
+  gate_watchdog=$!
+  wait "$gate_pid" 2>/dev/null || :
+  kill "$gate_watchdog" 2>/dev/null || :
+  if grep -q "successfully authenticated" "$gate_out"; then
+    df_check_ok P-onepassword "1Password agent 経由で GitHub 認証成功"
   else
-    df_check_fail P2-ssh "GitHub SSH 認証失敗。1Password のサインイン / SSH agent ON / 鍵の GitHub 登録を確認"
+    df_check_fail P-onepassword "GitHub SSH 認証失敗/タイムアウト（1Password のロック解除・SSH agent ON・鍵承認を確認）"
+    sed 's/^/    | /' "$gate_out" | tail -n 3
     exit 1
   fi
 
@@ -254,7 +257,7 @@ if [ "$STAGE" = 2 ]; then
     df_step link-claude-memory plain env PATH="$HM_PATH:$PATH" link-claude-memory || :
   fi
 
-  df_phase verify2
+  df_phase verify-clone
   # V5a: 自作 CLI ラッパが hardcode する source clone の実在
   v5_missing=""
   for r in furrow pare cifail rundiff revpost projects claude-memory; do
@@ -281,7 +284,7 @@ if [ "$STAGE" = 2 ]; then
       df_check_fail V5b-clone "gh repo list が空。clone 完全性を検証できていない"
     fi
   else
-    df_check_fail V5b-gh "gh 未認証（stage 2 前に gh auth login するか、後で再実行）"
+    df_check_fail V5b-gh "gh 未認証（gh auth login 後に --phase2 で再実行）"
   fi
   # V7: claude-memory link（「完了」の定義に含まれる）
   slug=$(printf '%s' "$HOME" | tr / -)
@@ -291,12 +294,16 @@ if [ "$STAGE" = 2 ]; then
   else
     df_check_fail V7-claude-memory "$mem が生きた symlink でない（link-claude-memory を確認）"
   fi
+}
 
+# ── リカバリ入口: clone 以降だけ ─────────────────────────────────────────────
+if [ "$MODE" = phase2 ]; then
+  run_clone_phases
   DF_REACHED_END=1
   exit 0
 fi
 
-# ── stage 1 ──────────────────────────────────────────────────────────────────
+# ── full run ─────────────────────────────────────────────────────────────────
 
 df_phase pre
 # 再実行 self-heal: 前回 SIGKILL 死などで残った drop-in を除去（この時点では
@@ -325,7 +332,8 @@ fi
 # なので、以降すべての sudo は -n 固定 = プロンプト事象を即時の非ゼロに変換する。
 export SUDO_ASKPASS=/usr/bin/false
 if ! sudo -n true 2>/dev/null; then
-  df_say "✘ sudo チケットが無い。先に \`sudo -v\` を実行し、同じターミナルで再実行すること"
+  df_check_fail P1-sudo "sudo チケットが無い"
+  df_say "  先に \`sudo -v\` を実行し、同じターミナルで再実行すること"
   exit 1
 fi
 
@@ -501,7 +509,7 @@ df_step chezmoi-apply quiet env \
   PATH="$HM_PATH:$PATH" \
   chezmoi --source "$REPO_DIR/chezmoi" apply --verbose || :
 
-df_phase verify1
+df_phase verify-system
 # 「終わった」を主張する前に事実を確認する。/etc/profiles/per-user/$USER/bin に
 # コマンドが揃うのは useUserPackages 由来で activation 中断でも起きる＝証拠にならない
 # （2026-07-18 の誤診の元）。以下は home-manager activation の実走を直接見る。
@@ -582,5 +590,8 @@ if [ -x /opt/homebrew/bin/brew ]; then
 else
   df_check_fail V6-brew "/opt/homebrew/bin/brew が無い"
 fi
+
+# ── clone 以降（事前準備で 1Password が生きていればここまで無人で完走する）────────
+run_clone_phases
 
 DF_REACHED_END=1

--- a/install.sh
+++ b/install.sh
@@ -6,9 +6,15 @@
 #      （付与後 Terminal を Cmd-Q で再起動）
 #   2. 1Password.app を手動インストール → iPhone の QR でサインイン → 設定 → 開発者 →
 #      SSH agent ON → セキュリティ → 自動ロックのタイマーを OFF（スリープ時ロックは残す）
+#      → ~/.ssh/config に IdentityAgent 行があることを確認（1Password が設定画面で示す
+#        snippet。無ければその内容で作る。これが無いと ssh は素の macOS agent(鍵ゼロ)を向く）
 #      → `ssh -o StrictHostKeyChecking=accept-new -T git@github.com` を 1 回実行し、
 #      1Password の承認ダイアログで「すべてのアプリで承認する」+ 認証
-#   3. `sudo -v`（このあとのワンライナーと同じターミナルで）
+#   3. GitHub fine-grained PAT（All repositories / Metadata: Read-only で足りる。t-8f19）を
+#      1Password からコピーし、ワンライナーと同じターミナルで `export GH_TOKEN=<PAT>`
+#      （ghq-get-mine の repo 一覧取得と clone 完全性検証が gh API を使うため。無いと
+#      ✓ 完了 に到達できないので P1-ghtoken で即 fail する）
+#   4. `sudo -v`（このあとのワンライナーと同じターミナルで）
 #
 # 実行（ここから先はパスワード入力・GUI 操作ゼロ。clone と claude-memory link まで完走）:
 #
@@ -26,7 +32,8 @@
 #
 # 引数:
 #   --phase2       ... clone 以降（SSH gate → ghq-get-mine → link → 検証）だけを実行
-#   --skip-clone   ... clone を行わない。結果は必ず PARTIAL 止まり（✓ 完了 は出ない）
+#   --skip-clone   ... SSH gate・clone・clone 検証を行わない（VM 実験用）。
+#                      結果は最大でも PARTIAL（✓ 完了 は出ない）
 # 環境変数:
 #   BRANCH / REPO_DIR / FLAKE_USER / FLAKE_HOST / DOTFILES_LOG_DIR
 #   DOTFILES_SKIP_FDA_GATE=1 ... FDA preflight を飛ばす（VM 実験用）
@@ -111,10 +118,16 @@ df_phase() {
 # df_step <name> <plain|quiet> <cmd...>
 #   quiet は出力を detail/<name>.log へ隔離（chezmoi の 3000 行 diff などのノイズ対策）。
 #   引数は events.tsv に書かない（secret が argv に載り得るため。house rule）。
-df_step() {
-  df_step_name="$1"
-  df_step_mode="$2"
-  shift 2
+# df_step_try = リトライ前提の 1 試行。events には TRY で記録し DF_STEP_FAILURES に
+#   数えない（数えると「attempt 1 失敗 → attempt 2 成功」の正常回復まで RESULT が
+#   FAILED になる偽失敗が出る。成否の正本は各 phase 末尾の df_check_ok/fail）。
+df_step()     { df_step_impl STEP "$@"; }
+df_step_try() { df_step_impl TRY "$@"; }
+df_step_impl() {
+  df_step_evt="$1"
+  df_step_name="$2"
+  df_step_mode="$3"
+  shift 3
   printf '%s\tSTEP_START\t%s\t-\n' "$(df_now)" "$df_step_name" >> "$DF_EVENTS"
   df_say "--- step $df_step_name"
   if [ "$df_step_mode" = quiet ]; then
@@ -128,10 +141,14 @@ df_step() {
   else
     if "$@"; then df_step_rc=0; else df_step_rc=$?; fi
   fi
-  printf '%s\tSTEP\t%s\t%s\n' "$(df_now)" "$df_step_name" "$df_step_rc" >> "$DF_EVENTS"
+  printf '%s\t%s\t%s\t%s\n' "$(df_now)" "$df_step_evt" "$df_step_name" "$df_step_rc" >> "$DF_EVENTS"
   if [ "$df_step_rc" -ne 0 ]; then
-    DF_STEP_FAILURES=$((DF_STEP_FAILURES + 1))
-    df_say "STEP-FAIL $df_step_name rc=$df_step_rc"
+    if [ "$df_step_evt" = STEP ]; then
+      DF_STEP_FAILURES=$((DF_STEP_FAILURES + 1))
+      df_say "STEP-FAIL $df_step_name rc=$df_step_rc"
+    else
+      df_say "try-fail $df_step_name rc=$df_step_rc（リトライ/フォールバックで回復を試みる）"
+    fi
   fi
   return "$df_step_rc"
 }
@@ -202,7 +219,8 @@ df_finish() {
     echo "log=$DF_LOG"
     echo "events=$DF_EVENTS"
     echo "--- steps ---"
-    awk -F'\t' '$2=="STEP"||$2=="CHECK"{printf "%-4s %s rc=%s\n", ($4=="0"?"ok":"FAIL"), $3, $4}' "$DF_EVENTS"
+    awk -F'\t' '$2=="STEP"||$2=="CHECK"{printf "%-4s %s rc=%s\n", ($4=="0"?"ok":"FAIL"), $3, $4}
+                $2=="TRY"{printf "%-4s %s rc=%s\n", ($4=="0"?"ok":"try"), $3, $4}' "$DF_EVENTS"
     awk -F'\t' '$2=="STEP" && $4!="0"{print $3}' "$DF_EVENTS" | while IFS= read -r df_f; do
       if [ -f "$DF_DETAIL/$df_f.log" ]; then
         echo "--- detail/$df_f.log (last 30) ---"
@@ -221,8 +239,122 @@ trap 'exit 130' INT
 trap 'exit 143' TERM
 # ===== logging prelude ここまで =====
 
+# ── 共有ヘルパ（full と --phase2 の両方が使う）─────────────────────────────────
+# CLT 判定。/usr/bin/git は shim（実行すると CLT 不在時に GUI ダイアログ）なので
+# 判定に使わない。phase2 でも git を叩く前に必ずこれで確認する。
+CLT_DIR=/Library/Developer/CommandLineTools
+clt_ok() {
+  [ -x "$CLT_DIR/usr/bin/git" ] && return 0
+  clt_dp=$(/usr/bin/xcode-select -p 2>/dev/null) || return 1
+  [ -n "$clt_dp" ] && [ -x "$clt_dp/usr/bin/git" ]
+}
+
+# gh 認証の前提 gate。ghq-get-mine（gh repo list）と V5b が gh API を必要とし、
+# 無いと ✓ 完了 に構造的に到達できないため、長い phase に入る前に即 fail させる。
+df_gate_ghtoken() {
+  if [ -n "${GH_TOKEN:-}${GITHUB_TOKEN:-}" ]; then
+    df_check_ok P1-ghtoken "GH_TOKEN/GITHUB_TOKEN あり"
+  elif env PATH="$HM_PATH:$PATH" gh auth status >/dev/null 2>&1; then
+    df_check_ok P1-ghtoken "gh auth 済み"
+  else
+    df_check_fail P1-ghtoken "gh の認証が無い"
+    df_say "  fine-grained PAT（All repositories / Metadata: Read-only）を 1Password からコピーし、"
+    df_say "  \`export GH_TOKEN=<PAT>\` してから再実行すること（事前準備 3）"
+    exit 1
+  fi
+}
+
+# ── 事後条件検証（システム層）。full の終盤 と --phase2 の両方から呼ぶ ──────────────
+run_verify_system() {
+  df_phase verify-system
+  # 「終わった」を主張する前に事実を確認する。/etc/profiles/per-user/$USER/bin に
+  # コマンドが揃うのは useUserPackages 由来で activation 中断でも起きる＝証拠にならない
+  # （2026-07-18 の誤診の元）。以下は home-manager activation の実走を直接見る。
+  hm_state="${XDG_STATE_HOME:-$HOME/.local/state}/home-manager"
+  gcroot="$hm_state/gcroots/current-home"
+  expect_gen=""
+  act=$(grep -o "/nix/store/[a-z0-9]*-activation-$USER" /run/current-system/activate 2>/dev/null | head -1 || :)
+  [ -n "$act" ] && expect_gen=$(grep -o '/nix/store/[a-z0-9]*-home-manager-generation' "$act" 2>/dev/null | head -1 || :)
+  if [ ! -e "$gcroot" ]; then
+    df_check_fail V1-hm-activation "$gcroot が無い = home-manager activation が完走していない"
+  elif [ -n "$expect_gen" ] && [ "$(readlink -f "$gcroot" 2>/dev/null)" != "$expect_gen" ]; then
+    df_check_fail V1-hm-stale "home-manager 世代が古い: actual=$(readlink -f "$gcroot" 2>/dev/null) expected=$expect_gen"
+  else
+    df_check_ok V1-hm-activation "home-manager activation 完走"
+  fi
+
+  # V2: user layer の実体。期待リストは手書きせず現世代から導出（drift しない）
+  if [ -n "$expect_gen" ] && [ -d "$expect_gen/home-files" ]; then
+    ( cd "$expect_gen/home-files" && find . \( -type f -o -type l \) | sed 's|^\./||' ) \
+      > "$DF_RUN_DIR/expected-home-files"
+    v2_missing=0
+    while IFS= read -r rel; do
+      [ -e "$HOME/$rel" ] || { v2_missing=$((v2_missing + 1)); df_say "    missing: ~/$rel"; }
+    done < "$DF_RUN_DIR/expected-home-files"
+    if [ "$v2_missing" -gt 0 ]; then
+      df_check_fail V2-home-files "$v2_missing 件の home file 欠落"
+    else
+      df_check_ok V2-home-files "$(wc -l < "$DF_RUN_DIR/expected-home-files" | tr -d ' ') files"
+    fi
+  else
+    df_check_fail V2-home-files "期待ファイル一覧を導出できない（世代パス不明 = V1 を先に直す）"
+  fi
+
+  # (V3 旧 hm-profile チェックは撤去: nix-darwin + useUserPackages 構成の home-manager は
+  #  profile を ~/.local/state/nix/profiles にも /nix/var/nix/profiles/per-user にも
+  #  作らない（gcroots/current-home のみ）。Tart VM の健全なフル実行で実測確認 2026-07-19。
+  #  残すと恒久 false FAIL で ✓ 完了 が構造的に出なくなる。activation の witness は V1/V2。）
+
+  # V4: workspace volume + ghq root。GHQ_ROOT は export しない —— env は git config に
+  # 勝つため、壊れた home-manager 層を覆い隠して「壊れた環境に正しく clone」する
+  # 2026-07-18 を再現してしまう。ghq root は home-manager 完走の witness として読む。
+  if ! diskutil info "$WORKSPACE_ROOT" 2>/dev/null | grep -q 'Case-sensitive'; then
+    df_check_fail V4-workspace "$WORKSPACE_ROOT が case-sensitive APFS として存在しない"
+  fi
+  ghq_root=$(env PATH="$HM_PATH:$PATH" ghq root 2>/dev/null || :)
+  if [ "$ghq_root" = "$WORKSPACE_ROOT" ]; then
+    df_check_ok V4-ghq-root "$ghq_root"
+  else
+    df_check_fail V4-ghq-root "ghq root='$ghq_root'（期待 $WORKSPACE_ROOT）。~/.config/git/config 欠落 = V1 の実害"
+  fi
+
+  # V6: brew の宣言 vs 実体（期待値は flake から導出。ci.yml の cask 検証と同じ流儀。
+  # flake 参照は $REPO_DIR 明示 —— `.#` だと cwd 依存になり --phase2（任意 cwd）で壊れる）
+  if [ -x /opt/homebrew/bin/brew ]; then
+    for kind in brews casks; do
+      env PATH="$HM_PATH:$PATH" nix eval --impure --json \
+        "$REPO_DIR#darwinConfigurations.${FLAKE_HOST}.config.homebrew.${kind}" 2>/dev/null \
+        | env PATH="$HM_PATH:$PATH" jq -r '.[] | if type=="string" then . else .name end' \
+        | sed 's|.*/||' | sort > "$DF_RUN_DIR/expected-$kind" || :
+      if [ "$kind" = brews ]; then
+        /opt/homebrew/bin/brew list --formula 2>/dev/null | sort > "$DF_RUN_DIR/actual-$kind" || :
+      else
+        /opt/homebrew/bin/brew list --cask 2>/dev/null | sort > "$DF_RUN_DIR/actual-$kind" || :
+      fi
+      if [ ! -s "$DF_RUN_DIR/expected-$kind" ]; then
+        df_check_fail "V6-$kind" "期待 $kind を flake から導出できない"
+        continue
+      fi
+      comm -23 "$DF_RUN_DIR/expected-$kind" "$DF_RUN_DIR/actual-$kind" > "$DF_RUN_DIR/missing-$kind"
+      if [ -s "$DF_RUN_DIR/missing-$kind" ]; then
+        df_check_fail "V6-$kind" "未 install: $(tr '\n' ' ' < "$DF_RUN_DIR/missing-$kind")"
+      else
+        df_check_ok "V6-$kind" "全 $(wc -l < "$DF_RUN_DIR/expected-$kind" | tr -d ' ') 件"
+      fi
+    done
+  else
+    df_check_fail V6-brew "/opt/homebrew/bin/brew が無い"
+  fi
+}
+
 # ── clone 以降（full の終盤 と --phase2 の両方から呼ぶ）───────────────────────────
 run_clone_phases() {
+  if [ "$SKIP_CLONE" = 1 ]; then
+    df_phase clone
+    df_say "--skip-clone 指定 → SSH gate / ghq-get-mine / clone 検証を行わない（RESULT は最大 PARTIAL）"
+    return 0
+  fi
+
   df_phase onepassword
   # ssh-add -l はロック中でも成功する偽陽性なので使わない。実署名で判定する。
   # agent がロック中だと ssh は GUI 承認待ちで無期限ブロックし得るため、watchdog で
@@ -233,44 +365,56 @@ run_clone_phases() {
     exit 1
   fi
   gate_out="$DF_RUN_DIR/ssh-gate.out"
-  ssh -o StrictHostKeyChecking=accept-new -o ConnectTimeout=15 -T git@github.com \
+  ssh -n -o StrictHostKeyChecking=accept-new -o ConnectTimeout=15 -T git@github.com \
     > "$gate_out" 2>&1 &
   gate_pid=$!
-  ( sleep 75; kill "$gate_pid" 2>/dev/null ) &
+  # watchdog の fd を FIFO から切り離す（>/dev/null 2>&1）。切り離さないと kill 後も
+  # orphan の sleep が FIFO の write 端を掴み、df_finish の wait(tee) が最大 75 秒止まる
+  ( sleep 75; kill "$gate_pid" 2>/dev/null ) >/dev/null 2>&1 &
   gate_watchdog=$!
   wait "$gate_pid" 2>/dev/null || :
   kill "$gate_watchdog" 2>/dev/null || :
   if grep -q "successfully authenticated" "$gate_out"; then
     df_check_ok P-onepassword "1Password agent 経由で GitHub 認証成功"
   else
-    df_check_fail P-onepassword "GitHub SSH 認証失敗/タイムアウト（1Password のロック解除・SSH agent ON・鍵承認を確認）"
+    df_check_fail P-onepassword "GitHub SSH 認証失敗/タイムアウト（1Password のロック解除・SSH agent ON・鍵承認・~/.ssh/config の IdentityAgent を確認）"
     sed 's/^/    | /' "$gate_out" | tail -n 3
     exit 1
   fi
 
   df_phase clone
-  if [ "$SKIP_CLONE" = 1 ]; then
-    df_say "--skip-clone 指定 → ghq-get-mine を実行しない（RESULT は PARTIAL 止まり）"
-  else
-    # ghq-get-mine 自身が ghq root != /Volumes/workspace で hard fail する安全弁を持つ
-    df_step ghq-get-mine quiet env PATH="$HM_PATH:$PATH" ghq-get-mine || exit 1
-    df_step link-claude-memory plain env PATH="$HM_PATH:$PATH" link-claude-memory || :
+  if ! clt_ok; then
+    df_check_fail P-clt "CLT が無い（--phase2 は full run 完了後のリカバリ入口。先にワンライナーを実行）"
+    exit 1
   fi
+  # SIGKILL 死の壊れ clone（.git はあるが HEAD 不能）を退避してから ghq に再 clone させる。
+  # 放置すると ghq get は「exists」で skip し、V5a の存在チェックも通ってしまう
+  for d in "$WORKSPACE_ROOT/github.com/$GITHUB_USERNAME"/*; do
+    [ -d "$d/.git" ] || continue
+    git -C "$d" rev-parse --verify -q HEAD >/dev/null 2>&1 && continue
+    df_say "壊れた clone を退避: $d -> $d.broken-$DF_RUN_ID"
+    mv "$d" "$d.broken-$DF_RUN_ID" || :
+  done
+  # ghq-get-mine 自身が ghq root != /Volumes/workspace で hard fail する安全弁を持つ
+  df_step ghq-get-mine quiet env PATH="$HM_PATH:$PATH" ghq-get-mine || exit 1
+  df_step link-claude-memory plain env PATH="$HM_PATH:$PATH" link-claude-memory || :
 
   df_phase verify-clone
-  # V5a: 自作 CLI ラッパが hardcode する source clone の実在
+  # V5a: 自作 CLI ラッパが hardcode する source clone の実在（HEAD 解決まで確認）
   v5_missing=""
   for r in furrow pare cifail rundiff revpost projects claude-memory; do
-    [ -d "$WORKSPACE_ROOT/github.com/$GITHUB_USERNAME/$r/.git" ] || v5_missing="$v5_missing $r"
+    git -C "$WORKSPACE_ROOT/github.com/$GITHUB_USERNAME/$r" rev-parse --verify -q HEAD \
+      >/dev/null 2>&1 || v5_missing="$v5_missing $r"
   done
   if [ -n "$v5_missing" ]; then
-    df_check_fail V5a-wrapper-src "自作 CLI の source 未 clone:$v5_missing"
+    df_check_fail V5a-wrapper-src "自作 CLI の source が無い/壊れている:$v5_missing"
   else
     df_check_ok V5a-wrapper-src "全 wrapper source clone 済み"
   fi
-  # V5b: gh repo list との全件突き合わせ
+  # V5b: gh repo list との全件突き合わせ（limit はソース側 ghq-get-mine の 200 より広く
+  # 取り、200 超で検証が空振りになる縮退を検出できるようにする）
   if env PATH="$HM_PATH:$PATH" gh auth status >/dev/null 2>&1; then
-    env PATH="$HM_PATH:$PATH" gh repo list "$GITHUB_USERNAME" --no-archived --limit 200 \
+    env PATH="$HM_PATH:$PATH" gh repo list "$GITHUB_USERNAME" --no-archived --limit 1000 \
       --json nameWithOwner --jq '.[].nameWithOwner' 2>/dev/null | sort > "$DF_RUN_DIR/expected-repos" || :
     env PATH="$HM_PATH:$PATH" ghq list 2>/dev/null | sed 's|^github.com/||' | sort > "$DF_RUN_DIR/actual-repos" || :
     if [ -s "$DF_RUN_DIR/expected-repos" ]; then
@@ -284,7 +428,7 @@ run_clone_phases() {
       df_check_fail V5b-clone "gh repo list が空。clone 完全性を検証できていない"
     fi
   else
-    df_check_fail V5b-gh "gh 未認証（gh auth login 後に --phase2 で再実行）"
+    df_check_fail V5b-gh "gh 未認証（GH_TOKEN を export するか gh auth login 後に --phase2 で再実行）"
   fi
   # V7: claude-memory link（「完了」の定義に含まれる）
   slug=$(printf '%s' "$HOME" | tr / -)
@@ -298,6 +442,21 @@ run_clone_phases() {
 
 # ── リカバリ入口: clone 以降だけ ─────────────────────────────────────────────
 if [ "$MODE" = phase2 ]; then
+  df_phase pre
+  # full run が SIGKILL 死した後に --phase2 へ来た場合の drop-in self-heal。
+  # 消せない（sudo チケット無し）なら FAIL を記録して ✓ 完了 を出さない
+  # （NOPASSWD:SETENV ALL を残したまま「完了」は宣言しない）
+  if [ -f "$SUDOERS_DROPIN" ]; then
+    df_say "前回の sudoers drop-in が残っている → 除去を試みる"
+    sudo -n rm -f "$SUDOERS_DROPIN" 2>/dev/null || :
+    if [ -f "$SUDOERS_DROPIN" ]; then
+      df_check_fail P-sudoers-residue "$SUDOERS_DROPIN が残存。\`sudo rm $SUDOERS_DROPIN\` を手動実行すること"
+    else
+      df_say "sudoers drop-in 削除済み（self-heal）"
+    fi
+  fi
+  [ "$SKIP_CLONE" = 1 ] || df_gate_ghtoken
+  run_verify_system
   run_clone_phases
   DF_REACHED_END=1
   exit 0
@@ -337,6 +496,9 @@ if ! sudo -n true 2>/dev/null; then
   exit 1
 fi
 
+# gh 認証 gate（15 分の nix/switch を走らせてから ghq-get-mine で落ちるのを防ぐ）
+[ "$SKIP_CLONE" = 1 ] || df_gate_ghtoken
+
 # bootstrap 用 sudoers drop-in。keepalive だけでは不足する（実測 2 系統）:
 #   - macOS 26 の sudo は use_pty 既定 ON → sudo ごとに新 pty/session でチケット不継承
 #   - brew は起動のたび sudo --reset-timestamp を叩きチケットを殺す
@@ -358,14 +520,8 @@ rm -f "$df_sudo_tmp"
 
 df_phase clt
 # headless CLT: sentinel で softwareupdate に CLT ラベルを出させて -i する。
-# /usr/bin/git は shim（実行すると CLT 不在時に GUI ダイアログ）なので判定に使わない。
-CLT_DIR=/Library/Developer/CommandLineTools
+# clt_ok は共有ヘルパ節で定義済み（/usr/bin/git shim は判定に使わない）。
 CLT_SENTINEL=/tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress
-clt_ok() {
-  [ -x "$CLT_DIR/usr/bin/git" ] && return 0
-  clt_dp=$(/usr/bin/xcode-select -p 2>/dev/null) || return 1
-  [ -n "$clt_dp" ] && [ -x "$clt_dp/usr/bin/git" ]
-}
 clt_pick_label() {
   # macOS 26 は複数ラベルを同時提示する（26.5 / 26.6 を実測）。beta を除き最新を
   # sort -V で選ぶ（lexical だと 26.9 > 26.10 になる罠）。
@@ -389,7 +545,7 @@ else
       continue
     fi
     df_say "  label: $clt_label"
-    df_step "clt-install-$clt_attempt" quiet sudo -n /usr/sbin/softwareupdate --install "$clt_label" || :
+    df_step_try "clt-install-$clt_attempt" quiet sudo -n /usr/sbin/softwareupdate --install "$clt_label" || :
     [ -d "$CLT_DIR" ] && sudo -n /usr/bin/xcode-select --switch "$CLT_DIR" 2>/dev/null || :
     sudo -n rm -f "$CLT_SENTINEL" 2>/dev/null || :
     clt_ok && break
@@ -422,6 +578,19 @@ df_phase nix
 # Determinate は .pkg 経路（curl|sh は素の Rust バイナリのみで、/nix 不在時の
 # 「捨て volume を add/delete して回復する」postinstall 前処理が無い = run 1 の敗因。
 # run 2 は手動 .pkg で成功しており、同機構を headless で使う）。
+# 再実行の fresh sh は nix を知らないので、導入済み判定の前に profile を source する
+# （しないと毎回 .pkg を再ダウンロード・再インストールする無駄が出る）
+if [ -f /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh ]; then
+  # shellcheck disable=SC1091
+  . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+fi
+# download は .part へ落として mv（atomic）。中断の部分ファイルを完成品と誤認しない
+nix_pkg="$DF_RUN_DIR/Determinate.pkg"
+nix_pkg_download() {
+  curl --proto '=https' --tlsv1.2 -fsSL -o "$nix_pkg.part" \
+    https://install.determinate.systems/determinate-pkg/stable/Universal \
+    && mv -f "$nix_pkg.part" "$nix_pkg"
+}
 if command -v nix >/dev/null 2>&1 && [ -d /nix ]; then
   df_say "nix 導入済み → skip"
 else
@@ -429,13 +598,11 @@ else
   while [ "$nix_attempt" -lt 2 ]; do
     nix_attempt=$((nix_attempt + 1))
     df_say "Determinate .pkg install 試行 $nix_attempt/2"
-    if [ ! -f "$DF_RUN_DIR/Determinate.pkg" ]; then
-      df_step "nix-pkg-download-$nix_attempt" plain \
-        curl --proto '=https' --tlsv1.2 -fsSL -o "$DF_RUN_DIR/Determinate.pkg" \
-        https://install.determinate.systems/determinate-pkg/stable/Universal || { sleep 10; continue; }
+    if [ ! -f "$nix_pkg" ]; then
+      df_step_try "nix-pkg-download-$nix_attempt" plain nix_pkg_download || { sleep 10; continue; }
     fi
-    df_step "nix-pkg-install-$nix_attempt" quiet \
-      sudo -n /usr/sbin/installer -pkg "$DF_RUN_DIR/Determinate.pkg" -target / || { sleep 10; continue; }
+    df_step_try "nix-pkg-install-$nix_attempt" quiet \
+      sudo -n /usr/sbin/installer -pkg "$nix_pkg" -target / || { sleep 10; continue; }
     break
   done
   if [ -f /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh ]; then
@@ -451,6 +618,12 @@ else
 fi
 
 df_phase repo
+# SIGKILL 死の壊れ clone（.git はあるが HEAD 不能 = git clone の途中死）を退避して
+# clone し直す。放置すると以後の全再実行が switch で同じ失敗を繰り返し、収束しない
+if [ -d "$REPO_DIR/.git" ] && ! git -C "$REPO_DIR" rev-parse --verify -q HEAD >/dev/null 2>&1; then
+  df_say "壊れた clone（前回中断の残骸）を退避: $REPO_DIR -> $REPO_DIR.broken-$DF_RUN_ID"
+  mv "$REPO_DIR" "$REPO_DIR.broken-$DF_RUN_ID"
+fi
 if [ ! -d "$REPO_DIR/.git" ]; then
   df_step git-clone plain \
     git clone -b "$BRANCH" "https://github.com/${GITHUB_USERNAME}/dotfiles.git" "$REPO_DIR" || exit 1
@@ -467,129 +640,49 @@ switch_cmd() {
   sudo -n USER="$USER" FLAKE_USER="${FLAKE_USER:-}" \
     nix run "$REPO_DIR#darwin-rebuild" -- switch --flake "$REPO_DIR#$FLAKE_HOST" --impure
 }
-if df_step darwin-switch plain switch_cmd; then
+# 初回は TRY（fallback+retry で回復し得る）。retry まで失敗したら STEP として数える
+if df_step_try darwin-switch plain switch_cmd; then
   :
 else
   # フォールバック: nix-darwin の brew bundle は fetch all → install all 設計で、
-  # 1 件の失敗が全 install を道連れにする。Brewfile を parse して tap → formula →
-  # cask を個別 install し、その後 switch をもう 1 回だけ試す（bounded retry）。
+  # 1 件の失敗が全 install を道連れにする。tap → formula → cask を個別 install し、
+  # その後 switch をもう 1 回だけ試す（bounded retry）。
+  # 対象リストは flake から nix eval で導出する —— /nix/store の *-Brewfile を find で
+  # 拾う方式は複数世代あると任意の（stale な）1 つを掴む。V6 と同じ流儀で正本から引く
   df_say "switch 失敗 → per-item brew フォールバック + bounded retry"
-  BREWFILE=$(/usr/bin/find /nix/store -maxdepth 1 -name '*-Brewfile' -print 2>/dev/null | head -1)
-  if [ -n "$BREWFILE" ] && [ -x /opt/homebrew/bin/brew ]; then
-    /usr/bin/grep '^tap "' "$BREWFILE" | /usr/bin/sed 's/tap "\([^"]*\)".*/\1/' | while IFS= read -r tap; do
-      [ -z "$tap" ] && continue
-      if /opt/homebrew/bin/brew tap "$tap" >/dev/null 2>&1; then
-        df_say "  ✓ tap $tap"
-      else
-        df_say "  ✘ tap $tap 失敗"
-      fi
-    done
-    /usr/bin/grep '^brew "' "$BREWFILE" | /usr/bin/sed 's/brew "\([^"]*\)".*/\1/' | while IFS= read -r formula; do
-      [ -z "$formula" ] && continue
-      if /opt/homebrew/bin/brew install --formula "$formula" >/dev/null 2>&1; then
-        df_say "  ✓ brew $formula"
-      else
-        df_say "  ✘ brew $formula 失敗"
-      fi
-    done
-    /usr/bin/grep '^cask "' "$BREWFILE" | /usr/bin/sed 's/cask "\([^"]*\)".*/\1/' | while IFS= read -r cask; do
-      [ -z "$cask" ] && continue
-      if /opt/homebrew/bin/brew install --cask "$cask" >/dev/null 2>&1; then
-        df_say "  ✓ cask $cask"
-      else
-        df_say "  ✘ cask $cask 失敗"
-      fi
+  if [ -x /opt/homebrew/bin/brew ]; then
+    for bf_kind in taps brews casks; do
+      env PATH="$HM_PATH:$PATH" nix eval --impure --json \
+        "$REPO_DIR#darwinConfigurations.${FLAKE_HOST}.config.homebrew.${bf_kind}" 2>/dev/null \
+        | env PATH="$HM_PATH:$PATH" jq -r '.[] | if type=="string" then . else .name end' \
+        | while IFS= read -r bf_item; do
+        [ -z "$bf_item" ] && continue
+        case "$bf_kind" in
+          taps)  bf_cmd="tap" ;;
+          brews) bf_cmd="install --formula" ;;
+          casks) bf_cmd="install --cask" ;;
+        esac
+        # shellcheck disable=SC2086  # bf_cmd の語分割は意図的
+        if /opt/homebrew/bin/brew $bf_cmd "$bf_item" >/dev/null 2>&1; then
+          df_say "  ✓ $bf_kind $bf_item"
+        else
+          df_say "  ✘ $bf_kind $bf_item 失敗"
+        fi
+      done
     done
   fi
   df_step darwin-switch-retry plain switch_cmd || df_say "switch retry も失敗（RESULT は FAILED になる。verify で実害を特定）"
 fi
 
 df_phase chezmoi
+# --no-tty: 対話プロンプト（外部変更されたターゲットの上書き確認）を無効化する。
+# 無いと stdin が TTY の環境（通常のターミナル実行）で無言のハングになり得る。
+# プロンプト事象はエラー化され step 失敗 = 正直な FAILED として観測される
 df_step chezmoi-apply quiet env \
   PATH="$HM_PATH:$PATH" \
-  chezmoi --source "$REPO_DIR/chezmoi" apply --verbose || :
+  chezmoi --source "$REPO_DIR/chezmoi" apply --verbose --no-tty || :
 
-df_phase verify-system
-# 「終わった」を主張する前に事実を確認する。/etc/profiles/per-user/$USER/bin に
-# コマンドが揃うのは useUserPackages 由来で activation 中断でも起きる＝証拠にならない
-# （2026-07-18 の誤診の元）。以下は home-manager activation の実走を直接見る。
-hm_state="${XDG_STATE_HOME:-$HOME/.local/state}/home-manager"
-gcroot="$hm_state/gcroots/current-home"
-expect_gen=""
-act=$(grep -o "/nix/store/[a-z0-9]*-activation-$USER" /run/current-system/activate 2>/dev/null | head -1 || :)
-[ -n "$act" ] && expect_gen=$(grep -o '/nix/store/[a-z0-9]*-home-manager-generation' "$act" 2>/dev/null | head -1 || :)
-if [ ! -e "$gcroot" ]; then
-  df_check_fail V1-hm-activation "$gcroot が無い = home-manager activation が完走していない"
-elif [ -n "$expect_gen" ] && [ "$(readlink -f "$gcroot" 2>/dev/null)" != "$expect_gen" ]; then
-  df_check_fail V1-hm-stale "home-manager 世代が古い: actual=$(readlink -f "$gcroot" 2>/dev/null) expected=$expect_gen"
-else
-  df_check_ok V1-hm-activation "home-manager activation 完走"
-fi
-
-# V2: user layer の実体。期待リストは手書きせず現世代から導出（drift しない）
-if [ -n "$expect_gen" ] && [ -d "$expect_gen/home-files" ]; then
-  ( cd "$expect_gen/home-files" && find . \( -type f -o -type l \) | sed 's|^\./||' ) \
-    > "$DF_RUN_DIR/expected-home-files"
-  v2_missing=0
-  while IFS= read -r rel; do
-    [ -e "$HOME/$rel" ] || { v2_missing=$((v2_missing + 1)); df_say "    missing: ~/$rel"; }
-  done < "$DF_RUN_DIR/expected-home-files"
-  if [ "$v2_missing" -gt 0 ]; then
-    df_check_fail V2-home-files "$v2_missing 件の home file 欠落"
-  else
-    df_check_ok V2-home-files "$(wc -l < "$DF_RUN_DIR/expected-home-files" | tr -d ' ') files"
-  fi
-else
-  df_check_fail V2-home-files "期待ファイル一覧を導出できない（世代パス不明 = V1 を先に直す）"
-fi
-
-# V3: home-manager profile（HM の分岐次第で置き場が 2 通り）
-if [ -e "${XDG_STATE_HOME:-$HOME/.local/state}/nix/profiles/home-manager" ] \
-  || [ -e "/nix/var/nix/profiles/per-user/$USER/home-manager" ]; then
-  df_check_ok V3-hm-profile "あり"
-else
-  df_check_fail V3-hm-profile "home-manager profile が両候補どちらにも無い"
-fi
-
-# V4: workspace volume + ghq root。GHQ_ROOT は export しない —— env は git config に
-# 勝つため、壊れた home-manager 層を覆い隠して「壊れた環境に正しく clone」する
-# 2026-07-18 を再現してしまう。ghq root は home-manager 完走の witness として読む。
-if ! diskutil info "$WORKSPACE_ROOT" 2>/dev/null | grep -q 'Case-sensitive'; then
-  df_check_fail V4-workspace "$WORKSPACE_ROOT が case-sensitive APFS として存在しない"
-fi
-ghq_root=$(env PATH="$HM_PATH:$PATH" ghq root 2>/dev/null || :)
-if [ "$ghq_root" = "$WORKSPACE_ROOT" ]; then
-  df_check_ok V4-ghq-root "$ghq_root"
-else
-  df_check_fail V4-ghq-root "ghq root='$ghq_root'（期待 $WORKSPACE_ROOT）。~/.config/git/config 欠落 = V1 の実害"
-fi
-
-# V6: brew の宣言 vs 実体（期待値は flake から導出。ci.yml の cask 検証と同じ流儀）
-if [ -x /opt/homebrew/bin/brew ]; then
-  for kind in brews casks; do
-    env PATH="$HM_PATH:$PATH" nix eval --impure --json \
-      ".#darwinConfigurations.${FLAKE_HOST}.config.homebrew.${kind}" 2>/dev/null \
-      | env PATH="$HM_PATH:$PATH" jq -r '.[] | if type=="string" then . else .name end' \
-      | sed 's|.*/||' | sort > "$DF_RUN_DIR/expected-$kind" || :
-    if [ "$kind" = brews ]; then
-      /opt/homebrew/bin/brew list --formula 2>/dev/null | sort > "$DF_RUN_DIR/actual-$kind" || :
-    else
-      /opt/homebrew/bin/brew list --cask 2>/dev/null | sort > "$DF_RUN_DIR/actual-$kind" || :
-    fi
-    if [ ! -s "$DF_RUN_DIR/expected-$kind" ]; then
-      df_check_fail "V6-$kind" "期待 $kind を flake から導出できない"
-      continue
-    fi
-    comm -23 "$DF_RUN_DIR/expected-$kind" "$DF_RUN_DIR/actual-$kind" > "$DF_RUN_DIR/missing-$kind"
-    if [ -s "$DF_RUN_DIR/missing-$kind" ]; then
-      df_check_fail "V6-$kind" "未 install: $(tr '\n' ' ' < "$DF_RUN_DIR/missing-$kind")"
-    else
-      df_check_ok "V6-$kind" "全 $(wc -l < "$DF_RUN_DIR/expected-$kind" | tr -d ' ') 件"
-    fi
-  done
-else
-  df_check_fail V6-brew "/opt/homebrew/bin/brew が無い"
-fi
+run_verify_system
 
 # ── clone 以降（事前準備で 1Password が生きていればここまで無人で完走する）────────
 run_clone_phases


### PR DESCRIPTION
## Why

ユーザー決定（2026-07-19）: **作業中は 1Password を解錠維持**（自動ロックのタイマー OFF・スリープ時ロックは残す）。2 段階分割の唯一の存在理由は「ロック中の SSH 署名が GUI を出す」（t-7h1t）だったので、この決定により **clone を無人 run に戻せる**。GUI 操作が前半（事前準備）に固まる形はユーザーの明示希望。

## What

- 事前準備（在席・GUI はここに全部）: ① Terminal FDA ② 1Password 手動導入 + iPhone QR サインイン + SSH agent ON + **自動ロックタイマー OFF** + 鍵承認 1 回（すべてのアプリで承認）③ `sudo -v`
- ワンライナー 1 本で **clone + link-claude-memory + 全検証まで無人完走**。`✓ 完了` は全通過時のみ（handoff の「完了」定義を単一 run で満たす）
- SSH gate: 実署名（`ssh-add -l` は偽陽性）+ **75 秒 watchdog**（agent ブロックは無制限・ConnectTimeout は TCP のみ・`timeout(1)` 非搭載）
- `--phase2` は**リカバリ入口へ降格**（SSH gate 起因の失敗を直した後の近道。通常はワンライナー再実行 = 冪等）
- README / glossary 追従（stage 1/2 語彙を撤去、`--phase2` を定義）

## Verified locally

shellcheck (style) / sh -n / nix flake check green。FDA gate fail-closed の挙動テスト green（`failed=P1-fda`）。

## ⚠ Merge は保留（品質担保）

**次セッションで adversarial 検証 workflow + Tart VM リハーサル（実 URL 経由・kill→再実行収束・sudo probe・FDA 抑止・.pkg TCC）を通してから merge する。**それまで auto-merge は設定しない。

SetStatus-task: https://github.com/akira-toriyama/projects/blob/main/.furrow/bodies/t-8qqz.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)