### PR TITLE
:sparkles: adopt unmanaged files — zmk log stack, chezmoi.toml, gh cred helper, zsh starter (t-pfsd)

### DIFF
--- a/chezmoi/dot_local/bin/executable_zmk-log
+++ b/chezmoi/dot_local/bin/executable_zmk-log
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Query CLI for ~/zmk-logs (24/7 dongle serial capture; see executable_zmk-log-capture.sh).
+#   zmk-log                 tail -f today's log
+#   zmk-log today           cat today's log
+#   zmk-log find [N]        major events over the last N days (default 3)
+#   zmk-log since "HH:MM"   today's lines since HH:MM
+#   zmk-log around "HH:MM"  today's lines HH:MM +/- 2 min
+#   zmk-log days            list captured days
+# Spec: projects t-6cdr body. Retire with the capture stack when stable (t-x0ak).
+
+LOGDIR="$HOME/zmk-logs"
+TODAY="$LOGDIR/zmk-$(date +%F).log"
+EVENTS='ZOMBIE|ZR-EPISODE|zombie-check|give-up|self-reboot|bounce|latch|refill|Booting Zephyr|ble_hid_host up|disconnected:|bond|berr=[1-9]|err'
+
+case "${1:-}" in
+    ""|tail)
+        exec tail -n 50 -F "$TODAY"
+        ;;
+    today)
+        exec cat "$TODAY"
+        ;;
+    days)
+        ls -1 "$LOGDIR" | grep '^zmk-.*\.log$' | sed 's/^zmk-//; s/\.log$//'
+        ;;
+    find)
+        N="${2:-3}"
+        ls -1 "$LOGDIR"/zmk-*.log 2>/dev/null | tail -n "$N" | xargs cat 2>/dev/null \
+            | grep -E "$EVENTS"
+        ;;
+    since)
+        [ -n "${2:-}" ] || { echo "usage: zmk-log since \"HH:MM\"" >&2; exit 2; }
+        awk -v t="$(date +%F) ${2}" '$0 >= t' "$TODAY"
+        ;;
+    around)
+        [ -n "${2:-}" ] || { echo "usage: zmk-log around \"HH:MM\"" >&2; exit 2; }
+        C=$(date -j -f "%F %H:%M" "$(date +%F) ${2}" +%s) || exit 2
+        FROM=$(date -j -f %s $((C - 120)) '+%F %T')
+        TO=$(date -j -f %s $((C + 120)) '+%F %T')
+        awk -v a="$FROM" -v b="$TO" '$0 >= a && $0 <= b' "$TODAY"
+        ;;
+    *)
+        echo "usage: zmk-log [tail|today|find [N]|since HH:MM|around HH:MM|days]" >&2
+        exit 2
+        ;;
+esac

--- a/chezmoi/dot_local/bin/executable_zmk-log-capture.sh
+++ b/chezmoi/dot_local/bin/executable_zmk-log-capture.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# 24/7 serial capture for the ZMK BLE HID Host dongle (launchd: org.nixos.zmk-log,
+# declared in system/modules/zmk-log.nix; retire when the dongle is stable — t-x0ak).
+# Resolves the dongle by USB product name "BLE HID Host" via ioreg (follows re-plug),
+# timestamps each line with "%F %T", appends to ~/zmk-logs/zmk-YYYY-MM-DD.log
+# (daily rotation via the dated filename), prunes logs older than RETAIN_DAYS.
+# Spec: projects t-6cdr body.
+
+LOGDIR="$HOME/zmk-logs"
+RETAIN_DAYS=120
+PRODUCT="BLE HID Host"
+
+mkdir -p "$LOGDIR"
+
+find_dev() {
+    # locationID (decimal) of the USB device -> hex prefix -> /dev/cu.usbmodem<prefix>*
+    local loc prefix
+    loc=$(ioreg -p IOUSB -l -w0 | grep -A20 "\"USB Product Name\" = \"$PRODUCT\"" \
+        | grep -m1 '"locationID"' | grep -oE '[0-9]+$')
+    [ -n "$loc" ] || return 1
+    prefix=$(printf '%x' "$loc" | sed 's/0*$//')
+    local devs=(/dev/cu.usbmodem${prefix}*)
+    [ -e "${devs[0]}" ] || return 1
+    echo "${devs[0]}"
+}
+
+prune() {
+    find "$LOGDIR" -name 'zmk-*.log' -mtime +"$RETAIN_DAYS" -delete 2>/dev/null
+}
+
+echo "$(date '+%F %T') capture: starting (product=\"$PRODUCT\")" >&2
+
+while :; do
+    prune
+    DEV=$(find_dev)
+    if [ -z "$DEV" ]; then
+        sleep 5
+        continue
+    fi
+    echo "$(date '+%F %T') capture: attached $DEV" >&2
+    # cat ends on USB re-enumeration (I/O error) -> loop re-resolves the device.
+    cat "$DEV" 2>/dev/null | while IFS= read -r line; do
+        printf '%s %s\n' "$(date '+%F %T')" "$line" >> "$LOGDIR/zmk-$(date +%F).log"
+    done
+    echo "$(date '+%F %T') capture: detached $DEV" >&2
+    sleep 2
+done

