### PR TITLE
:memo: docs: name the 1Password PAT item (dotfiles bootstrap) in prep steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@
 
 #### 3. GitHub PAT を環境変数に入れる
 
-- 1Password に保存してある **fine-grained PAT** をコピーし、次のワンライナーと同じターミナルで実行する
+- 1Password の item **`dotfiles bootstrap`**（Personal vault・fine-grained PAT）の credential を
+  コピーし、次のワンライナーと同じターミナルで実行する
 
   ```sh
   export GH_TOKEN=<PAT>

--- a/install.sh
+++ b/install.sh
@@ -11,7 +11,8 @@
 #      → `ssh -o StrictHostKeyChecking=accept-new -T git@github.com` を 1 回実行し、
 #      1Password の承認ダイアログで「すべてのアプリで承認する」+ 認証
 #   3. GitHub fine-grained PAT（All repositories / Metadata: Read-only で足りる。t-8f19）を
-#      1Password からコピーし、ワンライナーと同じターミナルで `export GH_TOKEN=<PAT>`
+#      1Password の item `dotfiles bootstrap`（Personal vault）からコピーし、
+#      ワンライナーと同じターミナルで `export GH_TOKEN=<PAT>`
 #      （ghq-get-mine の repo 一覧取得と clone 完全性検証が gh API を使うため。無いと
 #      ✓ 完了 に到達できないので P1-ghtoken で即 fail する）
 #   4. `sudo -v`（このあとのワンライナーと同じターミナルで）
@@ -258,7 +259,7 @@ df_gate_ghtoken() {
     df_check_ok P1-ghtoken "gh auth 済み"
   else
     df_check_fail P1-ghtoken "gh の認証が無い"
-    df_say "  fine-grained PAT（All repositories / Metadata: Read-only）を 1Password からコピーし、"
+    df_say "  fine-grained PAT を 1Password の item \`dotfiles bootstrap\`（Personal vault）からコピーし、"
     df_say "  \`export GH_TOKEN=<PAT>\` してから再実行すること（事前準備 3）"
     exit 1
   fi


### PR DESCRIPTION
The prep step said only "the fine-grained PAT in 1Password" — tonight's audit nearly grabbed the wrong token (PROJECTS_WRITE_PAT, which cannot see 4 private repos incl. claude-memory). Name the exact item (**Personal vault / `dotfiles bootstrap`**, same name as the token on GitHub) in README, the install.sh header, and the P1-ghtoken failure hint, so the wipe-day reader picks the right one.

Item **name** only — no secret value; the item was regenerated tonight and verified 35/35 repos visible (t-q1a1).

SetStatus-task: https://github.com/akira-toriyama/projects/blob/main/.furrow/bodies/t-q1a1.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)