### PR TITLE
:memo: docs(karabiner): drop Karabiner from docs and drift ignore-list

### DIFF
--- a/docs/reproduction-architecture.md
+++ b/docs/reproduction-architecture.md
@@ -24,7 +24,7 @@
 | カスタム tap のツール（borders, rift, skhd, krp 等） | **nix-darwin** `homebrew.brews` + `taps` | nixpkgs に無い→ brew 維持 |
 | macOS defaults（Dock/Finder/NSGlobalDomain 等） | **nix-darwin** `system.defaults` / `CustomUserPreferences` | 宣言的に再現。system-inventory が入力 |
 | zsh / starship / git のプログラム設定（DSL あり） | **home-manager** `programs.zsh` / `starship` / `git` | DSL で生成。現 `.zshrc` は刷新（後述） |
-| アプリ固有の手編集 dotfile（karabiner, borders, rift, focusfx, claude） | **chezmoi** | Nix DSL が無い・アプリ所有の生 JSON。現状維持 |
+| アプリ固有の手編集 dotfile（borders, rift, focusfx, claude） | **chezmoi** | Nix DSL が無い・アプリ所有の生 JSON。現状維持 |
 | シークレット（SSH 鍵, PAT, トークン） | **chezmoi + 1Password** `onepasswordRead` テンプレート | リポジトリに置かず apply 時に注入 |
 | 効果音等の不透明アセット（dot_local/share/sounds） | **chezmoi** | バイナリ資産 |
 | LaunchAgent（border-cycle 等） | **chezmoi**（現状の run_onchange 方式）/ システム級は nix-darwin | 既存資産を尊重 |
@@ -49,7 +49,7 @@ dotfiles/                       # 1リポジトリに flake と chezmoi 源を�
 │   └── modules/                #   zsh.nix / git.nix / packages.nix
 ├── chezmoi/                    # ★ chezmoi source root（.chezmoiroot の指す先）
 │   ├── .chezmoiignore  .chezmoi.toml.tmpl
-│   ├── dot_config/{karabiner,borders,rift,focusfx}/...   # 現 dot_config を移動
+│   ├── dot_config/{borders,rift,focusfx}/...   # 現 dot_config を移動
 │   ├── dot_claude/settings.json
 │   ├── dot_local/share/sounds/...
 │   ├── private_dot_ssh/private_id_*.tmpl   # ★ op から注入する秘密
@@ -128,7 +128,7 @@ chezmoi apply                                              # dotfile
 **Nix 化する（現 `dot_Brewfile` から）**
 
 - nixpkgs にある CLI（jq, gh, ghq, direnv, shellcheck, cmake, act, trash 等）→ `home.packages`
-- cask（chrome, raycast, karabiner-elements, vscode 等）→ `homebrew.casks`
+- cask（chrome, raycast, vscode 等）→ `homebrew.casks`（karabiner-elements は不採用で drop）
 - mas → 対象なし（PopClip 等は不要判断で drop。`homebrew.masApps` は未使用）
 - カスタム tap（borders=felixkratz, rift=acsandmann, skhd=jackielii 等）→ `homebrew.brews`+`taps`
 - `sleepwatcher (restart_service)` → `homebrew.brews`（service 扱いの正確な option 名は nix-darwin manual で要確認）
@@ -140,7 +140,7 @@ chezmoi apply                                              # dotfile
 
 **chezmoi に残す（Nix 化しない）**
 
-- `dot_config/{karabiner,borders,rift,focusfx}` … アプリ所有の生設定
+- `dot_config/{borders,rift,focusfx}` … アプリ所有の生設定
 - `dot_claude/settings.json`, `dot_local/share/*`
 - `run_onchange_border-cycle.sh.tmpl`（パッケージ導入ではなく挙動制御）
 - 新規: `private_*.tmpl`（SSH 鍵等を `onepasswordRead` で注入。`known_hosts` は非秘密で平文可）