--- a/home/modules/chezmoi.nix
+++ b/home/modules/chezmoi.nix
@@ -1,0 +1,25 @@
+{ ... }:
+
+{
+  # chezmoi 自身の設定（source の場所）を宣言する。これが無いと素の
+  # `chezmoi diff` / `apply` / `re-add` は source を知らず「管理 0 件」の
+  # silent no-op になる（install.sh と drift 検知は --source 明示で動くため
+  # 露見しなかった。docs が案内する素コマンドの前提を成立させる宣言。t-pfsd）。
+  #
+  # ・furrow.nix の global 既定ボードと同じ流儀（固定パスの小さな TOML を
+  #   home.file で宣言 ＝ 新 PC でも version 管理下で再現）。
+  # ・chezmoi 自身に自分の config を管理させるのは鶏と卵（source を知るための
+  #   設定が source の中にある）ため home-manager 所有とする。
+  # ・sourceDir は repo ルートを指す（.chezmoiroot=chezmoi を chezmoi が読んで
+  #   chezmoi/ を source に解決する）。正本 checkout は ghq 配下 —— bootstrap
+  #   残骸の ~/dotfiles ではない。
+  # ・新 Mac では switch（このファイル生成）→ chezmoi apply --source 明示 →
+  #   ghq-get-mine（正本 clone 降臨）の順なので矛盾しない。clone 前に素の
+  #   chezmoi を叩いた場合は「source が無い」と loud に失敗する（silent よりよい）。
+  # ・機体差分（複数マシン）が要るようになったら .chezmoi.toml.tmpl + chezmoi init
+  #   方式へ乗り換えを検討する（roadmap フェーズ1 の据え置き項目）。
+  home.file.".config/chezmoi/chezmoi.toml".text = ''
+    # Managed by home-manager (home/modules/chezmoi.nix). Do not edit by hand.
+    sourceDir = "/Volumes/workspace/github.com/akira-toriyama/dotfiles"
+  '';
+}

--- a/home/modules/default.nix
+++ b/home/modules/default.nix
@@ -8,6 +8,7 @@
     ./packages.nix
     ./mise.nix
     ./furrow.nix
+    ./chezmoi.nix
   ];
 
   home.username = username;

--- a/home/modules/git.nix
+++ b/home/modules/git.nix
@@ -38,6 +38,12 @@
 
       # push 時は同名の upstream branch へ（現行 ~/.gitconfig 踏襲）。
       push.default = "current";
+
+      # https 経路の GitHub 認証は gh に委譲。従来は `gh auth setup-git` が
+      # 未管理の ~/.gitconfig（global の読み順で後勝ち＝上書き側）に書いていた
+      # 1 節を宣言に引き取り、実ファイルは削除した（t-pfsd。新 Mac でも
+      # setup-git を叩く必要が無くなる）。
+      credential."https://github.com".helper = "!gh auth git-credential";
       # macOS の case-insensitive FS でも大文字小文字違いを別ファイル扱いに。
       core.ignorecase = false;
       # ghq の clone 先。env の GHQ_ROOT が優先するが faithful 再現として残す。

