### PR TITLE
:bug: chezmoi: op-sa guard — op whoami, not op account get (tty deadlock)

### DIFF
--- a/chezmoi/run_onchange_after_provision-op-sa-token.sh
+++ b/chezmoi/run_onchange_after_provision-op-sa-token.sh
@@ -14,7 +14,11 @@ if [ -s "$TOKEN_FILE" ]; then
   exit 0
 fi
 
-if ! command -v op >/dev/null 2>&1 || ! op account get >/dev/null 2>&1; then
+# Guard must be non-interactive: `op account get` with no account opens /dev/tty
+# and prompts "add an account manually? [Y/n]" even with stdout/stderr redirected
+# (stdin </dev/null does NOT prevent it — measured on Tart VM 2026-07-19), which
+# deadlocks unattended runs (install.sh). `op whoami` fails fast without prompting.
+if ! command -v op >/dev/null 2>&1 || ! op whoami >/dev/null 2>&1; then
   echo "op-sa provisioning: op not available/signed in yet — skipping (rerun chezmoi apply after op signin)" >&2
   exit 0
 fi


### PR DESCRIPTION
## Why

PR #219 の Tart VM kill→再実行リハーサル中、無人ワンライナーが chezmoi-apply 内の `run_onchange_after_provision-op-sa-token.sh`（#221）で**無限ブロック**した。原因: `op account get` はアカウント未設定だと **stdout/stderr をリダイレクトしていても /dev/tty を直接開いて対話プロンプトを出す**（`stdin </dev/null` でも防げない — VM 実測）。graceful skip を意図した guard 自体が対話してしまう。

## What

guard を `op whoami` に差し替え（同状態で即 rc=1・プロンプト無し — VM 実測）。挙動は意図どおりの graceful skip のまま、無人実行でハングしなくなる。

## Verified

- Tart VM（ssh -tt = 制御端末あり）で `op account get` のハングと `op whoami` の即時 rc=1 を実測
- sh -n / shellcheck green

SetStatus-task: https://github.com/akira-toriyama/projects/blob/main/.furrow/bodies/t-8qqz.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)