### PR TITLE
:sparkles: op: claude-automation Service Account for unattended secret reads

### DIFF
--- a/chezmoi/dot_local/bin/executable_op-sa
+++ b/chezmoi/dot_local/bin/executable_op-sa
@@ -1,0 +1,19 @@
+#!/bin/sh
+# op-sa: run op as the claude-automation Service Account (unattended, no biometric).
+# Reads only the Automation vault (read-only). Use for agent/unattended reads:
+#   op-sa read "op://Automation/<item>/<field>"
+# Human/interactive reads keep using plain `op` (app integration + Touch ID).
+# Token file is provisioned by run_onchange_after_provision-op-sa-token.sh.
+# Rate limit (Individual plan): 1,000 requests/day account-wide — don't loop on this.
+set -eu
+
+TOKEN_FILE="$HOME/.config/op/claude-sa-token"
+
+if [ ! -r "$TOKEN_FILE" ] || [ ! -s "$TOKEN_FILE" ]; then
+  echo "op-sa: token file missing or empty: $TOKEN_FILE" >&2
+  echo "op-sa: provision it with:" >&2
+  echo '  op read --out-file ~/.config/op/claude-sa-token "op://Personal/claude-sa-token/credential" && chmod 600 ~/.config/op/claude-sa-token' >&2
+  exit 1
+fi
+
+OP_SERVICE_ACCOUNT_TOKEN=$(cat "$TOKEN_FILE") exec op "$@"

--- a/chezmoi/run_onchange_after_provision-op-sa-token.sh
+++ b/chezmoi/run_onchange_after_provision-op-sa-token.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+# Provision the claude-automation Service Account token to ~/.config/op/claude-sa-token
+# (source of truth: 1Password item "claude-sa-token" in the Personal vault).
+# New-machine bootstrap: runs after `op signin`; skips gracefully when op isn't ready
+# so a fresh `chezmoi apply` never hard-fails on ordering.
+# Token rotation is manual — rotate on 1Password.com, update the item, then rerun:
+#   op read --out-file ~/.config/op/claude-sa-token "op://Personal/claude-sa-token/credential" && chmod 600 ~/.config/op/claude-sa-token
+set -eu
+
+TOKEN_FILE="$HOME/.config/op/claude-sa-token"
+
+# Already provisioned — rotation is manual (see header), never overwrite here.
+if [ -s "$TOKEN_FILE" ]; then
+  exit 0
+fi
+
+if ! command -v op >/dev/null 2>&1 || ! op account get >/dev/null 2>&1; then
+  echo "op-sa provisioning: op not available/signed in yet — skipping (rerun chezmoi apply after op signin)" >&2
+  exit 0
+fi
+
+mkdir -p "$HOME/.config/op"
+umask 077
+if op read --out-file "$TOKEN_FILE" "op://Personal/claude-sa-token/credential" >/dev/null 2>&1; then
+  chmod 600 "$TOKEN_FILE"
+  echo "op-sa provisioning: token written to $TOKEN_FILE" >&2
+else
+  echo "op-sa provisioning: item claude-sa-token not found in Personal vault — skipping" >&2
+fi

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -104,6 +104,21 @@ flowchart TD
 - **Don't call it:** 1pass, op cli（cli 単体を指す時のみ可）, シークレット
   ストア
 
+### Service Account (`op-sa`)
+**無人・agent 用の 1Password 機械アカウント**（`claude-automation`）。
+[[Automation vault]] のみ read-only。wrapper
+[`op-sa`](../chezmoi/dot_local/bin/executable_op-sa) が token を注入して
+biometric なしで `op read` を通す。token はグローバル export しない
+（使う瞬間だけ注入）。人間の対話は従来の `op`（app 統合 + Touch ID）。
+- **Don't call it:** bot account, automation token, SA トークン（token
+  自体を指す時のみ可）
+
+### Automation vault
+**[[Service Account (`op-sa`)]] が読める唯一の vault**。Claude の無人作業に
+要る secret だけを選んで入れる（Personal vault は仕様上 SA に付与不可）。
+中身の追加・削除は自由（SA の vault アクセス自体は immutable）。
+- **Don't call it:** bot vault, claude vault, 自動化保管庫
+
 ---
 
 ## ビルド / 適用


### PR DESCRIPTION
## What

1Password の同意プロンプトで無人の Claude Code セッションが止まる問題への恒久対策(Service Account 層)。

- **`op-sa` wrapper**(`chezmoi/dot_local/bin/executable_op-sa`): `OP_SERVICE_ACCOUNT_TOKEN` を呼び出し時のみ注入。read-only の Automation vault だけを biometric なしで読める
- **`run_onchange_after_provision-op-sa-token.sh`**: 新マシンで token を 1Password item(`Personal/claude-sa-token`)から `~/.config/op/claude-sa-token`(600)へ配布。`op signin` 前は graceful skip
- **glossary**: `Service Account (op-sa)` / `Automation vault` を追加

## Why

公式の app integration は terminal session ごと + 10 分無操作で biometric 承認が必要(調整不可・by design)。無人運用は 1Password 公式が Service Account を推奨。SA は仕様上 Personal vault に付与できないため、漏洩時の被害は Automation vault の選定済み secret に限定される。

## Verified

- `op-sa vault list` がプロンプトなしで通り、Automation vault のみ可視(スコープ確認)
- token ファイル 600 / shellcheck 通過 / `chezmoi apply` で wrapper 配置済み
- CI 対象外の経路(`.tmpl` 不使用)なので templates render に影響なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)