--- a/home/modules/zsh.nix
+++ b/home/modules/zsh.nix
@@ -1,18 +1,42 @@
 { ... }:
 
 {
-  # フェーズ3: バニラ zsh のみ有効化。
-  # プラグイン/プロンプト/エイリアスは後続フェーズで段階的に育てる。
-  programs.zsh.enable = true;
+  # zsh 本体は home-manager 所有（~/.zshrc / .zshenv / .zprofile を生成）。
+  # 中身は「0 から使いながら育てる」方針 —— フェーズ3 のバニラ有効化から、
+  # t-pfsd で初手セット（history 強化 / starship / 定番 QoL 2 点）を導入。
+  # alias / 関数は意図的に未導入: 必要になったものを 1 個ずつここへ足す。
+  programs.zsh = {
+    enable = true;
 
-  # cd するたびに、いる repo が upstream より behind なら 1 行警告（furrow t-5rgs ②）。
-  # 判定は dotfiles 管理の ~/.local/bin/git-stale-check（chezmoi）に委譲。重い処理
-  # （fetch）は script 側で ~600s throttle + background 化済みなので chpwd は軽い。
-  programs.zsh.initContent = ''
-    autoload -Uz add-zsh-hook
-    _git_stale_check_chpwd() {
-      [[ -x "$HOME/.local/bin/git-stale-check" ]] && "$HOME/.local/bin/git-stale-check"
-    }
-    add-zsh-hook chpwd _git_stale_check_chpwd
-  '';
+    # 初手① history 強化。repo に入るのは設定値だけで、履歴本体
+    # (~/.zsh_history) は管理外のローカル state のまま（public repo に履歴は
+    # 1 行も乗らない）。
+    history = {
+      size = 100000;      # メモリ上に保持する行数（既定 10000 の 10 倍）
+      save = 100000;      # ~/.zsh_history へ保存する行数
+      ignoreDups = true;  # 直前と同一のコマンドは積まない
+      ignoreSpace = true; # 行頭スペース付きは履歴に残さない（secret を打つ時の逃げ道）
+      share = true;       # セッション間で履歴を共有
+    };
+
+    # 初手③ 定番 QoL 2 点（プラグインマネージャ不要の一級オプション）。
+    autosuggestion.enable = true;     # history からの薄いインライン補完
+    syntaxHighlighting.enable = true; # コマンドの色付け（typo が打鍵中に分かる）
+
+    # cd するたびに、いる repo が upstream より behind なら 1 行警告（furrow t-5rgs ②）。
+    # 判定は dotfiles 管理の ~/.local/bin/git-stale-check（chezmoi）に委譲。重い処理
+    # （fetch）は script 側で ~600s throttle + background 化済みなので chpwd は軽い。
+    initContent = ''
+      autoload -Uz add-zsh-hook
+      _git_stale_check_chpwd() {
+        [[ -x "$HOME/.local/bin/git-stale-check" ]] && "$HOME/.local/bin/git-stale-check"
+      }
+      add-zsh-hook chpwd _git_stale_check_chpwd
+    '';
+  };
+
+  # 初手② プロンプト: starship（zsh integration は enable だけで自動 wiring）。
+  # Nerd Font は homebrew.nix の font-hack-nerd-font が受け皿。設定は当面デフォルト、
+  # カスタムしたくなったら programs.starship.settings で宣言的に育てる。
+  programs.starship.enable = true;
 }

--- a/system/modules/default.nix
+++ b/system/modules/default.nix
@@ -9,5 +9,6 @@
     ./power.nix
     ./launchd-drift.nix
     ./claude-maint.nix
+    ./zmk-log.nix
   ];
 }

