### PR TITLE
:bug: wrapper: go fallback uses GOTOOLCHAIN=auto — survive stale nixpkgs go (t-7t0w, t-cgcp)

### DIFF
--- a/home/modules/mise.nix
+++ b/home/modules/mise.nix
@@ -12,16 +12,17 @@
   # 【方針】言語ランタイム（go / node / python / deno / rust 等）は **mise に一元化**する。
   # ・per-project の版切替は mise の本領。nix `home.packages` は非ランタイムの CLI 用、
   #   homebrew は GUI/cask + nixpkgs 未収録の例外 CLI 用（言語ランタイムは置かない）。
-  # ・go の build 用トグルは別物: packages.nix の furrow ラッパが `${pkgs.go}` を内部固定で
-  #   使う（PATH 非公開）。ここ(mise)の go は手元の dev go（`go run`/`go test` 等）。
+  # ・source-build ラッパ（packages.nix の furrow/pare/rundiff 等）の build go も
+  #   ここで宣言する mise の go（PATH の go）が primary。mise 未導入の窓でだけ
+  #   `${pkgs.go}` に fallback（GOTOOLCHAIN=auto で floor 不足も自動回復。t-7t0w/t-cgcp）。
   programs.mise = {
     enable = true;
     globalConfig.tools = {
       node = "lts";
       python = "3.13";
       deno = "latest";
-      # dev go（furrow の `go run`/`go test` 等）。build go は別管理＝packages.nix の
-      # furrow ラッパが `${pkgs.go}` を内部固定で使う（PATH には出さない）。
+      # dev go（`go run`/`go test`）兼 source-build ラッパの primary build go。
+      # "latest" 宣言なので各 repo の go.mod floor を満たす前提（↑ヘッダの方針）。
       go = "latest";
       # rundiff の adapter fixture（cargo test キャプチャ）等で使う。↑方針の
       # とおり言語ランタイムは mise（cargo/rustc とも mise 管理）。

--- a/home/modules/packages.nix
+++ b/home/modules/packages.nix
@@ -185,6 +185,11 @@
     #   export するので、これが無いと別 version の go(例 nix go)を使ったとき
     #   「compile version が go tool version と不一致」で build が死ぬ。go 不在の
     #   context でのみ ${pkgs.go} に fallback（GOROOT 打ち消しは fallback でも有効）。
+    # ・GOTOOLCHAIN は primary=local（mise go は "latest" 宣言なので floor を満たす前提。
+    #   無断 toolchain DL をしない＝決定的）、fallback=auto（nixpkgs の go は pin が
+    #   古くなり得て、go.mod floor 未満だと local ではハードエラー。switch 直後〜
+    #   mise ツール導入前の窓で rundiff が PreToolUse hook から全 Bash 呼び出しを
+    #   道連れにした実績 t-7t0w。auto なら必要 toolchain を自動取得して build 続行）。
     # ・(cd src) を subshell に閉じて cwd を保つ＝呼び出し元のディレクトリで実行され、
     #   そこの .furrow-pointer.toml 発見が効く
     # ・出力は一時ファイル→atomic mv（並行起動でも壊れた binary を exec しない）
@@ -195,8 +200,8 @@
       bin="$cache/furrow"
       if [ ! -x "$bin" ] || [ -n "$(find "$src/cmd" "$src/internal" "$src/go.mod" "$src/go.sum" -newer "$bin" 2>/dev/null)" ]; then
         mkdir -p "$cache"
-        if command -v go >/dev/null 2>&1; then gobuild=go; else gobuild=${pkgs.go}/bin/go; fi
-        ( cd "$src" && env -u GOROOT GOTOOLCHAIN=local "$gobuild" build -o "$bin.tmp.$$" ./cmd/furrow && mv -f "$bin.tmp.$$" "$bin" ) >&2
+        if command -v go >/dev/null 2>&1; then gobuild=go; gotc=local; else gobuild=${pkgs.go}/bin/go; gotc=auto; fi
+        ( cd "$src" && env -u GOROOT GOTOOLCHAIN="$gotc" "$gobuild" build -o "$bin.tmp.$$" ./cmd/furrow && mv -f "$bin.tmp.$$" "$bin" ) >&2
       fi
       exec "$bin" "$@"
     '')
@@ -213,8 +218,8 @@
       bin="$cache/pare"
       if [ ! -x "$bin" ] || [ -n "$(find "$src/cmd" "$src/internal" "$src/go.mod" "$src/go.sum" -newer "$bin" 2>/dev/null)" ]; then
         mkdir -p "$cache"
-        if command -v go >/dev/null 2>&1; then gobuild=go; else gobuild=${pkgs.go}/bin/go; fi
-        ( cd "$src" && env -u GOROOT GOTOOLCHAIN=local "$gobuild" build -o "$bin.tmp.$$" ./cmd/pare && mv -f "$bin.tmp.$$" "$bin" ) >&2
+        if command -v go >/dev/null 2>&1; then gobuild=go; gotc=local; else gobuild=${pkgs.go}/bin/go; gotc=auto; fi
+        ( cd "$src" && env -u GOROOT GOTOOLCHAIN="$gotc" "$gobuild" build -o "$bin.tmp.$$" ./cmd/pare && mv -f "$bin.tmp.$$" "$bin" ) >&2
       fi
       exec "$bin" "$@"
     '')
