### PR TITLE
:fire: chore(homebrew): drop 7 unused casks + retire stale masApps freeze docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,7 +105,7 @@ flowchart TD
 - Determinate Nix と二重管理しないため **`nix.enable = false`**（host nix に設定済）。`/etc/nix/nix.custom.conf` には触らない。
 - switch 直後の親シェルでは `__NIX_DARWIN_SET_ENVIRONMENT_DONE=1` を継承して PATH 異常に見える false positive がある。**検証は新ターミナル or `env -i HOME=$HOME /bin/zsh -l -c '...'`** で行う。
 - `homebrew.onActivation.cleanup = "none"` 据え置き。`"zap"` 化は Phase 4 残りを全部宣言化してからユーザー確認の上で。
-- brew 同梱 `mas 1.8.6` は macOS 15+ で `mas get/install` が壊れている。`homebrew.masApps` 宣言は当面凍結（Nix 側 mas 6.0.1 は動くが nix-darwin homebrew モジュールが brew の mas を呼ぶため迂回できない）。
+- `homebrew.masApps` は未使用（MAS アプリ利用ゼロ）。宣言しても flake.nix の `bootstrapBrewOverride`（`lib.mkForce { }`。App Store 未サインインの bootstrap/CI/VM で switch を落とさないため）で live は常に空になる — 「宣言したのに入らない」は不具合ではない。詳細 → [docs/operations.md](docs/operations.md) の「Mac App Store 限定アプリ」節。
 - `system.defaults` は **ByHost ドメイン（`-currentHost`）には書けない**。Display 配置や一部 Finder 詳細は activationScripts で `defaults -currentHost write` を使う以外手がない。
 - macOS の **TCC/sandbox で保護されたアプリ**（Mail / Safari / Calendar 等）の defaults は switch が成功しても無音で適用されない。AI は「修正」追加で深追いしない。
 - chezmoi run スクリプトは **`run_onchange_` 既定**（idempotent）。`run_once_` は本当に一度きりの bootstrap でのみ使う。

--- a/README.md
+++ b/README.md
@@ -94,8 +94,6 @@ sudo -v && sh -c "$(curl -fsLS https://raw.githubusercontent.com/akira-toriyama/
 #### install.sh 後（そのまま・再ログイン不要）
 
 - **1Password の自動ロックタイマーを元に戻す**（事前準備 2 で OFF にしたもの。戻さないと無期限で解錠されたままになる）
-- **App Store アプリの手動インストール**（`masApps` 宣言は mas の不具合で凍結中。
-  控えは private の `projects` repo → `docs/machine-docs/masApps-backup-*.txt`）
 - **TCC / アクセシビリティの再付与**（chord の AX daemon 等。付与が要るアプリは起動時に要求してくる）
 
 #### ログアウト → 再ログイン後

--- a/chezmoi/dot_config/chord/private_config.toml
+++ b/chezmoi/dot_config/chord/private_config.toml
@@ -225,19 +225,6 @@ name = "rift focus next"
 input = "TU_LL_F"
 action-shell = "rift-cli execute window next"
 
-# doc: AltTab 起動（全スペース。旧 cmd+ctrl+tab）
-[[bindings]]
-name = "alttab all-spaces"
-input = "TU_LL_A"
-action-shell = "/Applications/AltTab.app/Contents/MacOS/AltTab --show=1"
-
-# doc: AltTab 起動（現スペース。旧 alt+tab）
-[[bindings]]
-name = "alttab current-space"
-input = "TU_LL_S"
-action-shell = "/Applications/AltTab.app/Contents/MacOS/AltTab --show=0"
-
-
 # ---- ZMK 単押し専用キー ----
 
 # doc: Mission Control（全ワークスペースをグリッド表示）

--- a/docs/chord.md
+++ b/docs/chord.md
@@ -70,8 +70,6 @@ private_config.toml の `# doc:` 行＋`[[bindings]]` を編集 →
 | `TU_LL_V` | タブを右へ（VS Code: Cmd+Shift+]） | com.microsoft.VSCode |
 | `TU_LL_D` | 前のウィンドウへ（rift フォーカス） | * |
 | `TU_LL_F` | 次のウィンドウへ（rift フォーカス） | * |
-| `TU_LL_A` | AltTab 起動（全スペース。旧 cmd+ctrl+tab） | * |
-| `TU_LL_S` | AltTab 起動（現スペース。旧 alt+tab） | * |
 | `VK_X1` | Mission Control（全ワークスペースをグリッド表示） | * |
 | `Ctrl + B` | ← Left | * |
 | `Ctrl + F` | → Right | * |

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -123,7 +123,8 @@ switch を落とさないため。PR #108 で常用 + bootstrap 共通方針に�
 将来 MAS アプリが必要になったら:
 
 - (a) 手動で App Store からインストール（最も確実）、または
