### PR TITLE
:arrow_up:(release) adopt glyph v0.10.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
           persist-credentials: false
 
       - name: install glyph
-        uses: akira-toriyama/glyph/.github/actions/install@v0.10.1
+        uses: akira-toriyama/glyph/.github/actions/install@v0.10.2
         with:
           version: v0.8.0
           token: ${{ github.token }}


### PR DESCRIPTION
Bumps this repo's `release.yml` glyph pin to [v0.10.2](https://github.com/akira-toriyama/glyph/releases/tag/v0.10.2).

The two fleet-managed pins (`commit-lint.yml`, `version-preview.yml`) come from fleet-sync; this is the per-repo half the runbook names, so the workflow and the binary it runs stay on the same revision.

What v0.10.2 fixes: a PR merged with the merge button no longer vanishes from the version and the notes; a would-be `@mention` can no longer escape its fence and notify a stranger; the API client speaks its credential only to the origin it was pointed at.

🤖 Generated with [Claude Code](https://claude.com/claude-code)