### PR TITLE
:sparkles:(claude) enforce work-report task ids via Stop hook

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,19 @@ jobs:
           fi
           echo "✅ my- command prefix 規約 OK"
 
+  # 自作 Claude hook スクリプトの回帰テスト（Stop hook の判定ロジック。
+  # 「lint/test で防げることは人力でやらない」— hook の壊れは CI で止める）
+  hook-scripts-test:
+    name: hook scripts test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # CI-only, never pushes — drop the persisted checkout token. t-yaxa
+          persist-credentials: false
+      - name: Run claude-work-report-check tests
+        run: bash scripts/claude-work-report-check-test.sh
+
   # chezmoi テンプレートのレンダリング検証（構文エラー早期検出）
   chezmoi-templates:
     name: chezmoi templates render
@@ -309,6 +322,7 @@ jobs:
       - shellcheck
       - convention-executable-prefix
       - convention-command-prefix
+      - hook-scripts-test
       - chezmoi-templates
       - flake-changes
       - darwin-build
@@ -339,6 +353,7 @@ jobs:
       - shellcheck
       - convention-executable-prefix
       - convention-command-prefix
+      - hook-scripts-test
       - chezmoi-templates
       - darwin-build
       - darwin-switch-smoke

--- a/chezmoi/dot_local/bin/executable_claude-work-report-check
+++ b/chezmoi/dot_local/bin/executable_claude-work-report-check
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# claude-work-report-check — Claude Code Stop hook: validate the work-request
+# closing template (global CLAUDE.md「作業・task 依頼への返し方」).
+#
+# WHAT IT ENFORCES: when the final assistant message uses the closing template
+# (the fixed opener 「品質担保できる範囲まで…」 or a 「やり残しは task 化…」
+# line), the やり残し declaration must be VERIFIABLE — at least one furrow task
+# id (t-xxxx) or the literal 「なし」 on that line. Prose alone (「後で task 化
+# します」) cannot be checked with `furrow show`; ids can. On violation we emit
+# {"decision":"block","reason":…} so Claude gets exactly one repair round.
+#
+# WHAT IT CANNOT ENFORCE (scope decision, furrow t-m2bf): firing of the template
+# itself. Whether a turn was a work request needs semantic classification of the
+# conversation — the Stop payload carries no cheap, reliable signal for that.
+# This hook guarantees well-formedness WHEN the template is used, not usage.
+#
+# Loop safety: stop_hook_active=true → always allow (the repair round is
+# single; Claude Code would force-stop after repeated blocks anyway).
+# Fail-open: no jq / unparseable JSON / missing fields → allow. Breaking every
+# session stop costs far more than skipping one check (same asymmetry call as
+# modify_settings.json).
+#
+# Owned by dotfiles (chezmoi → ~/.local/bin/claude-work-report-check). Wired
+# from ~/.claude/settings.json hooks.Stop by modify_settings.json (step 5).
+# Tests: scripts/claude-work-report-check-test.sh (run in CI).
+set -u
+
+command -v jq >/dev/null 2>&1 || exit 0
+
+input=$(cat 2>/dev/null) || exit 0
+printf '%s' "$input" | jq -e . >/dev/null 2>&1 || exit 0
+
+[ "$(printf '%s' "$input" | jq -r '.stop_hook_active // false')" = "true" ] && exit 0
+
+msg=$(printf '%s' "$input" | jq -r '.last_assistant_message // empty')
+[ -n "$msg" ] || exit 0
+
+# Template detection — two independent markers, either one arms the check:
+#   a) the fixed opening line 「品質担保できる範囲まで」
+#   b) a やり残し declaration line (やり残し + task on the same line)
+# Ordinary conversation ABOUT the workflow can hit (b); the cost is one
+# spurious repair round, bounded by the stop_hook_active guard above.
+armed=0
+if printf '%s' "$msg" | grep -qF '品質担保できる範囲まで'; then
+  armed=1
+elif printf '%s' "$msg" | grep -qiE 'やり残し.*task|task.*やり残し'; then
+  armed=1
+fi
+[ "$armed" -eq 1 ] || exit 0
+
+# The declaration line itself must carry the proof: a furrow id or 「なし」.
+# Scoped to やり残し lines on purpose — a stray 「問題なし」 elsewhere in the
+# message must not satisfy the check. An armed message with NO やり残し line at
+# all (opener present, declaration dropped) is also a violation.
+decl=$(printf '%s' "$msg" | grep -F 'やり残し' || true)
+if [ -n "$decl" ]; then
+  printf '%s' "$decl" | grep -qE 't-[a-z0-9]{3,}' && exit 0
+  printf '%s' "$decl" | grep -qF 'なし' && exit 0
+fi
+
+jq -n '{decision: "block", reason: "正常終了定型の「やり残し」宣言に task ID がありません（global CLAUDE.md「作業・task 依頼への返し方」— ID は furrow show で検証できるが、文だけでは検証できない）。やり残しを furrow で task 化して「やり残しは task 化済: t-xxxx, t-yyyy」と ID を列挙するか、本当に無ければ「なし」と書いてください。直したらそのまま停止してよい。"}'
+exit 0

