### PR TITLE
:construction_worker:(ci) pin the glyph install action and its binary to v0.11.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,9 +51,9 @@ jobs:
           persist-credentials: false
 
       - name: install glyph
-        uses: akira-toriyama/glyph/.github/actions/install@v0.10.2
+        uses: akira-toriyama/glyph/.github/actions/install@v0.11.1
         with:
-          version: v0.8.0
+          version: v0.11.1
           token: ${{ github.token }}
 
       - name: Compose the verdict and upsert the rolling DRAFT


### PR DESCRIPTION
Rollout of glyph **v0.11.1**, the tag the fleet's canonical pins now name. See the [rollout runbook](https://github.com/akira-toriyama/.github/blob/main/docs/glyph-rollout-runbook.md) — this reference is not fleet-managed, so it needs this per-repo PR.

Fired before the fleet was touched: [glyph-test#22](https://github.com/akira-toriyama/glyph-test/pull/22) ran `lint.yml@v0.11.1` at real CI in both directions, and [glyph-test#23](https://github.com/akira-toriyama/glyph-test/pull/23) moved one consumer's release path first and watched the run.

SetStatus-task: https://github.com/akira-toriyama/projects/blob/main/.furrow/bodies/t-271g.md