-- (b) Nix 側の `mas`（`home/modules/packages.nix` 経由）で `mas install <id>` を手で叩く
+- (b) `mas` CLI を一時導入して（nixpkgs にあり。利用ゼロのため常設はしていない）
+  `mas install <id>` を手で叩く
 - 宣言的に戻したい場合は `bootstrapBrewOverride` の緩め方（サインイン済み前提の
   構成分離等）の設計から始める
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -113,34 +113,19 @@ sudo /run/current-system/sw/bin/darwin-rebuild switch --flake .#default --impure
 <details>
 <summary><b>3. Mac App Store 限定アプリを追加したい</b></summary>
 
-### 手順
+現在 MAS アプリの利用はゼロで、`homebrew.masApps` 経由の install は使っていない。
 
-```sh
-# 1. App ID を取得
-mas search "App Name"
-# または App Store の "Share Link" から /id1234567890 部分を抜く
+**⚠️ 生きている制約**: `flake.nix` の `bootstrapBrewOverride` が `homebrew.masApps` を
+`lib.mkForce { }` で強制的に空にする（App Store 未サインインの bootstrap/CI/VM で
+switch を落とさないため。PR #108 で常用 + bootstrap 共通方針に統一）。
+**masApps に何を宣言しても live では `{}`** — 「宣言したのに入らない」は不具合ではない。
 
-# 2. system/modules/homebrew.nix の masApps に追記
-#    masApps = {
-#      "EdgeView 3" = 1580323719;
-#      "NewApp"     = 1234567890;
-#    };
+将来 MAS アプリが必要になったら:
 
-# 3. PR ~ merge（セクション 2 と同じフロー）
-```
-
-### ⚠️ 既知の制約（2 段重ね）
-
-1. **`bootstrapBrewOverride` が masApps を強制的に空にする**
-   `flake.nix` の `darwinConfigurations.default` には `lib.mkForce { }` を含む override が適用される（PR #108 で常用 + bootstrap 共通方針に統一）。**masApps に何を宣言しても live では `{}`**。
-2. brew 同梱 `mas 1.8.6` は macOS 15+ で `mas get/install` が壊れていた経緯あり ([CLAUDE.md:67](../CLAUDE.md))。`brew upgrade mas` で 7.x 化すれば解消するが、nix-darwin の homebrew モジュールは内部で brew 同梱 `mas` を呼ぶため迂回しづらい。
-
-そのため実際の install は:
-
-- (a) 手動で App Store からインストール済みにしておく（最も確実）、または
-- (b) Nix 側の `mas`（`home/modules/packages.nix` 経由）で別途 `mas install <id>` を手で叩く
-
-将来 `bootstrapBrewOverride` を緩めるか、nix-darwin の mas 呼び出しが Nix 側を見るようになれば nix-darwin homebrew 経由の install が復活する想定。
+- (a) 手動で App Store からインストール（最も確実）、または
+- (b) Nix 側の `mas`（`home/modules/packages.nix` 経由）で `mas install <id>` を手で叩く
+- 宣言的に戻したい場合は `bootstrapBrewOverride` の緩め方（サインイン済み前提の
+  構成分離等）の設計から始める
 
 </details>
 
@@ -321,7 +306,6 @@ ghq-get-mine                                                   # 自リポジト
 | switch 後の親シェルで PATH 異常に見える | `__NIX_DARWIN_SET_ENVIRONMENT_DONE=1` 継承の false positive → **新ターミナル**または `env -i HOME=$HOME /bin/zsh -l -c '...'` |
 | `chezmoi apply` が prompt で止まる | MM 状態 → `--force` で source 優先、または re-add で live 優先 |
 | cask が CI で fail | cask 名タイポ / 廃止 / macOS 要件不一致 → `brew info --cask <name>` で確認 |
-| `mas install` が無音失敗 | brew 同梱 mas のバグ（過去 1.8.6 系で macOS 15+ 不具合）→ Nix 側 `mas`（`home/modules/packages.nix`）経由で叩く |
 | `system.defaults` がアプリに反映されない | TCC/sandbox 保護領域（Mail/Safari/Calendar 等）は switch 成功でも適用されない、深追いしない |
 
 ### 5.10 chord daemon を手元 build で入れ替え（AX 維持）

--- a/docs/reproduction-architecture.md
+++ b/docs/reproduction-architecture.md
@@ -129,7 +129,7 @@ chezmoi apply                                              # dotfile
 
 - nixpkgs にある CLI（jq, gh, ghq, direnv, shellcheck, cmake, act, trash 等）→ `home.packages`
 - cask（chrome, raycast, karabiner-elements, vscode 等）→ `homebrew.casks`
-- mas（PopClip ほか）→ `homebrew.masApps`
+- mas → 対象なし（PopClip 等は不要判断で drop。`homebrew.masApps` は未使用）
 - カスタム tap（borders=felixkratz, rift=acsandmann, skhd=jackielii 等）→ `homebrew.brews`+`taps`
 - `sleepwatcher (restart_service)` → `homebrew.brews`（service 扱いの正確な option 名は nix-darwin manual で要確認）
 - macOS defaults（system-inventory の表）→ `system.defaults` / `CustomUserPreferences`