--- a/chezmoi/private_dot_claude/modify_settings.json
+++ b/chezmoi/private_dot_claude/modify_settings.json
@@ -2,7 +2,7 @@
 # chezmoi modify_ script for ~/.claude/settings.json.
 #
 # chezmoi pipes the CURRENT settings.json on stdin; our stdout becomes the new
-# file. We ensure exactly FOUR things and pass everything else (the permissions
+# file. We ensure exactly FIVE things and pass everything else (the permissions
 # the user accumulates interactively, plugins, env, other hooks) through
 # untouched:
 #   1. a SessionStart hook that runs git-stale-check (so an agent sees a
@@ -43,6 +43,11 @@
 #      interactively and re-apply must never fight that — this exists so a new
 #      Mac starts on the intended model+effort instead of whatever the installer
 #      picks.
+#   5. a Stop hook that runs claude-work-report-check — validates the
+#      work-request closing template (global CLAUDE.md「作業・task 依頼への
+#      返し方」): a やり残し declaration must carry furrow task ids or 「なし」,
+#      else the stop is blocked for one repair round (furrow t-m2bf). The hook
+#      script itself is fail-open and loop-safe; see its header.
 #
 # Idempotent: each hook and each allow entry is added only if absent (the allow
 # merge is a set-union), so re-apply never duplicates and the user's own edits
@@ -56,6 +61,8 @@ set -u
 
 # shellcheck disable=SC2016  # $HOME must stay literal — Claude expands it at hook run
 cmd='$HOME/.local/bin/git-stale-check'
+# shellcheck disable=SC2016  # same: literal $HOME, expanded at hook run
+cmd_stop='$HOME/.local/bin/claude-work-report-check'
 
 input=$(cat)
 [ -n "$input" ] || input='{}'
@@ -65,8 +72,9 @@ if ! command -v jq >/dev/null 2>&1 || ! printf '%s' "$input" | jq -e . >/dev/nul
   exit 0
 fi
 
