### PR TITLE
:sparkles:(packages) put glyph on PATH via the source-build wrapper

### DIFF
--- a/chezmoi/private_dot_claude/CLAUDE.md
+++ b/chezmoi/private_dot_claude/CLAUDE.md
@@ -99,6 +99,12 @@ source-build wrapper＝呼ぶたび変更検知で rebuild）。**作って終�
 - **cifail** — CI 失敗の要点抽出。生 run ログを漁らず `cifail`（cwd の remote/現 branch から推定。
   `--pr N` / `--branch B` / `--run ID` / `--json`）。job ゼロの失敗 run（workflow 文法エラー等）も拾う。
 - **furrow** — タスク管理（↑ Workflow 節が正典）。
+- **glyph** — commit 規約の正本（gitmoji → semver → notes）。**commit する前に
+  `glyph lint --range origin/main..HEAD`**（1 通なら `--message "<subject>"`）。
+  push してから CI の commit-lint で落ちるのは 1 往復の無駄で、実際に起きている
+  （scope の大文字 1 文字で exit 3）。規約は暗記せず `glyph rules` を引く。
+  repo に commit-msg hook を入れるなら `glyph hook install`（hook は glyph を呼ぶ
+  だけなので規約が動いても drift しない）。
 - 条件待ち・GUI 検証は自作でなく adopt 済（wait4x / peekaboo、↑ Repo 現在地節の bullet）。
 
 ## 自作アプリ・自作 CLI は source を使う（brew 版は使わない）

--- a/home/modules/packages.nix
+++ b/home/modules/packages.nix
@@ -270,6 +270,28 @@
       exec "$bin" "$@"
     '')
 
+    # glyph: furrow と同型の source-build ラッパ。commit 規約（gitmoji → semver →
+    # notes）の正本 CLI で、これが PATH に居ないと規約違反は push して CI が回るまで
+    # 分からない（t-g6z9 の事故: scope の大文字 1 文字で commit-lint exit 3 → force-push
+    # と CI 再実行 1 往復）。commit 前に `glyph lint --range origin/main..HEAD`。
+    # cifail と同じく呼び出し元 cwd の git を読む（--range / --stdin いずれも）ので、
+    # (cd src) は build 用 subshell に閉じ exec は呼び出し元 cwd のまま実行する。
+    # `glyph hook install` が書く commit-msg hook もこの wrapper を PATH 越しに呼ぶ
+    # ＝ wrapper が無い間 hook は warn して pass する（no-op）ので、これが hook を
+    # 実効化する前提でもある。
+    (writeShellScriptBin "glyph" ''
+      set -eu
+      src=/Volumes/workspace/github.com/akira-toriyama/glyph
+      cache="''${XDG_CACHE_HOME:-$HOME/.cache}/glyph"
+      bin="$cache/glyph"
+      if [ ! -x "$bin" ] || [ -n "$(find "$src/cmd" "$src/internal" "$src/go.mod" "$src/go.sum" -newer "$bin" 2>/dev/null)" ]; then
+        mkdir -p "$cache"
+        if command -v go >/dev/null 2>&1; then gobuild=go; gotc=local; else gobuild=${pkgs.go}/bin/go; gotc=auto; fi
+        ( cd "$src" && env -u GOROOT GOTOOLCHAIN="$gotc" "$gobuild" build -o "$bin.tmp.$$" ./cmd/glyph && mv -f "$bin.tmp.$$" "$bin" ) >&2
+      fi
+      exec "$bin" "$@"
+    '')
+
     # revpost: furrow と同型の source-build ラッパ。findings JSON（native / reviewdog
     # rdjson・rdjsonl）を pipe して anchor 検証済みの inline PR review を一括投稿する
     # CLI（422 根絶）。target は明示引数 `owner/repo#N` で cwd 非依存・auth は gh を


### PR DESCRIPTION
## Why

glyph is the **source of truth for the commit convention**, but it was the one family CLI with no wrapper here — `command -v glyph` came back empty while furrow / pare / cifail / rundiff / revpost all resolve.

So a convention violation was only visible **after a push**, once CI ran commit-lint. That's a real round trip, not a hypothetical: a single uppercase letter in a scope (`:bug:(parseFlat)` — scope is `[a-z0-9][a-z0-9-]*`) exited 3 and cost a force-push plus a CI re-run (t-g6z9).

## What

- **`home/modules/packages.nix`** — the same always-fresh-from-source wrapper furrow/pare/cifail use: rebuild on change into `~/.cache`, atomic `mv`, `(cd src)` scoped to the build so `exec` runs in the **caller's cwd** (glyph reads the caller's git for `--range` and `--stdin`)
- **`chezmoi/private_dot_claude/CLAUDE.md`** — add glyph to the "自作 CLI（いつ使うか）" section so `glyph lint --range origin/main..HEAD` becomes the reflex before committing, and `glyph rules` the way to look up the convention instead of recalling it

## This also makes the commit-msg hook real

`glyph hook install` (glyph#44, merged today) writes a hook that shells out to glyph and — by design — **warns and passes when glyph is absent from PATH**, because CI is the authority and a missing tool must not make committing impossible.

That means until this wrapper exists, the hook is a **no-op on this machine**, and distributing it to the fleet (t-7m35, six repos) would install six no-ops. This PR is the prerequisite for that rollout.

## Verification

- `nix-instantiate --parse` on the modified `packages.nix`: clean
- Wrapper logic simulated verbatim outside nix — builds, `glyph version` reports `dev (9d82a31)`, and `glyph lint --range origin/main..HEAD` resolves the **caller's** repo, confirming the `(cd src)` subshell doesn't leak cwd

## Needs your hand

`darwin-rebuild switch` is yours to run — the wrapper won't be on PATH until then.

SetStatus-task: https://github.com/akira-toriyama/projects/blob/main/.furrow/bodies/t-g6z9.md in-progress

🤖 Generated with [Claude Code](https://claude.com/claude-code)