### PR TITLE
:bug:(install) suppress idle sleep so 1Password stays unlocked

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,13 @@ sudo -v && sh -c "$(curl -fsLS https://raw.githubusercontent.com/akira-toriyama/
 - SSH gate（1Password）起因の失敗だけを直した後は近道がある:
 
   ```sh
+  export GH_TOKEN=<PAT>   # 別ターミナルなら再 export が要る（下記）
   sh ~/dotfiles/install.sh --phase2
   ```
+
+  - **`--phase2` も P1-ghtoken gate を通る**。`GH_TOKEN` はシェル変数なので、
+    ターミナルを開き直した／再起動した後は消えている。再 export せずに叩くと
+    SSH を直した直後に `P1-ghtoken` で即 fail する（二段の徒労）
 
 ### ログと結果（機械可読）
 

--- a/chezmoi/run_onchange_install-vscode-extensions.sh
+++ b/chezmoi/run_onchange_install-vscode-extensions.sh
@@ -16,9 +16,27 @@ if [ ! -x "$CODE_BIN" ]; then
   exit 0
 fi
 
+# `code --install-extension` は Aqua セッションが無いと（SSH 越しの実行・headless VM
+# での検証など）Electron が WindowServer に繋がれず無期限にブロックする。実測
+# 2026-07-20: Tart VM を SSH 駆動した `install.sh --skip-clone` の chezmoi apply が
+# この 1 行で 37 分ハングし（CPU ゼロ = 純粋な block）、install 全体が停止した。
+# install.sh 側の df_step chezmoi-apply に watchdog は無いので、ここで自前で張る。
+# macOS に timeout(1) は無いため background + sleep watchdog（install.sh の SSH gate
+# と同じ機構）。拡張は環境の必須要素ではないので、失敗しても warn して続行する
+# —— VSCode 未導入時に exit 0 で skip しているのと同じ扱い。
 for ext in \
   anthropic.claude-code
 do
-  "$CODE_BIN" --install-extension "$ext" --force >/dev/null
+  "$CODE_BIN" --install-extension "$ext" --force >/dev/null &
+  ext_pid=$!
+  ( sleep 120; kill "$ext_pid" 2>/dev/null ) >/dev/null 2>&1 &
+  ext_watchdog=$!
+  if wait "$ext_pid" 2>/dev/null; then
+    kill "$ext_watchdog" 2>/dev/null || :
+  else
+    kill "$ext_watchdog" 2>/dev/null || :
+    echo "⚠ $ext のインストールに失敗/タイムアウト（GUI セッション外での実行が疑わしい）。" >&2
+    echo "  スキップして続行する。GUI セッションで chezmoi apply を再実行すれば入る。" >&2
+  fi
 done
 echo "VSCode 拡張のインストール完了"

--- a/docs/reproduction-architecture.md
+++ b/docs/reproduction-architecture.md
@@ -108,6 +108,36 @@ chezmoi apply                                              # dotfile
 - **chezmoi を最後**にする（`op signin` 済みでないと秘密テンプレートが失敗するため）。
 - 実装は [install.sh](../install.sh) の §1.5 を参照（冪等: 既に case-sensitive 領域があれば skip）。
 
