### PR TITLE
:memo: docs: make the ssh-config prep step deterministic — curl the chezmoi source

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,18 @@
 - 設定 → 開発者 → **SSH agent を ON**
 - 設定 → セキュリティ → **自動ロックのタイマーを OFF**（スリープ時ロックは残す）
   - 目的: 実行中のロックで clone が止まるのを防ぐため
-- `~/.ssh/config` に **IdentityAgent 行がある**ことを確認する
-  - 無ければ、1Password の設定画面が示す snippet の内容でファイルを作る
-  - これが無いと ssh は素の macOS agent（鍵ゼロ）を向いてしまう
-  - このファイルの正本は chezmoi（`chezmoi/private_dot_ssh/private_config`）。
-    ここで手作りするのはワンライナー前に SSH 承認を済ませるための仮置きで、
-    install 中の `chezmoi apply` 以降は宣言が enforce する（1Password は読者に徹し、
-    アプリの「自動編集」ボタンは使わない — 使うと drift になり `chezmoi verify` が警告する）
+- `~/.ssh/config` を **正本（chezmoi 宣言）そのまま**で置く（判断・GUI 操作なし）:
+
+  ```sh
+  mkdir -p ~/.ssh && curl -fsSL https://raw.githubusercontent.com/akira-toriyama/dotfiles/main/chezmoi/private_dot_ssh/private_config -o ~/.ssh/config && chmod 600 ~/.ssh/config
+  ```
+
+  - 中身は 1Password SSH agent への IdentityAgent 指定。これが無いと ssh は
+    素の macOS agent（鍵ゼロ）を向いてしまう
+  - 正本は `chezmoi/private_dot_ssh/private_config` の 1 箇所（上の curl はそれを
+    取るだけ）。install 中の `chezmoi apply` 以降は宣言が enforce する（1Password は
+    読者に徹し、アプリの「自動編集」ボタンは使わない — 使うと drift になり
+    `chezmoi verify` が警告する）
 - 動作確認として次を 1 回実行し、承認ダイアログで「**すべてのアプリで承認する**」を選んで認証する
 
   ```sh

--- a/install.sh
+++ b/install.sh
@@ -6,8 +6,9 @@
 #      （付与後 Terminal を Cmd-Q で再起動）
 #   2. 1Password.app を手動インストール → iPhone の QR でサインイン → 設定 → 開発者 →
 #      SSH agent ON → セキュリティ → 自動ロックのタイマーを OFF（スリープ時ロックは残す）
-#      → ~/.ssh/config に IdentityAgent 行があることを確認（1Password が設定画面で示す
-#        snippet。無ければその内容で作る。これが無いと ssh は素の macOS agent(鍵ゼロ)を向く）
+#      → ~/.ssh/config を chezmoi 正本そのままで置く（README の curl ワンライナー =
+#        raw の chezmoi/private_dot_ssh/private_config を取得して 600 で保存。
+#        これが無いと ssh は素の macOS agent(鍵ゼロ)を向く）
 #      → `ssh -o StrictHostKeyChecking=accept-new -T git@github.com` を 1 回実行し、
 #      1Password の承認ダイアログで「すべてのアプリで承認する」+ 認証
 #   3. GitHub fine-grained PAT（All repositories / Metadata: Read-only で足りる。t-8f19）を


### PR DESCRIPTION
The prep step said "confirm the IdentityAgent line exists; if missing, create it from the snippet 1Password's settings screen shows" — vague because until #228 the file had no owner and the truth lived only in 1Password's GUI.

Now that chezmoi owns `~/.ssh/config`, the prep step fetches the declared file verbatim:

```sh
mkdir -p ~/.ssh && curl -fsSL https://raw.githubusercontent.com/akira-toriyama/dotfiles/main/chezmoi/private_dot_ssh/private_config -o ~/.ssh/config && chmod 600 ~/.ssh/config
```

No judgement, no GUI dependence, single source (the curl just fetches the chezmoi declaration; `chezmoi apply` enforces the same file later). install.sh header synced.

Verified: the curl path fetches byte-identical content to the live declared config, 600 perms.

SetStatus-task: https://github.com/akira-toriyama/projects/blob/main/.furrow/bodies/t-8qqz.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)