### PR TITLE
:wrench:(azookey) move the 「」 chords from fi/fo to fn/fm

### DIFF
--- a/chezmoi/private_Library/private_Containers/private_dev.ensan.inputmethod.azooKeyMac/private_Data/private_Library/private_Application Support/azooKeyMac/CustomInputTable/custom_input_table.tsv
+++ b/chezmoi/private_Library/private_Containers/private_dev.ensan.inputmethod.azooKeyMac/private_Data/private_Library/private_Application Support/azooKeyMac/CustomInputTable/custom_input_table.tsv
@@ -234,14 +234,14 @@ pyo	ぴょ
 fa	ふぁ
 hwa	ふぁ
 fwa	ふぁ
-fi	「
+fi	ふぃ
 hwi	ふぃ
 fwi	ふぃ
 fwu	ふぅ
 fe	ふぇ
 hwe	ふぇ
 fwe	ふぇ
-fo	」
+fo	ふぉ
 hwo	ふぉ
 fwo	ふぉ
 fya	ふゃ
@@ -296,6 +296,8 @@ fh	？
 fj	ー
 fk	、
 fl	。
+fn	「
+fm	」
 ！	!
 ”	"
 ＃	#


### PR DESCRIPTION
## 何を変えたか

azooKey のカスタムローマ字表で、全角約物 `「` `」` の f 系コードを移設した。

| 入力 | before | after |
|---|---|---|
| `fn` | （f + ん系の宙ぶらりん） | `「` |
| `fm` | （同上） | `」` |
| `fi` | `「` | `ふぃ`（上流既定へ復帰） |
| `fo` | `」` | `ふぉ`（上流既定へ復帰） |

`fh ？` / `fj ー` / `fk 、` / `fl 。` は変更なし。fn/fm はその home-row ブロックを同じ右手の下段へ延長する。

## なぜ

`fi`/`fo` は実在のローマ字キーで、割り当てが `ふぃ`/`ふぉ` を潰していた（`firumu` → `「るむ`、`ffi` → `っ「`）。fn/fm は上流既定表にもこの表にも存在しない未使用キーなので、何も潰さない。

## 検証

上流 [AzooKeyKanaKanjiConverter](https://github.com/azooKey/AzooKeyKanaKanjiConverter)（`Core/Package.swift` が pin する `b724d68`）の実装を読み、converter を実際にビルドして差分実行した。

- **上流既定値の確認**: `defaultRoman2Kana.swift:241,248` → `"fi": "ふぃ"` / `"fo": "ふぉ"`。`fn`/`fm` は既定表に**不在**（`rg 'fn|fm'` が 0 件）
- **衝突なし**: マッチャは**逆順サフィックストライ + 最長一致**（`InputTable.swift`）。`n{any character}` → `ん` は「直前が `n`」で発火、`fn` は「直前が `f`」で発火 → 発火条件が排他で互いに隠せない。`ff` → `っf` はリテラル `f` を残すので `ffn` → `っ「`
- **全探索差分**: `[a-z]^1..4` の 475,254 通りを before/after 両表で実行 → 差分 2,796 root すべてが `fi`/`fo`/`fn`/`fm` に由来。未説明の差分 **0**。`maxKeyCount=4` なので深さ 4 の網羅は完全性の証明になる
- **書式**: `InputStyleManager.checkFormat` が両表とも `.fullyValid`（重複キー検出込み）。335 行 / タブ 1 個 / 末尾 LF あり / CR・BOM・行末空白なし
- **副次的な修正**: `fi`/`fo` を戻したことで、既定表を全置換するこの表の 1-292 行が上流 `defaultRomanToKanaMap` と key・value・順序すべて一致に復帰した。**既定ルールの上書きがゼロ**になる
- 回帰チェック: `nihonngo`→にほんご / `konnnichiha`→こんにちは / `kannji`→かんじ / `unmei`→うんめい / `anmari`→あんまり / `sutaffu`→すたっふ / `nya`→にゃ / `fwi`→ふぃ すべて不変

`chezmoi apply` 済み、live と source は byte 一致。

## 反映

TSV の編集は `run_onchange_after_configure-azookey.sh` のハッシュを動かさないので自動再読み込みはされない。`CustomInputTableStore.registerIfExists()` が `activateServer` で走るため、**入力ソースを一旦 ABC に切り替えて戻すだけ**で再登録される（`killall` は不要 — アクティブ IME の kill は入力ソース一覧から外れる事故があるため避ける）。

SetStatus-task: https://github.com/akira-toriyama/projects/blob/main/.furrow/bodies/t-4rm8.md done

🤖 Generated with [Claude Code](https://claude.com/claude-code)