+### 3.1 無人実行の前提条件（変更時は必ずここを見る）
+
+`install.sh` は単一ステージの**無人**一気通貫で、`clone` を在席ステージに分けていない。
+その設計が成立する根拠は 1 つだけ:
+
+> **実行中ずっと 1Password が解錠されたままであること。**
+
+SSH gate（`P-onepassword`）が 1Password agent の実署名を要求するため、run 中に
+一度でも施錠されると `✓ 完了` に到達できない。しかも**無人での復帰手段が無い**
+（新 Mac は Touch ID 未登録・システム解錠 無効 = GUI で人がパスワードを打つ以外に無い）。
+したがって「施錠されたら諦める」ではなく「**施錠させない**」でしか守れない。
+
+この前提を破り得る要素と、現在の守り:
+
+| 破る要素 | 守り | 場所 |
+|---|---|---|
+| 1Password の自動ロックタイマー | 事前準備で OFF にさせる | [README](../README.md) 事前準備 2 |
+| 画面オフ → `autolock.onDeviceLock` で施錠 | `caffeinate -dis` を run 全体に張る | [install.sh](../install.sh) logging prelude 直後 |
+| idle system sleep | 同上（`-i` / `-s`） | 同上 |
+
+**注意**: [power.nix](../system/modules/power.nix) の `power.sleep.display = 5` は
+`darwin-switch` の最中に適用される。つまり **run 自身が「5 分放置で画面オフ」を仕込む**。
+端末への出力は HID 入力ではないのでタイマーを戻さず、20 分の switch を挟むと確実に
+画面が消える。2026-07-20 の実測ではこれが原因で `P-onepassword` が落ちた
+（画面オフ 08:06:27 → 1Password 施錠 → gate 08:17:33 で承認プロンプト時間切れ）。
+
+**この前提は commit body にしか書かれておらず（`e2ff5a2` / #219）、同日の別 PR
+（`e74cbbc` / #220、`power.sleep` 導入）が無言で無効化した。**同じ事故を繰り返さないため、
+電源・ロック・スリープ・1Password 設定に触る変更は必ずこの節と突き合わせること。
+
 ---
 
 ## 4. 落とし穴と回避（コミュニティ既知）

--- a/install.sh
+++ b/install.sh
@@ -241,6 +241,30 @@ trap 'exit 130' INT
 trap 'exit 143' TERM
 # ===== logging prelude ここまで =====
 
+# ── idle sleep 抑止（無人完走の前提条件。実測 2026-07-20 で確立）──────────────────
+# 本 run 自身が仕掛ける自滅を塞ぐ。因果は 4 段:
+#   1. darwin-switch が system/modules/power.nix の power.sleep.display = 5 を適用
+#      （実測 08:01:16 powerd "Sleep timer 0 display timer 5"）
+#   2. 端末への出力は HID 入力ではないので display sleep タイマーを戻さない。
+#      20 分無操作の switch/chezmoi を挟むので 5 分後に画面が消える（実測 08:06:27）
+#   3. 1Password は画面オフを DeviceWentToSleep と解釈して施錠する。README が OFF に
+#      させる `security.autolock.minutes` とは別系統の `security.autolock.onDeviceLock`
+#      （既定 有効）が効くため、事前準備どおり手順を踏んでいても防げない
+#      （実測 08:06:27 "Locked. Reason: Automatic(DeviceWentToSleep)"）
+#   4. 施錠された agent は SSH gate の署名要求に承認プロンプトを出し、無人なので
+#      60 秒で時間切れ → P-onepassword が落ちる（実測 08:17:33 "ssh authorization
+#      prompt timed out"）。gate の 75 秒 watchdog はこれより後なので発火しない
+# 一度ロックされると無人復帰は不可能（Touch ID 未登録・システム解錠 無効の新 Mac では
+# 人間が GUI でパスワードを打つ以外に手が無い）。よって事後リカバリでなく予防で塞ぐ。
+# -w $$ で本スクリプト終了時に自動で落ちる（trap 不要 = SIGKILL 死でも残骸が出ない）。
+if [ -x /usr/bin/caffeinate ]; then
+  /usr/bin/caffeinate -dis -w $$ &
+  df_say "idle sleep 抑止を開始（caffeinate -dis。実行中のみ）"
+else
+  df_say "WARNING: /usr/bin/caffeinate が無い。長い phase 中の画面オフで 1Password が"
+  df_say "         施錠され SSH gate が落ちる可能性がある"
+fi
+
 # ── 共有ヘルパ（full と --phase2 の両方が使う）─────────────────────────────────
 # CLT 判定。/usr/bin/git は shim（実行すると CLT 不在時に GUI ダイアログ）なので
 # 判定に使わない。phase2 でも git を叩く前に必ずこれで確認する。

--- a/system/modules/power.nix
+++ b/system/modules/power.nix
@@ -7,6 +7,11 @@
   #
   # 画面ロック解除（`sysadminctl -screenLock off -password -`）は対で行う手動 1 回の
   # 操作。ByHost 域のため nix-darwin では管理できない — defaults.nix 冒頭コメント参照。