-out=$(printf '%s\n' "$input" | jq --arg cmd "$cmd" '
+out=$(printf '%s\n' "$input" | jq --arg cmd "$cmd" --arg stop "$cmd_stop" '
   def hook_present: [ (.hooks.SessionStart // [])[]?.hooks[]?.command ] | any(. == $cmd);
+  def stop_hook_present: [ (.hooks.Stop // [])[]?.hooks[]?.command ] | any(. == $stop);
 
   ( if hook_present then .
     else
@@ -74,6 +82,12 @@ out=$(printf '%s\n' "$input" | jq --arg cmd "$cmd" '
       | (.hooks.SessionStart //= [])
       | (.hooks.SessionStart += [ { hooks: [ { type: "command", command: $cmd } ] } ])
     end )
+  | ( if stop_hook_present then .
+      else
+          (.hooks //= {})
+        | (.hooks.Stop //= [])
+        | (.hooks.Stop += [ { hooks: [ { type: "command", command: $stop } ] } ])
+      end )
   | (.permissions //= {})
   | (.permissions.allow //= [])
   | .permissions.allow += ( [ "Bash(git status:*)"

--- a/scripts/claude-work-report-check-test.sh
+++ b/scripts/claude-work-report-check-test.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Regression tests for the Stop hook
+# chezmoi/dot_local/bin/executable_claude-work-report-check.
+#
+# Run locally: bash scripts/claude-work-report-check-test.sh
+# CI: .github/workflows/ci.yml job `hook-scripts-test`.
+#
+# Contract under test: the hook emits {"decision":"block",...} when (and only
+# when) the work-request closing template is used without a verifiable
+# やり残し declaration (a t-xxxx furrow id or the literal 「なし」 on the
+# declaration line). Everything else — including malformed input — must allow.
+set -u
+
+script="$(cd "$(dirname "$0")/.." && pwd)/chezmoi/dot_local/bin/executable_claude-work-report-check"
+fail=0
+n=0
+
+run() { # $1=name  $2=stdin payload  $3=expected: allow|block
+  local name=$1 payload=$2 expect=$3 out decision
+  out=$(printf '%s' "$payload" | bash "$script")
+  if [ -z "$out" ]; then
+    decision=allow
+  else
+    decision=$(printf '%s' "$out" | jq -r '.decision // "allow"' 2>/dev/null) || decision=unparseable
+  fi
+  n=$((n + 1))
+  if [ "$decision" = "$expect" ]; then
+    printf '  ✓ %s\n' "$name"
+  else
+    printf '  ✗ %s — expected %s, got %s (output: %s)\n' "$name" "$expect" "$decision" "$out"
+    fail=1
+  fi
+}
+
+mk() { # $1=last_assistant_message → full hook payload
+  jq -n --arg m "$1" '{stop_hook_active: false, last_assistant_message: $m}'
+}
+
+run "定型なしの普通の応答 → allow" \
+  "$(mk '原因は Authorization ヘッダ欠落でした。修正済みです。')" allow
+
+run "定型 + task ID 列挙 → allow" \
+  "$(mk '品質担保できる範囲まで作業続けました。
+やり残しは task 化済: t-ab3d, t-9kzz
+別セッションで作業お願いします。')" allow
+
+run "定型 + なし → allow" \
+  "$(mk '品質担保できる範囲まで作業続けました。
+やり残しは task 化済: なし
+別セッションで作業お願いします。')" allow
+
+run "opener だけで やり残し宣言行が無い → block" \
+  "$(mk '品質担保できる範囲まで作業続けました。以上です。')" block
+
+run "やり残し宣言行に ID も なし も無い → block" \
+  "$(mk 'やり残しは task 化済:（あとでやります）')" block
+
+run "なし は宣言行スコープ（他行の「問題なし」では通らない）→ block" \
+  "$(mk '品質担保できる範囲まで作業続けました。
+やり残しは task 化済: 未起票
+テストは問題なしでした。')" block
+
+run "stop_hook_active=true は違反があっても素通し → allow" \
+  "$(jq -n '{stop_hook_active: true, last_assistant_message: "やり残しは task 化済:（あとで）"}')" allow
+
+run "壊れた JSON → allow (fail-open)" 'not-json{{' allow
+
+run "last_assistant_message 欠落 → allow (fail-open)" \
+  '{"stop_hook_active": false}' allow
+
+echo
+if [ "$fail" -eq 0 ]; then
+  echo "✅ all $n tests passed"
+else
+  echo "❌ failure(s) above ($n tests)"
+fi
+exit "$fail"


### PR DESCRIPTION
## What

Stop hook `claude-work-report-check` — validates the work-request closing template (global CLAUDE.md「作業・task 依頼への返し方」). When the final assistant message uses the template (opener 「品質担保できる範囲まで…」 or a やり残し declaration line), the declaration must carry verifiable furrow task ids (`t-xxxx`) or the literal 「なし」; otherwise the stop is blocked for exactly one repair round.

- **Loop-safe**: `stop_hook_active=true` → always allow (one repair round max).
- **Fail-open**: no jq / unparseable JSON / missing fields → allow (never break stopping; same asymmetry call as `modify_settings.json`).
- **なし is declaration-line scoped** — a stray 「問題なし」 elsewhere does not satisfy the check.

## Scope (t-m2bf decision)

The hook guarantees **well-formedness when the template is used**. Firing of the template itself (forgetting it entirely) is not machine-detectable from the Stop payload — it needs semantic classification of whether the turn was a work request. That remainder stays prose-guided; a claude-md-eval case for it is tracked separately.

## Wiring & tests

- `modify_settings.json` step 5 registers the hook idempotently (keyed on command path; verified: applied → `~/.claude/settings.json` now carries `hooks.Stop`, live script blocks a violating payload E2E).
- `scripts/claude-work-report-check-test.sh`: 9 cases (allow/block/fail-open). Mutation-checked: neutering the hook fails the 3 block cases.
- New CI job `hook-scripts-test`, required via `ci-gate` and watched by `notify-red-main`.

SetStatus-task: https://github.com/akira-toriyama/projects/blob/main/.furrow/bodies/t-m2bf.md done

🤖 Generated with [Claude Code](https://claude.com/claude-code)