@@ -234,8 +239,8 @@
       bin="$cache/rundiff"
       if [ ! -x "$bin" ] || [ -n "$(find "$src/cmd" "$src/internal" "$src/go.mod" "$src/go.sum" -newer "$bin" 2>/dev/null)" ]; then
         mkdir -p "$cache"
-        if command -v go >/dev/null 2>&1; then gobuild=go; else gobuild=${pkgs.go}/bin/go; fi
-        ( cd "$src" && env -u GOROOT GOTOOLCHAIN=local "$gobuild" build -o "$bin.tmp.$$" ./cmd/rundiff && mv -f "$bin.tmp.$$" "$bin" ) >&2
+        if command -v go >/dev/null 2>&1; then gobuild=go; gotc=local; else gobuild=${pkgs.go}/bin/go; gotc=auto; fi
+        ( cd "$src" && env -u GOROOT GOTOOLCHAIN="$gotc" "$gobuild" build -o "$bin.tmp.$$" ./cmd/rundiff && mv -f "$bin.tmp.$$" "$bin" ) >&2
       fi
       exec "$bin" "$@"
     '')
@@ -251,8 +256,8 @@
       bin="$cache/cifail"
       if [ ! -x "$bin" ] || [ -n "$(find "$src/cmd" "$src/internal" "$src/go.mod" "$src/go.sum" -newer "$bin" 2>/dev/null)" ]; then
         mkdir -p "$cache"
-        if command -v go >/dev/null 2>&1; then gobuild=go; else gobuild=${pkgs.go}/bin/go; fi
-        ( cd "$src" && env -u GOROOT GOTOOLCHAIN=local "$gobuild" build -o "$bin.tmp.$$" ./cmd/cifail && mv -f "$bin.tmp.$$" "$bin" ) >&2
+        if command -v go >/dev/null 2>&1; then gobuild=go; gotc=local; else gobuild=${pkgs.go}/bin/go; gotc=auto; fi
+        ( cd "$src" && env -u GOROOT GOTOOLCHAIN="$gotc" "$gobuild" build -o "$bin.tmp.$$" ./cmd/cifail && mv -f "$bin.tmp.$$" "$bin" ) >&2
       fi
       exec "$bin" "$@"
     '')
@@ -268,8 +273,8 @@
       bin="$cache/revpost"
       if [ ! -x "$bin" ] || [ -n "$(find "$src/cmd" "$src/internal" "$src/go.mod" "$src/go.sum" -newer "$bin" 2>/dev/null)" ]; then
         mkdir -p "$cache"
-        if command -v go >/dev/null 2>&1; then gobuild=go; else gobuild=${pkgs.go}/bin/go; fi
-        ( cd "$src" && env -u GOROOT GOTOOLCHAIN=local "$gobuild" build -o "$bin.tmp.$$" ./cmd/revpost && mv -f "$bin.tmp.$$" "$bin" ) >&2
+        if command -v go >/dev/null 2>&1; then gobuild=go; gotc=local; else gobuild=${pkgs.go}/bin/go; gotc=auto; fi
+        ( cd "$src" && env -u GOROOT GOTOOLCHAIN="$gotc" "$gobuild" build -o "$bin.tmp.$$" ./cmd/revpost && mv -f "$bin.tmp.$$" "$bin" ) >&2
       fi
       exec "$bin" "$@"
     '')


### PR DESCRIPTION
## Problem (t-7t0w)

The source-build wrappers (furrow/pare/rundiff/cifail/revpost) fall back to `${pkgs.go}` when mise's go is absent — exactly the window between `darwin-rebuild switch` and mise tool install on a fresh Mac. With `GOTOOLCHAIN=local` that go hard-fails once a repo's go.mod floor passes the nixpkgs pin (measured: rundiff floor 1.26.4 vs nix go 1.26.2), and rundiff runs from the PreToolUse hook on **every Bash call**, so the whole window breaks.

## Fix

- **primary** (mise go on PATH): keep `GOTOOLCHAIN=local` — mise go is `latest`, meets floors, no surprise toolchain downloads (deterministic)
- **fallback** (`${pkgs.go}`): `GOTOOLCHAIN=auto` — auto-fetch the required toolchain and keep building (the fallback is already a degraded path; availability wins)
- **mise.nix comment drift fixed (t-cgcp)**: it claimed the wrappers pin `${pkgs.go}` internally with PATH hidden; reality is PATH-go-first with `${pkgs.go}` fallback. Comments now match the implementation.

## Verification

- `nix flake check` / `darwin-rebuild build` green
- Repro + fix measured with the previously pinned nixpkgs go 1.26.2 (rev from flake.lock history):
  - `GOTOOLCHAIN=local` → `go: go.mod requires go >= 1.26.4` (the exact t-7t0w error)
  - `GOTOOLCHAIN=auto` → `go: downloading go1.26.4` → build succeeds, binary runs
- Built wrapper exercised end-to-end with a go-less PATH + isolated cache → builds via fallback and execs

SetStatus-task: https://github.com/akira-toriyama/projects/blob/main/.furrow/bodies/t-7t0w.md done

🤖 Generated with [Claude Code](https://claude.com/claude-code)