--- a/flake.nix
+++ b/flake.nix
@@ -76,9 +76,8 @@
       #   - autoUpdate=true: cask メタデータが古いと上流 cask 更新直後に
       #     checksum mismatch で brew bundle fetch が失敗する。activation の
       #     度に brew update を強制して fresh metadata を引く。
-      #   - masApps 空: 1Password など App Store サインインが必要な mas は
-      #     bootstrap/CI/VM の文脈ではセットアップできず、`mas 1.8.6` は
-      #     macOS 15+ で `mas get/install` が壊れているため強制空に。
+      #   - masApps 空: App Store サインインが必要な mas install は bootstrap/CI/VM
+      #     の文脈では成立しないため強制空に（現在 MAS アプリ利用ゼロ、宣言も空）。
       bootstrapBrewOverride = { lib, ... }: {
         homebrew.masApps = lib.mkForce { };
         homebrew.onActivation.autoUpdate = lib.mkForce true;

--- a/home/modules/packages.nix
+++ b/home/modules/packages.nix
@@ -17,7 +17,6 @@
     chezmoi # dotfiles 管理本体
     ghq     # リポジトリ管理（go get 風 clone）
     jq      # JSON CLI
-    mas     # Mac App Store CLI（masApps 宣言と独立して `mas search` 等で使える）
 
     # === 開発 util（t-e77z B-4: 未宣言 brew の仕分け宣言）===
     # xcodes: Xcode の版管理・install CLI（Swift 開発の複数 Xcode 運用）

--- a/home/modules/zsh.nix
+++ b/home/modules/zsh.nix
@@ -36,7 +36,7 @@
   };
 
   # 初手② プロンプト: starship（zsh integration は enable だけで自動 wiring）。
-  # Nerd Font は homebrew.nix の font-hack-nerd-font が受け皿。設定は当面デフォルト、
+  # 設定は当面デフォルト（Nerd Font cask は未使用判断で drop 済み・依存しない）、
   # カスタムしたくなったら programs.starship.settings で宣言的に育てる。
   programs.starship.enable = true;
 }

--- a/system/modules/homebrew.nix
+++ b/system/modules/homebrew.nix
@@ -49,28 +49,11 @@
       "the-unarchiver"      # 解凍
       "visual-studio-code"  # エディタ（主力。zed は統合して drop）
       "vlc"                 # メディア
-
-      # === inventory「維持」確定組 ===
-      "popclip"             # テキスト操作（単体で標準動作、karabiner 連携は廃止）
-      "alt-tab"             # Cmd-Tab 強化（単体動作、karabiner 連携は廃止）
-      "font-hack-nerd-font" # プロンプト/ターミナル用 Nerd Font
-
-      # === 任意・現に導入済（新PC 再現で欠落しないよう宣言）===
-      "linearmouse"         # マウス挙動カスタム（速度/加速。WM 非該当のため維持）
-      "via"                 # キーボード(QMK/VIA) マッピング GUI（自作キーボード用）
-      "transmission"        # BitTorrent
-      "monodraw"            # ASCII アート / テキスト図エディタ
     ];
 
-    # 明示的に未宣言（破棄方針 / cleanup=zap 化で実体が消える）:
-    #   google-japanese-ime  ← azookey に置換済
-    #   karabiner-elements   ← 新PC では使わない方針（remapping は手放す, t-e77z）
-    #   raycast / warp / fsnotes / zed ← GUI コールドスイープで未使用と判明し drop (t-e77z)
-    #   omniwm / flashspace / borders  ← WM スタック drop (t-e77z C-5)
-
-    # mas は macOS 15+ の get バグ（mas 1.8.6）で凍結中。EdgeView は「不要」判断で
-    # 宣言を撤去したため、現状 masApps は空。再開時は brew の mas を 7.0.0+ にしてから
-    # 必要な id を足す。
+    # masApps は未使用（MAS アプリ利用ゼロ。EdgeView は「不要」判断で撤去済み）。
+    # 宣言しても flake.nix の bootstrapBrewOverride（lib.mkForce { }）で live は空に
+    # なる点に注意（App Store 未サインインの bootstrap/CI/VM で switch を落とさないため）。
     masApps = { };
   };
 }


### PR DESCRIPTION
## Summary

- Drop 7 unused casks (user decision): popclip, alt-tab, font-hack-nerd-font, linearmouse, via, transmission, monodraw. Also remove the "explicitly undeclared" comment block.
- Retire the stale mas-bug freeze story: the mas 1.8.6 breakage was resolved 2026-05-26 (mas 7.0.0) and MAS app usage is now zero, but README/CLAUDE.md/operations.md/homebrew.nix still presented the bug as the current reason masApps is empty.
- Document the single live constraint everywhere: `bootstrapBrewOverride` force-empties `masApps` because App Store sign-in is unavailable in bootstrap/CI/VM contexts.
- README: remove the "manually install App Store apps" post-install step and the backup-file pointer (nothing to install).

Note: `cleanup = "none"`, so the dropped casks' installed apps remain on disk until removed manually.

SetStatus-task: https://github.com/akira-toriyama/projects/blob/main/.furrow/bodies/t-gn3d.md done

🤖 Generated with [Claude Code](https://claude.com/claude-code)