### PR TITLE
:memo:(docs) rename the bootstrap PAT item to DOTFILES_BOOTSTRAP

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@
 
 #### 3. GitHub PAT を環境変数に入れる
 
-- 1Password の item **`dotfiles bootstrap`**（Personal vault・fine-grained PAT）の credential を
+- 1Password の item **`DOTFILES_BOOTSTRAP`**（Personal vault・fine-grained PAT）の credential を
   コピーし、次のワンライナーと同じターミナルで実行する
 
   ```sh
@@ -53,7 +53,7 @@
 - 無い場合は序盤の P1-ghtoken gate で即 fail する（長い処理が走ってから死なない）
 - token は**無期限**（切れる心配は無い。実測 2026-07-20: 期限ヘッダ無し）。
   万一 revoke / rotate した場合は GitHub → Settings → Developer settings →
-  Fine-grained tokens → `dotfiles bootstrap` を **Regenerate** し、新しい値で
+  Fine-grained tokens → `DOTFILES_BOOTSTRAP` を **Regenerate** し、新しい値で
   1Password の同名 item を更新する
 
 ### 実行

--- a/install.sh
+++ b/install.sh
@@ -12,7 +12,7 @@
 #      → `ssh -o StrictHostKeyChecking=accept-new -T git@github.com` を 1 回実行し、
 #      1Password の承認ダイアログで「すべてのアプリで承認する」+ 認証
 #   3. GitHub fine-grained PAT（All repositories / Metadata: Read-only で足りる。t-8f19）を
-#      1Password の item `dotfiles bootstrap`（Personal vault）からコピーし、
+#      1Password の item `DOTFILES_BOOTSTRAP`（Personal vault）からコピーし、
 #      ワンライナーと同じターミナルで `export GH_TOKEN=<PAT>`
 #      （ghq-get-mine の repo 一覧取得と clone 完全性検証が gh API を使うため。無いと
 #      ✓ 完了 に到達できないので P1-ghtoken で即 fail する）
@@ -290,7 +290,7 @@ df_gate_ghtoken() {
     df_check_ok P1-ghtoken "gh auth 済み"
   else
     df_check_fail P1-ghtoken "gh の認証が無い"
-    df_say "  fine-grained PAT を 1Password の item \`dotfiles bootstrap\`（Personal vault）からコピーし、"
+    df_say "  fine-grained PAT を 1Password の item \`DOTFILES_BOOTSTRAP\`（Personal vault）からコピーし、"
     df_say "  \`export GH_TOKEN=<PAT>\` してから再実行すること（事前準備 3）"
     exit 1
   fi


### PR DESCRIPTION
bootstrap 用 PAT を保持する 1Password item を `dotfiles bootstrap` → **`DOTFILES_BOOTSTRAP`** に改名。

README だけでなく `install.sh` の 2 箇所も揃えた（リポジトリ規約: 用語の改名はコード変更と同一 PR で反映）:

- `install.sh:15` — ヘッダの事前準備コメント
- `install.sh:293` — **`P1-ghtoken` の失敗メッセージ**。GH_TOKEN が無い時に operator が実際に読む行なので、
  ここが旧名のままだと存在しない item を探させることになる

改名漏れゼロを確認（`grep -riF 'dotfiles bootstrap'` → 0 件）。

検証: `shellcheck install.sh` / `sh -n install.sh` ともに pass。

🤖 Generated with [Claude Code](https://claude.com/claude-code)