### PR TITLE
:arrow_up:(ci) adopt glyph v0.11.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,9 +51,9 @@ jobs:
           persist-credentials: false
 
       - name: install glyph
-        uses: akira-toriyama/glyph/.github/actions/install@v0.11.1
+        uses: akira-toriyama/glyph/.github/actions/install@v0.11.2
         with:
-          version: v0.11.1
+          version: v0.11.2
           token: ${{ github.token }}
 
       - name: Compose the verdict and upsert the rolling DRAFT


### PR DESCRIPTION
Moves this repo's glyph pin(s) to `v0.11.2`.

Sites 4 and 5 (`actions/install@` and the `version:` it is handed) move in the
**same edit** — the rollout runbook is explicit that no combination of a new
`@tag` with an old `version:` is ever deliberate, and `version:` is the site
that has actually rotted twice.

glyph `v0.11.2` was verified artifact-side before this rollout (tag → `d3d87e1`,
5 assets, notes with zero SHA overlap with `v0.11.1`, attestation exit 0 with
tamper/wrong-signer negative controls) and live-fired in `glyph-test` in both
directions — a valid commit passed, a malformed one failed with exit 3.

SetStatus-task: https://github.com/akira-toriyama/projects/blob/main/.furrow/bodies/t-vznc.md