### PR TITLE
:memo:(claude) name the default model by alias, not "Opus 4.8"

### DIFF
--- a/chezmoi/private_dot_claude/CLAUDE.md
+++ b/chezmoi/private_dot_claude/CLAUDE.md
@@ -58,15 +58,19 @@
   （dotfiles の `darwin-rebuild switch` 等は従来どおりユーザーに実行してもらう）。
 - **配布**: [GitHub Packages](https://github.com/akira-toriyama?tab=packages) への追加 OK。
 
-## モデル運用（Fable 5 / Opus 4.8 / Sonnet 5）
+## モデル運用（Fable 5 / 最新 Opus / Sonnet 5）
 
-**既定 = Opus 4.8 + effort xhigh、ultracode は毎セッション手動**（dotfiles の
+**既定 = 最新 Opus + effort xhigh、ultracode は毎セッション手動**（dotfiles の
 `modify_settings.json` が seed: `model: "opus[1m]"` / `effortLevel: "xhigh"`。新しい Mac の
 初期値。`//=` なので対話的な `/model`・`/effort` が常に優先 — dotfiles は既存マシンの値を訂正しない）。
+**`opus[1m]` は版を固定しない alias**（その時点の最新 Opus の 1M context 版に解決される。
+2026-07 現在は Opus 5）。新しい Opus が出れば黙って乗り換わるのが意図した挙動なので、
+**settings にもこの文書にも版番号を書かない** — `claude-opus-4-8` のような具体 ID で pin すると
+世代交代のたびに stale になり、「4.8 を既定にしている」と書いた文書と実体がずれる（実際にずれた）。
 **ultracode は恒久化できない**（= xhigh + 自動 workflow orchestration で、Claude Code の仕様上
 セッション限定。`effortLevel` の有効値は low/medium/high/xhigh のみで、`"ultracode"` は起動時に
 `xhigh` へ正規化される。settings キー・env・`--effort` フラグのどれでも恒久 ON にできない —
-`--effort` は max 止まり）。日常の**メインループは Opus 4.8** を回し、substantive な作業を
+`--effort` は max 止まり）。日常の**メインループは最新 Opus** を回し、substantive な作業を
 ファンアウトさせたいセッションでは開始時に `/effort ultracode` を1回入れる。
 
 前提（誤解しない）: メインループのモデルは Claude 自身では切り替えられない（`/model` は
@@ -75,7 +79,7 @@
 **Claude への運用指示** ＝ Claude が気づいて従うかどうかに拠る。過信しない。
 
 - **担当分担**:
-  - **Opus 4.8 = メインループ＋並列網羅（ultracode）担当**: 日常の実装・設計・最終判断、
+  - **最新 Opus（`opus[1m]`） = メインループ＋並列網羅（ultracode）担当**: 日常の実装・設計・最終判断、
     レビュー・監査・多ファイル移行・エッジケース洗い出し・検証。このセッションの主戦力。
   - **Sonnet 5 = 機械的サブエージェント**（列挙・探索・変換など手足の作業。`effort: low`）。
     メインループを担うのではなく、workflow の安い stage に使う。

--- a/chezmoi/private_dot_claude/modify_settings.json
+++ b/chezmoi/private_dot_claude/modify_settings.json
@@ -24,9 +24,14 @@
 #      (`command -v rundiff`), so an uninstalled rundiff is a no-op rather than
 #      an error on every Bash call.
 #   4. model-routing defaults: model "opus[1m]" + effortLevel "xhigh" — the
-#      「モデル運用」policy in the global CLAUDE.md (Opus 4.8 as the daily main
-#      loop; Fable 5 only via the fable-architect subagent or an explicit /model
-#      switch).
+#      「モデル運用」policy in the global CLAUDE.md (the LATEST Opus as the daily
+#      main loop; Fable 5 only via the fable-architect subagent or an explicit
+#      /model switch).
+#      NOTE: "opus[1m]" is a version-free alias — it resolves to whatever the
+#      current latest Opus is (Opus 5 as of 2026-07), which is the point: a new
+#      Opus is adopted without touching this file. Never pin a concrete id such
+#      as "claude-opus-4-8[1m]" here; the seed would then quietly ship a stale
+#      generation on every new Mac.
 #      NOTE: effortLevel is seeded as "xhigh", NOT "ultracode". "ultracode"
 #      (= xhigh + automatic workflow orchestration) is session-only by design and
 #      is NOT a persistable effortLevel value: Claude Code accepts only


### PR DESCRIPTION
## 何を

`~/.claude/CLAUDE.md` の「モデル運用」節と `modify_settings.json` の comment から、
**版番号「Opus 4.8」を落として「最新 Opus」表記に統一**する。

## なぜ

seed している値 `model: "opus[1m]"` は**版を固定しない alias** で、その時点の最新
Opus（2026-07 現在は Opus 5）に解決される。にもかかわらず周囲の散文が「既定 =
Opus 4.8」と書いていたため、**文書上の既定と seed が実際に入れるものがずれていた**
（実際に「既定は Opus 4.8 か？」への回答が文書由来で誤りかけた）。

再発防止として、ずれの原因だったルールを本文に明記:
`claude-opus-4-8[1m]` のような具体 ID で pin しない（settings にも散文にも）。

## 変更なし

`.model //= "opus[1m]"` の**値自体は変更していない** — もともと alias なので、
誤っていたのは説明文だけ。挙動の変更はゼロ（doc-only）。

## 実測

このマシンへ `chezmoi apply ~/.claude/CLAUDE.md ~/.claude/settings.json` 済み:

```
$ jq '{model, effortLevel}' ~/.claude/settings.json
{ "model": "opus[1m]", "effortLevel": "xhigh" }   # ← model は未適用だったので今回入った

$ grep -c "Opus 4.8" ~/.claude/CLAUDE.md   → 0
$ chezmoi status                            → （空 = live と source が一致）
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