--- a/docs/system-inventory.md
+++ b/docs/system-inventory.md
@@ -3,7 +3,7 @@
 再現したい macOS 環境の **パッケージ / macOS defaults の素材台帳**。
 **nix パッケージ層 / nix-darwin defaults を構築する際の入力**として使う（[reproduction-architecture.md](reproduction-architecture.md) 参照）。
 
-構築方針との対応: zsh=刷新 / ssh=1Password / IME=Azookey予定 / yabai=不採用 / karabiner=マウスのみ採用。
+構築方針との対応: zsh=刷新 / ssh=1Password / IME=Azookey予定 / yabai=不採用 / karabiner=不採用。
 
 ## Homebrew taps
 
@@ -35,13 +35,13 @@
 
 | cask | 用途 | 方針 |
 |---|---|---|
-| alt-tab | ウィンドウ切替 | 維持候補（マウス設定が AltTab 前提） |
+| alt-tab | ウィンドウ切替 | 維持候補 |
 | appcleaner | アンインストーラ | 任意 |
 | font-hack-nerd-font | フォント | 維持候補 |
 | fsnotes | ノート | 任意 |
 | google-chrome | ブラウザ | 維持候補 |
 | google-japanese-ime | IME | **破棄**（Azookey 予定） |
-| karabiner-elements | キー/マウス再マップ | **維持**（マウス設定で必須） |
+| karabiner-elements | キー/マウス再マップ | **破棄**（不採用決定） |
 | raycast | ランチャー | 維持候補 |
 | the-unarchiver | 解凍 | 任意 |
 | transmission | BitTorrent | 任意 |
@@ -58,7 +58,7 @@
 | Dropover | 1355679052 | 任意 |
 | EdgeView 2 | 1206246482 | 任意 |
 | Flashcards | 307840670 | 任意 |
-| **PopClip** | **445189367** | **維持（ユーザー決定）**。karabiner button6 ルールが依存 |
+| **PopClip** | **445189367** | **維持（ユーザー決定）** |
 
 ## VS Code 拡張（要判断: nix/home-manager 管理 or 手動）
 

--- a/system/modules/scripts/check-dotfiles-drift.sh
+++ b/system/modules/scripts/check-dotfiles-drift.sh
@@ -41,7 +41,7 @@ set -eu
 
 # 「明示的に未宣言 (破棄方針)」相当の cask は通知から除外する。
 # homebrew.nix 末尾コメントの破棄方針リストとは別管理。両方を更新する想定。
-IGNORE_EXTRA_CASKS="google-japanese-ime karabiner-elements"
+IGNORE_EXTRA_CASKS="google-japanese-ime"
 
 # git の未コミットは「この日数以上どのファイルも触られていない」時だけ通知する。
 # 作業中 (= 最近編集) は鳴らさず、本当に忘れて放置したものだけ拾うための滞留ゲート。


### PR DESCRIPTION
Karabiner-Elements is not adopted (user decision). It is neither installed (no cask, no `~/.config/karabiner`) nor declared in `homebrew.nix`, but docs still said "keep — required for mouse config". This PR aligns the docs and the drift script with reality:

- **docs/system-inventory.md** — 構築方針を `karabiner=不採用` に変更、cask 方針を 維持→破棄、alt-tab / PopClip 行から karabiner 依存の記述を削除
- **docs/reproduction-architecture.md** — chezmoi の `dot_config/{...}` リストと cask 移行例から karabiner を除去
- **system/modules/scripts/check-dotfiles-drift.sh** — `IGNORE_EXTRA_CASKS` から `karabiner-elements` を削除（既に uninstall 済みで抑止対象が存在しない。今後もし入っても drift 通知される側に倒す）

Kept as-is: generic *example* mentions of Karabiner (cli-app-dev SKILL.md, wand config.toml comment) — design-philosophy examples, not claims that this machine uses it.

Verified: `nix flake check --no-build` ✅

SetStatus-task: https://github.com/akira-toriyama/projects/blob/main/.furrow/bodies/t-4gc3.md done

🤖 Generated with [Claude Code](https://claude.com/claude-code)