+  #
+  # ⚠️ display = 5 は install.sh の無人実行と干渉する（switch 中に適用され、5 分後の
+  # 画面オフが 1Password を施錠して SSH gate を殺す。実測 2026-07-20）。install.sh 側は
+  # caffeinate -dis で塞いでいる。ここを触る時は docs/reproduction-architecture.md §3.1
+  # 「無人実行の前提条件」と必ず突き合わせること。
   power.sleep = {
     display = 5;         # 放置 5 分で画面を完全オフ（OLED は減光より消灯が正）
     computer = "never";  # 画面オフ中も本体を眠らせない（バックグラウンド作業を止めない）


### PR DESCRIPTION
## 何が起きていたか

実機の run（2026-07-20 07:42:59 開始）が **34 分後に `P-onepassword` で FAILED**。
`install.sh` が **自分で自分の足を撃っていた**。

```
08:01:16  powerd: Sleep timer 0 display timer 5      ← darwin-switch が power.sleep.display=5 を適用
08:06:27  Display is turned off                      ← 端末出力は HID 入力でないので 5 分で消灯
08:06:27  1Password: Locked. Reason: Automatic(DeviceWentToSleep)
08:16:32  SSH gate 到達 → 承認プロンプト表示
08:17:33  ssh authorization prompt timed out         ← 60 秒無応答
```

**operator の手順ミスではない。** 1Password の `settings.json`（mtime 07:31:09 = 実行開始より前）に
`"security.autolock.minutes": -1` と `"sshAgent.enabled": true` が入っており、
unified log には 07:34:52 の検証 `ssh -T`・07:34:59 の承認クリックまで残っている。
事前準備 (b)(c)(d)(e) は完遂されていた。

効いたのは**別系統のキー** `security.autolock.onDeviceLock`（未設定＝既定で有効）。
README が OFF させる `autolock.minutes` では塞げない上、README は括弧書きで
「スリープ時ロックは残す」と塞ぐ手段を明示的に禁じている。

## なぜ retry でなく caffeinate か

一度施錠されると**無人復帰の経路が存在しない**。新しい Mac は Touch ID 未登録
（`current_availability: NotEnrolled`）・システム解錠 無効（`System unlock is enabled: false`）で、
GUI に居る人間がパスワードを打つ以外に解錠手段が無い。よって事後リカバリではなく予防でしか守れない。

gate の 75 秒 watchdog も無力（agent 側の 60 秒 timeout が先に切れるので発火しない）。

## 変更

- `install.sh` — logging prelude 直後に `caffeinate -dis -w $$`。`-w $$` で本スクリプトの寿命に
  縛るので trap 不要・SIGKILL でも残骸なし
- `docs/reproduction-architecture.md` — §3.1「無人実行の前提条件」を新設
- `system/modules/power.nix` — §3.1 への相互参照コメント
- `README.md` — リカバリ節に `--phase2` も `GH_TOKEN` 再 export が要る旨（別コミット）

## なぜレビューで防げなかったか（再発防止の芯）

単一ステージ化 `e2ff5a2` (#219) の設計前提は commit body にだけ書かれていた:

> keep 1Password unlocked during work (auto-lock timer OFF, sleep-lock stays)
> — which removes the only reason the clone lived in a separate attended stage.

その唯一の根拠を **同日の別 PR `e74cbbc` (#220)（`power.sleep` 導入）が無言で無効化**した。
コードにも README にも docs にも無いので、レビューで検出しようがなかった。
→ §3.1 に明文化し、`power.nix` から相互参照した。

さらに、**過去の VM リハーサルはこのバグを構造的に隠していた**。VM には 1Password を
入れられないため `P-onepassword` での FAILED を「想定どおり正直に落ちた」と評価しており、
1Password が*在る*ときに施錠されて落ちる経路は一度も試されていない。

## 検証

- `shellcheck install.sh` / `sh -n install.sh` / `nix flake check --no-build` — 全 pass
- `caffeinate -dis -w $$` の実測: `PreventUserIdleDisplaySleep 1` /
  `PreventUserIdleSystemSleep 1` / `PreventSystemSleep 1` が立ち、親終了後に残骸ゼロ
- クリーン Tart VM（vanilla macOS 26.5）で `--skip-clone` フル実行を並行検証中

SetStatus-task: https://github.com/akira-toriyama/projects/blob/main/.furrow/bodies/t-8qqz.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)