### PR TITLE
:arrow_up:(release) adopt glyph v0.10.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
           persist-credentials: false
 
       - name: install glyph
-        uses: akira-toriyama/glyph/.github/actions/install@v0.8.1
+        uses: akira-toriyama/glyph/.github/actions/install@v0.10.0
         with:
           version: v0.8.0
           token: ${{ github.token }}


### PR DESCRIPTION
Matches akira-toriyama/.github#119. The install action pin was still v0.8.1, so CI installed a binary older than the pinned workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)