### PR TITLE
:memo: docs(readme): note azooKey input source needs manual enable

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,11 @@ sudo -v && sh -c "$(curl -fsLS https://raw.githubusercontent.com/akira-toriyama/
 - **App Store アプリの手動インストール**（`masApps` 宣言は mas の不具合で凍結中。
   控えは private の `projects` repo → `docs/machine-docs/masApps-backup-*.txt`）
 - **TCC / アクセシビリティの再付与**（chord の AX daemon 等。付与が要るアプリは起動時に要求してくる）
+- **azooKey（日本語 IME）を入力ソースに追加**（cask 導入は自動だが、有効化だけは手動）
+  - システム設定 → キーボード → 入力ソース → **編集（鉛筆）→ `+` → 日本語 → azooKey** を選んで追加
+  - macOS 26 は 3rd party IME の**プログラムからの有効化を成功を装って無視する**設計のため、
+    `install.sh` / `defaults` / TIS API では有効化できない（Tart VM で検証済。task t-1t2e）。
+    ここだけは GUI 操作が必須で自動化から漏れる
 
 ### 補足
 


### PR DESCRIPTION
## What

新しい Mac 構築後に手で残る作業として、README の「`✓ 完了` 後に手で残るもの」節に **azooKey 入力ソースの手動有効化**を追記。

## Why

azooKey の cask 導入は自動化されているが、**入力ソースとしての有効化だけは自動化できない**ことを Tart VM で検証した:

- `defaults write com.apple.HIToolbox AppleEnabledInputSources` に追記 → reboot(fresh login)後も session enabled に載らない
- azooKey.app 起動済み + GUI セッションで `TISEnableInputSource(親)` → status 0(成功)を返すのに `enabled=false` のまま、`TISSelectInputSource` は -50

macOS 26 は 3rd party IME の programmatic 有効化を **no-op success として拒否**する設計(silent keylogger 対策)。よって install.sh への組み込みは不可で、GUI 1 ステップ(System Settings > キーボード > 入力ソース > + > azooKey)が必須。これを post-install の手動作業として明記する。

## 検証環境

Tart VM: macOS 26.5 / SIP on / vanilla image / 実際の署名済み pkg(v0.1.4)

SetStatus-task: https://github.com/akira-toriyama/projects/blob/main/.furrow/bodies/t-1t2e.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)