### PR TITLE
:arrow_up:(release) adopt glyph v0.10.1

### DIFF
--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -17,4 +17,4 @@ permissions:
 
 jobs:
   lint:
-    uses: akira-toriyama/glyph/.github/workflows/lint.yml@v0.10.0
+    uses: akira-toriyama/glyph/.github/workflows/lint.yml@v0.10.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
           persist-credentials: false
 
       - name: install glyph
-        uses: akira-toriyama/glyph/.github/actions/install@v0.10.0
+        uses: akira-toriyama/glyph/.github/actions/install@v0.10.1
         with:
           version: v0.8.0
           token: ${{ github.token }}

--- a/.github/workflows/version-preview.yml
+++ b/.github/workflows/version-preview.yml
@@ -47,4 +47,4 @@ permissions:
 
 jobs:
   verdict:
-    uses: akira-toriyama/glyph/.github/workflows/pr-verdict.yml@v0.10.0
+    uses: akira-toriyama/glyph/.github/workflows/pr-verdict.yml@v0.10.1


### PR DESCRIPTION
Matches akira-toriyama/.github#121. Bumps glyph install/release pins v0.10.0 -> v0.10.1 (fixes the lowercase-trailer BREAKING CHANGE swallow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)