### PR TITLE
:memo:(docs) add rule ledger for the global CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,8 @@ chezmoi prefix（`executable_` / `private_` / `encrypted_` / `run_once_` /
 詳細: [docs/reproduction-architecture.md](docs/reproduction-architecture.md) /
 進捗: [docs/roadmap.md](docs/roadmap.md) /
 環境素材: [docs/system-inventory.md](docs/system-inventory.md) /
-運用: [docs/operations.md](docs/operations.md)
+運用: [docs/operations.md](docs/operations.md) /
+global CLAUDE.md ルールの強制状態: [docs/claude-md-ledger.md](docs/claude-md-ledger.md)
 
 **最終目標**: このマシンを破棄しても新しい Mac で `install.sh` ワンコマンドで同等の環境が再現できる状態を維持する。
 

--- a/docs/claude-md-ledger.md
+++ b/docs/claude-md-ledger.md
@@ -1,0 +1,80 @@
+# CLAUDE.md ルール台帳（global）
+
+対象 = **global CLAUDE.md**（source: [`chezmoi/private_dot_claude/CLAUDE.md`](../chezmoi/private_dot_claude/CLAUDE.md) → 配布先 `~/.claude/CLAUDE.md`）。
+各 repo の CLAUDE.md（dotfiles 自身の [`CLAUDE.md`](../CLAUDE.md) 含む）は対象外 — 必要になったら各 repo の docs/ に同形式で作る。
+
+目的（furrow t-gqd5・2026-07-26 壁打ち合意）:
+
+1. **散文頼みのルールと機構で強制済みのルールを見分ける** — 📖 の行がそのまま機構化バックログ。
+2. **各ルールで誰が動くかを 1 表にする** — Claude の手番 / ユーザーの手番 / 機構。
+3. **ユーザーの手番の一覧化** — どこにも文書化されていなかった。本台帳の最高価値。
+
+手本 = [.github/docs/fleet-change-policy.md](https://github.com/akira-toriyama/.github/blob/main/docs/fleet-change-policy.md) の「機械で強制されている段とそうでない段の一覧」。
+**ルール本文はここに転記しない** — 正本は global CLAUDE.md の各節（転記は剥離の元）。この表は「誰が・どう強制されるか」だけを持つ。
+
+## 印の凡例
+
+| 印 | 意味 |
+|---|---|
+| 🔒 | **機構が強制** — 違反が機械的に止まる / 正しい状態が自動で作られる |
+| 🟡 | **半機構** — 機構はあるが warn-only・事後（push 後）・部分カバー |
+| 📖 | **散文頼み** — 発火は Claude の読解と記憶次第（= 機構化候補） |
+| 🙅 | **強制対象外** — 許可・裁量・判断規範で、機械で止める「違反」が定義できない |
+
+## 台帳
+
+| ルール（正本 = global CLAUDE.md の節） | Claude の手番 | ユーザーの手番 | 機構 | 印 |
+|---|---|---|---|---|
+| gitmoji commit 規約（Commits 節） | `glyph rules` を引いて書く。push 前に `glyph lint --range origin/main..HEAD` | — | PR の [commit-lint.yml](../.github/workflows/commit-lint.yml)（fleet 同期・glyph reusable） | 🟡 PR で必ず走り赤 X は付くが、branch protection 必須は `ci-gate` 1 本のみ（実測）で commit-lint 赤は merge を**止めない**。押さえは赤を見て直す運用。push 前 lint は 📖 |
+| body の和訳 footer（Commits 節） | `---（和訳）` を付ける | — | なし（実測: 和訳無し英語 body を `glyph lint` が exit 0 で通す） | 📖 |
+| furrow 一本化・source 使用（Workflow 節） | wrapper の `furrow` を叩く | — | `packages.nix` の source-build wrapper。brew 版未導入なので shadow は構造的に不発 | 🟡 `brew install` する事故自体は止まらない |
+| 着手前後の `furrow sync`（Workflow 節） | 読む前・書いた後に回す | — | なし | 📖 |
+| repos 帰属・ラベル純タグ・`-l <repo>` 廃止（Workflow 節） | `-r` / auto 導出に乗る | — | global 既定ボード（[furrow.nix](../home/modules/furrow.nix) 生成 config）が repo を auto 付与・auto フィルタ | 🟡 実測では `-l dotfiles` の did-you-mean ガードは発火せず素通り（下記[検証状態](#検証状態)） |
+| 進捗の正本は task body 一本（Workflow 節） | body のチェックリストを更新・複製しない | — | なし | 📖 |
+| セッション粒度・中断時の 1 行明言（Workflow 節） | 単位を区切る・希望を書き残す | — | なし | 📖 |
+| PR footer `SetStatus-task:`（Workflow 節） | footer を書く | — | [task-status.yml](../.github/workflows/task-status.yml)（fleet 同期）が lane を自動適用。非ブロッキング | 🟡 footer を**書き忘れても**何も落ちない |
+| 遠慮なく task 化・やり残しを暗黙にしない（Workflow 節） | 起票する | — | Stop hook が正常終了定型の task ID 列挙を強制（下の行） | 🟡 |
+| 指示なし時は task を進める／状況共有を GO と読まない（Workflow 節） | 既定挙動として従う | 作業開始の GO を明示する | なし（memory 併用） | 📖 |
+| 品質>速度・迷ったら一貫性・破壊的変更 OK（開発ポリシー節） | 判断規範として適用 | 好み・リスク受容の裁定 | — | 🙅 |
+| lint/test で防げることは人力でやらない（開発ポリシー節） | 機構化を検討し、CLAUDE.md の散文変更は配る前に測る | — | 測定ハーネス [scripts/claude-md-eval](../scripts/claude-md-eval/README.md) は存在。**回す発火自体は散文** | 🟡 |
+| 「できた」は実測とセット（開発ポリシー節） | 実測／未確認を分けて報告 | — | なし（報告文の形は機械で判定できない） | 📖 |
+| 未検証の観測を書かない・反証 1 周（開発ポリシー節） | 反証エージェントを回す。body に出所と検証状態 | — | なし。furrow lint は store 構造検査のみで body の検証状態節は見ない（t-h8gc が機構化 task） | 📖 |
+| fleet 変更の段取り（開発ポリシー節） | 段を踏む | カナリア/フリート進行の判断 | 正本 [fleet-change-policy.md](https://github.com/akira-toriyama/.github/blob/main/docs/fleet-change-policy.md) に機械強制の段一覧あり | → 別台帳（重複させない） |
+| glossary.md の維持（開発ポリシー節） | 用語変更をコード変更と同一 PR で | — | [glossary.yml](../.github/workflows/glossary.yml) は Pages deploy のみ。存在・追従の強制なし | 📖 |
+| headless 検証優先／調査・VM・配布の許可（開発ポリシー節） | 設計原則として適用・許可を行使 | VM 外（ホスト）の sudo 実行 | — | 🙅 |
+| 出力の形・全規則（出力の形節） | 会話で適用 | — | claude-md-eval で**測定**は可能（強制ではない） | 📖 |
+| 正常終了定型の task ID 列挙（作業依頼への返し方節） | 定型で締め、やり残しの ID を列挙（無ければ「なし」） | — | Stop hook [claude-work-report-check](../chezmoi/dot_local/bin/executable_claude-work-report-check)（PR #270・t-m2bf）: 定型使用時に ID/「なし」が無ければ停止をブロック。CI に回帰テスト | 🟡 定型の**発火自体**（使い忘れ）は判定不能で 📖 のまま |
+| 質問・報告フロー（作業依頼への返し方節） | 入口フィルタ・推奨つき一問一答 | 裁定・「残り全部推奨で」の委任 | なし | 📖 |
+| 既定 model/effort（モデル運用節） | — | `/model`・`/effort` の対話変更 | [modify_settings.json](../chezmoi/private_dot_claude/modify_settings.json) が `//=` で seed（新 Mac の初期値） | 🔒 seed として。既存マシンの値は訂正しない設計 |
+| ultracode は毎セッション手動（モデル運用節） | — | セッション開始時に `/effort ultracode` | 機構化不能（Claude Code 仕様: 恒久設定値に存在しない） | 🙅 仕様 — 純ユーザー手番 |
+| Fable のファンアウト禁止（モデル運用節） | `fable-architect` 経由でのみ Fable を使う | — | [agents/fable-architect.md](../chezmoi/private_dot_claude/agents/fable-architect.md) の `tools:` に Agent 非搭載 → harness が拒否 | 🔒 Agent ツール経路のみ（Bash から `claude -p` を叩く迂回は構造では止まらない — 未実測） |
+| Fable% ≥ Weekly% 不変条件・約 4 日で 100%（モデル運用節） | `~/.claude.json` の枠を読み委譲判断 | 「これ Fable で」の発令 | なし | 📖 |
+| Opus 失敗の body 記録（モデル運用節） | 失敗の都度 task body に書く | — | なし | 📖 |
+| SwiftUI+Sill・AppKit 原則禁止・最新 macOS のみ（Mac アプリ節） | 設計・実装時に適用 | — | なし（lint 化候補: `import AppKit` 検出等） | 📖 |
+| 現在地ワンショット・pare/cifail/wait4x/peekaboo を既定で使う（現在地・自作 CLI 節） | 生ログ・手書きループより先にツールへ手を伸ばす | — | 読み取り git allowlist と rundiff の test 自動 wrap（PreToolUse hook）は modify_settings.json が 🔒。**使う判断そのもの**は散文 | 🟡 |
+| 自作 CLI/アプリは source・brew 版禁止（source 節） | `brew install` しない | `brew install` しない | PATH 構造: brew 版が無ければ shadow は起きない（実測: furrow/cifail は nix profile のみ） | 🟡 導入操作自体は止まらない |
+
+## ユーザーの手番（一覧）
+
+機構化できない・Claude からは起こせない操作。**この一覧はここが初出**（各ルールの正本には分散して埋まっていた）。
+
+- **セッション開始時の `/effort ultracode`** — 恒久化不能（モデル運用節）。ファンアウトさせたいセッションで 1 回。
+- **`/model` 切替と「これ Fable で」の発令** — メインループのモデルは Claude からは変えられない。セッション跨ぎの「何度も失敗している」記憶を持つのはユーザー側（モデル運用節）。
+- **ホスト側 sudo の実行** — `darwin-rebuild switch` / `--rollback` 等。Claude はコマンド提示まで（開発ポリシー節・dotfiles CLAUDE.md ルール 2）。
+- **破壊的 git の明示指示** — force push・履歴改変・push 済みへの amend はユーザーが明示した時だけ（dotfiles CLAUDE.md ルール 4）。
+- **好み・リスク受容・product 判断の裁定** — 一問一答への回答、「残り全部推奨で」の委任（作業依頼への返し方節）。
+- **作業開始の GO** — 質問・状況共有・相談への返答は GO ではない。保留中の作業は明示指示で再開（Workflow 節）。
+- **PR merge の判断（Claude 主導運用を明示していない repo）** — dotfiles は repo CLAUDE.md ルール 5 で Claude が merge してよい。明示の無い repo では従来どおりユーザー。
+
+## 検証状態
+
+強制状態の印は 2026-07-26 に成果物を読む・実測して付けた:
+
+- **読取**: commit-lint.yml / task-status.yml / ci.yml / agents/fable-architect.md / modify_settings.json / furrow.nix / .githooks/pre-push / scripts/claude-md-eval/README.md
+- **実測**: ① glyph の和訳非強制 — 和訳なし英語 body を `glyph lint --message` に通して exit 0。② Stop hook — fixture 9 ケース緑 + 変異検証（hook 無効化で block 系 3 件が fail）+ live 配布後の E2E block。③ brew shadow 不在 — `which furrow cifail pare glyph` が全て nix profile、`/opt/homebrew/bin` に無し。④ **`-l <repo>` ガードは実測では発火しなかった** — `furrow ls -l dotfiles` は既存 label への通常フィルタとして exit 0、`furrow add -l dotfiles --draft` も成功。CLAUDE.md の「did-you-mean ガードが exit 2 で受け止める」とは挙動が異なる（label が実在する場合の差か、原因は未調査 — t-gqd5 body に記録）。
+- **記載準拠（本台帳では未再検証）**: ultracode の恒久化不能・`/model` がユーザー操作限定である点は CLAUDE.md / modify_settings.json コメントの記載に依る。
+
+## 運用
+
+- global CLAUDE.md にルールを足す・変える PR では、**同一 PR でこの台帳の行を更新する**（glossary.md と同じ作法。ただしこの作法自体が 📖 — 台帳の更新漏れを機械では検知していない）。
+- 📖 の行 = 機構化バックログ。機構化する時は furrow task を切り、完了したら印を進める。

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -241,14 +241,23 @@ PR 経由で `main` に squash-merge する（直 push なし）。
 - **Don't call it:** topic branch, work branch, 作業ブランチ
 
 ### pre-push hook
-[`.githooks/pre-push`](../.githooks/pre-push) が `chezmoi verify` で
-**apply 忘れを検知**して push を止める。乖離（`chezmoi status` の `R` 含む）
-があれば `chezmoi apply` してから push。緊急時のみ `git push --no-verify`。
+[`.githooks/pre-push`](../.githooks/pre-push) が chezmoi/ を触る push で
+`chezmoi verify` を実行し、乖離（`chezmoi status` の `R` 含む）を**警告する**
+（**warn-only、2026-07-03〜。push は止めない** — Claude 主導運用のため）。
+気づいたら `chezmoi apply` で live を追従。恒久ゲートは CI と main の
+ブランチ保護が担う。詳細 → [operations.md §5.11](operations.md)。
 - **Don't call it:** pre-push check, verify hook, プッシュ前検証
 
 ### `chezmoi templates render` (CI)
 全 `.tmpl` の `execute-template` 検証 CI ジョブ。
 - **Don't call it:** template lint, tmpl check, テンプレ検証
+
+### ルール台帳 (claude-md-ledger)
+[`docs/claude-md-ledger.md`](claude-md-ledger.md)。global CLAUDE.md の各ルールに
+「Claude の手番 / ユーザーの手番 / 機構」の 3 列と強制状態の印（🔒/🟡/📖/🙅）を
+付けた索引。ルール本文は転記しない（正本は CLAUDE.md の節）。📖 の行 =
+機構化バックログ。ルールの追加・変更と**同一 PR** でこの台帳も更新する。
+- **Don't call it:** rule list, ルール一覧, enforcement matrix
 
 ---
 


### PR DESCRIPTION
## What

[docs/claude-md-ledger.md](https://github.com/akira-toriyama/dotfiles/blob/main/docs/claude-md-ledger.md) — global CLAUDE.md の全ルールを「Claude の手番 / ユーザーの手番 / 機構」の 3 列 + 強制状態の印（🔒 機構強制 / 🟡 半機構 / 📖 散文頼み / 🙅 強制対象外）で索引化。手本は fleet-change-policy.md の機械強制の段一覧（t-gqd5・2026-07-26 壁打ち合意）。

- ルール本文は転記せず正本（CLAUDE.md の節）へのポインタのみ — 剥離防止。
- 📖 の行がそのまま機構化バックログ。
- **ユーザーの手番一覧を初めて文書化**（毎セッション ultracode・/model と「これ Fable で」・ホスト sudo・破壊的 git の明示指示・裁定と委任・merge 判断）。

## 検証

- 印は成果物の読取＋実測で付与（台帳の「検証状態」節に一覧。glyph の和訳非強制・brew shadow 不在・Stop hook の block 動作は実測）。
- 反証エージェント 1 周で過大主張 1 件を訂正: **commit-lint 赤は merge を止めない**（`gh api` 実測: branch protection 必須は `ci-gate` 1 本のみ）→ 🔒 でなく 🟡。
- 実測で CLAUDE.md 記載との差異 1 件検出: furrow の `-l <repo>` did-you-mean ガードが既存 label 一致時に発火しない → t-mztn 起票。

## Also

- glossary.md に「ルール台帳」を追加、**stale だった pre-push 記述を訂正**（「push を止める」→ 2026-07-03 から warn-only が実体）。
- repo CLAUDE.md の docs リストに台帳へのリンク 1 行（行動規則の散文ではなくナビなので claude-md-eval 対象外と判断）。

SetStatus-task: https://github.com/akira-toriyama/projects/blob/main/.furrow/bodies/t-gqd5.md done

🤖 Generated with [Claude Code](https://claude.com/claude-code)
