### PR TITLE
:memo: readme: expiry hint for the PAT + post-install manual steps section

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,18 @@
 - 設定 → 開発者 → **SSH agent を ON**
 - 設定 → セキュリティ → **自動ロックのタイマーを OFF**（スリープ時ロックは残す）
   - 目的: 実行中のロックで clone が止まるのを防ぐため
-- `~/.ssh/config` に **IdentityAgent 行がある**ことを確認する
-  - 無ければ、1Password の設定画面が示す snippet の内容でファイルを作る
-  - これが無いと ssh は素の macOS agent（鍵ゼロ）を向いてしまう
-  - このファイルの正本は chezmoi（`chezmoi/private_dot_ssh/private_config`）。
-    ここで手作りするのはワンライナー前に SSH 承認を済ませるための仮置きで、
-    install 中の `chezmoi apply` 以降は宣言が enforce する（1Password は読者に徹し、
-    アプリの「自動編集」ボタンは使わない — 使うと drift になり `chezmoi verify` が警告する）
+- `~/.ssh/config` を **正本（chezmoi 宣言）そのまま**で置く（判断・GUI 操作なし）:
+
+  ```sh
+  mkdir -p ~/.ssh && curl -fsSL https://raw.githubusercontent.com/akira-toriyama/dotfiles/main/chezmoi/private_dot_ssh/private_config -o ~/.ssh/config && chmod 600 ~/.ssh/config
+  ```
+
+  - 中身は 1Password SSH agent への IdentityAgent 指定。これが無いと ssh は
+    素の macOS agent（鍵ゼロ）を向いてしまう
+  - 正本は `chezmoi/private_dot_ssh/private_config` の 1 箇所（上の curl はそれを
+    取るだけ）。install 中の `chezmoi apply` 以降は宣言が enforce する（1Password は
+    読者に徹し、アプリの「自動編集」ボタンは使わない — 使うと drift になり
+    `chezmoi verify` が警告する）
 - 動作確認として次を 1 回実行し、承認ダイアログで「**すべてのアプリで承認する**」を選んで認証する
 
   ```sh

--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@
 - 権限は **All repositories / Metadata: Read-only** で足りる
 - 用途: `ghq-get-mine` の repo 一覧取得と clone 完全性検証（gh API）
 - 無い場合は序盤の P1-ghtoken gate で即 fail する（長い処理が走ってから死なない）
+- token は **30 日期限**。切れていたら GitHub → Settings → Developer settings →
+  Fine-grained tokens → `dotfiles bootstrap` を **Regenerate** し、新しい値で
+  1Password の同名 item を更新してから使う
 
 #### 4. sudo チケットを作る
 
@@ -84,6 +87,13 @@ sudo -v && sh -c "$(curl -fsLS https://raw.githubusercontent.com/akira-toriyama/
 - `detail/<step>.log` — ノイズの多い step（chezmoi apply 等）の隔離出力
 
 `~/.dotfiles-install/latest` が最新 run を指す。
+
+### `✓ 完了` 後に手で残るもの
+
+- **1Password の自動ロックタイマーを元に戻す**（事前準備 2 で OFF にしたもの。戻さないと無期限で解錠されたままになる）
+- **App Store アプリの手動インストール**（`masApps` 宣言は mas の不具合で凍結中。
+  控えは private の `projects` repo → `docs/machine-docs/masApps-backup-*.txt`）
+- **TCC / アクセシビリティの再付与**（chord の AX daemon 等。付与が要るアプリは起動時に要求してくる）
 
 ### 補足
 

--- a/install.sh
+++ b/install.sh
@@ -6,8 +6,9 @@
 #      （付与後 Terminal を Cmd-Q で再起動）
 #   2. 1Password.app を手動インストール → iPhone の QR でサインイン → 設定 → 開発者 →
 #      SSH agent ON → セキュリティ → 自動ロックのタイマーを OFF（スリープ時ロックは残す）
-#      → ~/.ssh/config に IdentityAgent 行があることを確認（1Password が設定画面で示す
-#        snippet。無ければその内容で作る。これが無いと ssh は素の macOS agent(鍵ゼロ)を向く）
+#      → ~/.ssh/config を chezmoi 正本そのままで置く（README の curl ワンライナー =
+#        raw の chezmoi/private_dot_ssh/private_config を取得して 600 で保存。
+#        これが無いと ssh は素の macOS agent(鍵ゼロ)を向く）
 #      → `ssh -o StrictHostKeyChecking=accept-new -T git@github.com` を 1 回実行し、
 #      1Password の承認ダイアログで「すべてのアプリで承認する」+ 認証
 #   3. GitHub fine-grained PAT（All repositories / Metadata: Read-only で足りる。t-8f19）を


### PR DESCRIPTION
Follow-up review of the README for wipe day (after #230/#231):

- The `dotfiles bootstrap` PAT expires in **30 days** — document what to do when it has expired (Regenerate on GitHub → update the same-named 1Password item).
- New **「✓ 完了 後に手で残るもの」** section:
  - restore the 1Password auto-lock timer that prep step 2 disables (otherwise it stays disabled forever)
  - install App Store apps by hand (masApps declaration frozen due to the mas 1.8.6 breakage; the backup list lives in the private projects repo under `docs/machine-docs/`)
  - re-grant TCC/Accessibility (chord AX daemon etc.)

SetStatus-task: https://github.com/akira-toriyama/projects/blob/main/.furrow/bodies/t-q1a1.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)