### PR TITLE
:memo: docs: one sudo password prompt, not two — drop the redundant prep step

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,16 +55,14 @@
   Fine-grained tokens → `dotfiles bootstrap` を **Regenerate** し、新しい値で
   1Password の同名 item を更新してから使う
 
-#### 4. sudo チケットを作る
-
-- 同じターミナルで `sudo -v`
-
-### 実行（ここから先はパスワード入力・GUI 操作ゼロ・無人で完走）
+### 実行
 
 ```sh
 sudo -v && sh -c "$(curl -fsLS https://raw.githubusercontent.com/akira-toriyama/dotfiles/main/install.sh)"
 ```
 
+- **パスワード入力は先頭の `sudo -v` の 1 回だけ**（貼り付け直後に聞かれる）。
+  それ以降はパスワード入力・GUI 操作ゼロで無人完走する
 - **`✓ 完了` は全 phase + 事後条件検証を通過した時だけ出る**
   （スキップ・失敗があれば必ず FAILED / PARTIAL になる）
 

--- a/install.sh
+++ b/install.sh
@@ -16,9 +16,9 @@
 #      ワンライナーと同じターミナルで `export GH_TOKEN=<PAT>`
 #      （ghq-get-mine の repo 一覧取得と clone 完全性検証が gh API を使うため。無いと
 #      ✓ 完了 に到達できないので P1-ghtoken で即 fail する）
-#   4. `sudo -v`（このあとのワンライナーと同じターミナルで）
 #
-# 実行（ここから先はパスワード入力・GUI 操作ゼロ。clone と claude-memory link まで完走）:
+# 実行（パスワードはワンライナー先頭の sudo -v で 1 回だけ。以降は入力・GUI ゼロで
+# clone と claude-memory link まで完走）:
 #
 #   sudo -v && sh -c "$(curl -fsLS https://raw.githubusercontent.com/akira-toriyama/dotfiles/main/install.sh)"
 #


### PR DESCRIPTION
Prep step 4 (`sudo -v`) duplicated the one-liner's own leading `sudo -v` and read as "enter the password twice" (user hit exactly this confusion). The prep-step ticket expires in ~5 minutes anyway — by the time you've copied the PAT and pasted the one-liner it may be gone — so the one-liner's `sudo -v` is the one that matters.

- Drop prep step 4 entirely (prep is now 3 steps: FDA / 1Password / PAT)
- State explicitly at 実行: **the password is asked exactly once**, right after pasting; everything after runs unattended
- install.sh header synced

SetStatus-task: https://github.com/akira-toriyama/projects/blob/main/.furrow/bodies/t-q1a1.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)