--- a/system/modules/zmk-log.nix
+++ b/system/modules/zmk-log.nix
@@ -1,0 +1,32 @@
+{ username, ... }:
+
+{
+  # 自作キーボード dongle (ZMK BLE HID Host) のシリアルログを 24/7 常駐キャプチャする
+  # LaunchAgent（launchd-drift / claude-maint と同じ流儀）。dongle 安定化までの調査用で、
+  # 撤去は zmk-ble-hid-host t-x0ak (icebox) が管理する。
+  #
+  # スクリプト本体は chezmoi 所有の ~/.local/bin/zmk-log-capture.sh（照会 CLI は同
+  # ~/.local/bin/zmk-log）。手編集で育てる生スクリプトなので claude-maint のような
+  # Nix store コピー (${./...}) にせず、1 ファイル 1 所有の原則で chezmoi に置く。
+  # ログ実体 ~/zmk-logs/ は state（管理外・script が mkdir -p で自作）。
+  #
+  # 旧: 手置きの ~/Library/LaunchAgents/com.tommy.zmk-log.plist ＋ ~/bin/ 直下の
+  # スクリプト（PC 初期化のたび手で再構築していた）。この宣言が置換する (t-pfsd)。
+  launchd.user.agents.zmk-log = {
+    serviceConfig = {
+      Label = "org.nixos.zmk-log";
+      ProgramArguments = [
+        "/bin/bash"
+        "/Users/${username}/.local/bin/zmk-log-capture.sh"
+      ];
+      # login 時に起動し、process が死んだら launchd が再起動（USB 抜き差しは
+      # script 内 loop が追従するので KeepAlive の出番は異常死のみ）。
+      RunAtLoad = true;
+      KeepAlive = true;
+      # 旧 plist は ~/zmk-logs/launchd.{out,err} だったが、新 Mac 初回起動時に
+      # dir 不在で launchd が開けない縁を踏まないよう /tmp に置く（家風も /tmp）。
+      StandardOutPath = "/tmp/zmk-log-capture.log";
+      StandardErrorPath = "/tmp/zmk-log-capture.log";
+    };
+  };
+}


### PR DESCRIPTION
Adopt the last remaining unmanaged files found by a full $HOME survey, and start the zsh growth phase:

- **zmk log stack** — `~/bin/zmk-log{,-capture.sh}` + the hand-placed `com.tommy.zmk-log.plist` were rebuilt by hand after every PC re-init (the script header says so itself). Scripts move to chezmoi (`~/.local/bin`, alongside git-stale-check / op-sa), the agent becomes `launchd.user.agents.zmk-log` (same style as claude-maint / launchd-drift). Retirement once the dongle stabilizes is tracked as zmk-ble-hid-host t-x0ak (icebox).
- **chezmoi.toml** — this machine had no chezmoi config, so bare `chezmoi diff / apply / re-add` were "0 managed entries" silent no-ops (install.sh and the drift checker always pass `--source`, which hid it). Declared via home-manager, same pattern as furrow.nix; sourceDir points at the ghq checkout (canonical — `~/dotfiles` is a bootstrap leftover slated for deletion).
- **gh credential helper** — the one stray section `gh auth setup-git` wrote into the unmanaged `~/.gitconfig` (which wins over the managed `~/.config/git/config` in read order) is now declared in git.nix; the stray file is deleted at apply time.
- **zsh starter set** — history hardening (100k, ignoreDups / ignoreSpace / share), starship prompt, autosuggestion + syntaxHighlighting. Aliases intentionally deferred — grow them one by one in zsh.nix.

Post-merge apply (manual, tracked in the t-pfsd checklist): switch → chezmoi apply → boot out the old com.tommy.zmk-log agent → delete the `~/bin` scripts, the old plist, and `~/.gitconfig`.

---（和訳）

$HOME 全域調査で見つかった残りの未管理ファイルを宣言化し、zsh の育成フェーズを開始する:

- **zmk ログ基盤** — PC 初期化のたび手で再構築していた 3 点セット（capture スクリプト・照会 CLI・手置き plist）を chezmoi (~/.local/bin) + launchd.user.agents.zmk-log へ移管。dongle 安定後の撤去は zmk-ble-hid-host t-x0ak (icebox) が管理。
- **chezmoi.toml** — このマシンには chezmoi の設定が無く、素の chezmoi diff / apply / re-add が「管理 0 件」の silent no-op だった（install.sh と drift 検知は --source 明示のため露見せず）。furrow.nix と同じ流儀で home-manager 宣言（sourceDir = ghq 正本）。
- **gh credential helper** — gh auth setup-git が未管理 ~/.gitconfig（読み順で後勝ち）に書いていた 1 節を git.nix へ引き取り、実ファイルは apply 時に削除。
- **zsh 初手セット** — history 強化（100k・ignoreDups・ignoreSpace・share）・starship・autosuggestion + syntaxHighlighting。alias は意図的に見送り（zsh.nix で使いながら育成）。

merge 後の適用手順（switch → chezmoi apply → 旧 agent 退役 → 残骸削除）は t-pfsd の checklist で管理。

SetStatus-task: https://github.com/akira-toriyama/projects/blob/main/.furrow/bodies/t-pfsd.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)