### PR TITLE
:bug:(claude) seed effortLevel as xhigh, not the non-persistable "ultracode"

### DIFF
--- a/chezmoi/private_dot_claude/CLAUDE.md
+++ b/chezmoi/private_dot_claude/CLAUDE.md
@@ -60,10 +60,14 @@
 
 ## モデル運用（Fable 5 / Opus 4.8 / Sonnet 5）
 
-**既定 = Opus 4.8 + effort ultracode**（dotfiles の `modify_settings.json` が seed:
-`model: "opus[1m]"` / `effortLevel: "ultracode"`。新しい Mac の初期値。`//=` なので
-対話的な `/model`・`/effort` が常に優先 — dotfiles は既存マシンの値を訂正しない）。
-日常の**メインループは Opus 4.8** を ultracode で回し、substantive な作業は既定でファンアウトする。
+**既定 = Opus 4.8 + effort xhigh、ultracode は毎セッション手動**（dotfiles の
+`modify_settings.json` が seed: `model: "opus[1m]"` / `effortLevel: "xhigh"`。新しい Mac の
+初期値。`//=` なので対話的な `/model`・`/effort` が常に優先 — dotfiles は既存マシンの値を訂正しない）。
+**ultracode は恒久化できない**（= xhigh + 自動 workflow orchestration で、Claude Code の仕様上
+セッション限定。`effortLevel` の有効値は low/medium/high/xhigh のみで、`"ultracode"` は起動時に
+`xhigh` へ正規化される。settings キー・env・`--effort` フラグのどれでも恒久 ON にできない —
+`--effort` は max 止まり）。日常の**メインループは Opus 4.8** を回し、substantive な作業を
+ファンアウトさせたいセッションでは開始時に `/effort ultracode` を1回入れる。
 
 前提（誤解しない）: メインループのモデルは Claude 自身では切り替えられない（`/model` は
 ユーザー操作）。そして **タスクの難易度を検知してモデルを自動で切り替える機構は存在しない**

--- a/chezmoi/private_dot_claude/modify_settings.json
+++ b/chezmoi/private_dot_claude/modify_settings.json
@@ -23,10 +23,17 @@
 #      commands it actually rewrites. The hook it registers is itself guarded
 #      (`command -v rundiff`), so an uninstalled rundiff is a no-op rather than
 #      an error on every Bash call.
-#   4. model-routing defaults: model "opus[1m]" + effortLevel "ultracode" — the
+#   4. model-routing defaults: model "opus[1m]" + effortLevel "xhigh" — the
 #      「モデル運用」policy in the global CLAUDE.md (Opus 4.8 as the daily main
-#      loop, run at ultracode so substantive work fans out by default; Fable 5
-#      only via the fable-architect subagent or an explicit /model switch).
+#      loop; Fable 5 only via the fable-architect subagent or an explicit /model
+#      switch).
+#      NOTE: effortLevel is seeded as "xhigh", NOT "ultracode". "ultracode"
+#      (= xhigh + automatic workflow orchestration) is session-only by design and
+#      is NOT a persistable effortLevel value: Claude Code accepts only
+#      low/medium/high/xhigh here and normalizes "ultracode" to "xhigh" at
+#      startup, so seeding it never produced a persistent ultracode default. Enter
+#      it per session with /effort ultracode — there is no settings key, env var,
+#      or --effort launch flag that persists it (--effort tops out at max).
 #      Seeded ONLY IF ABSENT (jq //=): /model and /effort change the live values
 #      interactively and re-apply must never fight that — this exists so a new
 #      Mac starts on the intended model+effort instead of whatever the installer
@@ -69,7 +76,7 @@ out=$(printf '%s\n' "$input" | jq --arg cmd "$cmd" '
                             , "Bash(git worktree list:*)"
                             ] - .permissions.allow )
   | (.model //= "opus[1m]")
-  | (.effortLevel //= "ultracode")
+  | (.effortLevel //= "xhigh")
 ')
 
 # 3. rundiff PreToolUse hook. `rundiff hook print --json` emits the mergeable


### PR DESCRIPTION
## 何を直したか

`modify_settings.json` が `effortLevel` に `"ultracode"` を seed していたが、これは**恒久化できない不正値**だった。Claude Code は settings.json の `effortLevel` に `low/medium/high/xhigh` のみを受け付け、`"ultracode"` は起動時に `xhigh` へ正規化する。よって「既定 = ultracode」は新しい Mac でも成立していなかった。

## 変更

- **`modify_settings.json`**: seed 値を `"ultracode"` → `"xhigh"`（+ ヘッダコメント item 4 に理由を明記）。
- **`CLAUDE.md`（モデル運用節）**: 「既定 = ultracode」を「既定 = xhigh、ultracode は毎セッション `/effort ultracode`」に訂正。恒久化不可の理由（session 限定・`--effort` は max 止まり）を追記。

## 根拠

- `/effort ultracode` の出力: `Set effort level to ultracode (this session only): xhigh + dynamic workflow orchestration`
- 公式ドキュメント（code.claude.com/docs）: 「Ultracode lasts for the current session and resets when you start a new one.」
- 実機 `claude --help`: `--effort <level>` は `low/medium/high/xhigh/max` のみ（ultracode 不可）。
- 環境: Claude Code 2.1.116。

## 影響

- 挙動: 新しい Mac は今後 `xhigh` 既定で起動（従来も実効は `xhigh` に正規化されていたので**実挙動は不変**。seed の意図とドキュメントが実態に一致する）。
- ultracode 運用はこれまでどおり各セッションで `/effort ultracode`。

## 備考

`fable-architect` subagent（`model: fable`）は別マシンで実起用し Fable 5（`claude-fable-5`）解決を確認済み。agent 定義自体は変更不要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
