### PR TITLE
:bug:(install) detach caffeinate from the FIFO so the run can finish

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -258,7 +258,13 @@ trap 'exit 143' TERM
 # 人間が GUI でパスワードを打つ以外に手が無い）。よって事後リカバリでなく予防で塞ぐ。
 # -w $$ で本スクリプト終了時に自動で落ちる（trap 不要 = SIGKILL 死でも残骸が出ない）。
 if [ -x /usr/bin/caffeinate ]; then
-  /usr/bin/caffeinate -dis -w $$ &
+  # fd を FIFO から切り離す（>/dev/null 2>&1）。切り離さないと caffeinate が FIFO の
+  # write 端を掴んだまま install.sh の終了を待ち、install.sh は df_finish の wait(tee)、
+  # tee は FIFO の EOF を待つ三つ巴のデッドロックになる（RESULT は出るが summary.txt が
+  # 書かれず、プロセスが永久に終わらない。実測 2026-07-20 の Tart VM で再現）。
+  # SSH gate の watchdog が同じ理由で同じ対策を取っている（下の「watchdog の fd を
+  # FIFO から切り離す」を参照）。
+  /usr/bin/caffeinate -dis -w $$ >/dev/null 2>&1 &
   df_say "idle sleep 抑止を開始（caffeinate -dis。実行中のみ）"
 else
   df_say "WARNING: /usr/bin/caffeinate が無い。長い phase 中の画面オフで 1Password が"


### PR DESCRIPTION
## リグレッション（#249 で私が入れたもの）

#249 の `caffeinate` は `exec > "$DF_FIFO_DIR/pipe" 2>&1` の**後**に起動しているので、
logging 用 FIFO を stdout/stderr として継承していた。結果、run の終端で三つ巴のデッドロック:

```
install.sh(742) → df_finish の wait(tee) でブロック
tee(748)        → FIFO の EOF 待ちでブロック
caffeinate(751) → その FIFO の write 端(fd 1w,2w)を掴んだまま -w $$ で install.sh を待つ
```

`RESULT: PARTIAL (exit 0)` は表示されるが、**`summary.txt` が書かれずプロセスが永久に終わらない**。
README が「まずここを読め」と指定している機械可読ファイルが欠落するので実害がある。

## 実測

Tart VM（clean vanilla → 修正版ワンライナー）で再現:

```
$ lsof -p 751
caffeinat 751 admin 1w FIFO .../dfinstall.VZwKoD/pipe
caffeinat 751 admin 2w FIFO .../dfinstall.VZwKoD/pipe
$ sample 742
654 __wait4 (in libsystem_kernel.dylib)
$ ls .../20260720-115554-full/summary.txt
No such file or directory
```

最小再現スクリプトで両方向を確認:

| | 結果 |
|---|---|
| fd を FIFO に繋いだまま | `wait(tee)` から戻らない（20秒で強制終了） |
| `>/dev/null 2>&1` で切り離す | 即座に戻る |

## なぜ起きたか

[install.sh](install.sh) の SSH gate watchdog は**同じ罠を既に文書化して回避**していた:

> watchdog の fd を FIFO から切り離す（`>/dev/null 2>&1`）。切り離さないと kill 後も
> orphan の sleep が FIFO の write 端を掴み、df_finish の wait(tee) が最大 75 秒止まる

#249 はこの先例を踏襲し損ねた。しかも `caffeinate -w $$` は install.sh 自身を待つので、
sleep の「最大 75 秒」と違って**永久に解けない**。

## 検証

- `shellcheck install.sh` / `sh -n install.sh` — pass
- 最小再現による before/after 比較 — 上表のとおり

SetStatus-task: https://github.com/akira-toriyama/projects/blob/main/.furrow/bodies/t-8qqz.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)