### PR TITLE
:sparkles: nix: idle power policy — display off 5m, computer/disk never sleep

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,9 +134,10 @@ op read "op://Vault/Item/field"
 ## Roadmap board / task tracker
 
 dotfiles の作業タスク（バックログ・設計メモ・引き継ぎ）の**正本は furrow + private repo
-[`akira-toriyama/projects`](https://github.com/akira-toriyama/projects)**（label `dotfiles`）。
-`furrow ls -l dotfiles`（着手候補 = ready / in-progress）/ `furrow show <id>` / 起票は
-`furrow add "…" -l dotfiles`。運用ルールの正典は
+[`akira-toriyama/projects`](https://github.com/akira-toriyama/projects)**（帰属は一級の
+repos フィールド `akira-toriyama/dotfiles`。ラベルは純粋タグ — repos-pivot 以降 `-l <repo>` は廃止）。
+`furrow ls -r dotfiles`（着手候補 = ready / in-progress）/ `furrow show <id>` / 起票は
+`furrow add "…" -r dotfiles`（この checkout 内なら global 既定ボードが repo を auto 付与）。運用ルールの正典は
 [`projects/CLAUDE.md`](https://github.com/akira-toriyama/projects/blob/main/CLAUDE.md)、
 全 repo 共通の作法は global `~/.claude/CLAUDE.md` の Workflow 節（furrow source を使う・
 着手前に projects 最新化・PR 本文に `SetStatus-task:` footer）。

--- a/system/modules/default.nix
+++ b/system/modules/default.nix
@@ -6,6 +6,7 @@
   imports = [
     ./homebrew.nix
     ./defaults.nix
+    ./power.nix
     ./launchd-drift.nix
     ./claude-maint.nix
   ];

--- a/system/modules/defaults.nix
+++ b/system/modules/defaults.nix
@@ -2,10 +2,15 @@
 
 {
   # macOS defaults を宣言的に管理（system-inventory.md の表が入力）。
+  # 放置時の電源（画面オフ/スリープ）は power.nix が所有。
   #
-  # 持ち込まない判断（セキュリティ低下を伴うため）:
-  #   - com.apple.screensaver askForPassword=0 (復帰時パスワード省略)
-  #   - spctl --master-disable (Gatekeeper 無効化)
+  # 持ち込まない判断:
+  #   - spctl --master-disable (Gatekeeper 無効化) — セキュリティ低下を伴うため。
+  #   - com.apple.screensaver askForPassword=0 (復帰時パスワード省略) — 2026-07-19 に
+  #     自宅・自室の据え置き機を前提に「ロック解除する」へ方針転換したが、宣言化は
+  #     不可能: ByHost 域のため system.defaults では書けず（CLAUDE.md 既知の落とし穴）、
+  #     現代 macOS のロック設定の正は sysadminctl。適用は手動 1 回
+  #     `sysadminctl -screenLock off -password -`（この機体には適用済み。新 Mac でも手動）。
   # どうしても必要になったら個別に再考し、理由を本コメントに残すこと。
 
   system.defaults = {

--- a/system/modules/power.nix
+++ b/system/modules/power.nix
@@ -1,0 +1,15 @@
+{ ... }:
+
+{
+  # 放置時の電源方針: OLED (LG ULTRAGEAR+) の保護と Claude Code の常時稼働を両立する。
+  # 適用は switch 時に systemsetup 経由（nix-darwin modules/power/sleep.nix）。
+  # 2026-07-19 に同値を pmset で手動適用済み — 本宣言は新 Mac 再現のための正本。
+  #
+  # 画面ロック解除（`sysadminctl -screenLock off -password -`）は対で行う手動 1 回の
+  # 操作。ByHost 域のため nix-darwin では管理できない — defaults.nix 冒頭コメント参照。
+  power.sleep = {
+    display = 5;         # 放置 5 分で画面を完全オフ（OLED は減光より消灯が正）
+    computer = "never";  # 画面オフ中も本体を眠らせない（バックグラウンド作業を止めない）
+    harddisk = "never";  # 作業 repo が載る外付け HDD (/Volumes/workspace) のスピンダウン防止
+  };
+}


### PR DESCRIPTION
## Summary

Declare the idle power policy in nix-darwin (`system/modules/power.nix`, new — one file, one owner):

- `power.sleep.display = 5` — screen fully off after 5 idle minutes (OLED LG ULTRAGEAR+: off beats dimming)
- `power.sleep.computer = "never"` — background work (Claude Code sessions) keeps running while the screen is off
- `power.sleep.harddisk = "never"` — no spin-down for the external HDD hosting /Volumes/workspace repos

The same values were applied live on 2026-07-19 via `pmset`; this PR makes them reproducible on a fresh Mac. Screen-lock removal (`sysadminctl -screenLock off`) is deliberately NOT declared — ByHost domain, unmanageable from `system.defaults` — and is recorded as a documented one-shot manual step in the `defaults.nix` header comment.

Also fixes the stale pre-repos-pivot furrow examples in CLAUDE.md (`-l dotfiles` → `-r dotfiles`).

## Verification

- `nix flake check --no-build` ✅
- `nix run nix-darwin#darwin-rebuild -- build --flake .#default --impure` ✅ (non-destructive build)
- Live values already active and confirmed: `pmset -g custom` → displaysleep 5 / sleep 0 / disksleep 0, `sysadminctl -screenLock status` → off

---（和訳）

放置時の電源方針を nix-darwin で宣言化: 画面 5 分で完全オフ（OLED 保護）・本体/外付け HDD はスリープしない（Claude Code の常時稼働）。同値は 2026-07-19 に pmset で手動適用済みで、本 PR は新 Mac 再現用の正本化。画面ロック解除は ByHost 域のため宣言不可 → defaults.nix コメントに手動 1 回の手順として記録。あわせて CLAUDE.md の旧 `-l dotfiles` 起票例を repos-pivot 後の `-r` に修正。

🤖 Generated with [Claude Code](https://claude.com/claude-code)