### PR TITLE
:construction_worker:(ci) bump the glyph release pin to v0.8.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
           persist-credentials: false
 
       - name: install glyph
-        uses: akira-toriyama/glyph/.github/actions/install@v0.8.0
+        uses: akira-toriyama/glyph/.github/actions/install@v0.8.1
         with:
           version: v0.8.0
           token: ${{ github.token }}


### PR DESCRIPTION
Ships glyph v0.8.1 (mention-escaping in notes / pr-verdict, glyph#38): `@v0.8.0` → `@v0.8.1` in `release.yml`.

SetStatus-task: https://github.com/akira-toriyama/projects/blob/main/.furrow/bodies/t-hykw.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)