### PR TITLE
:art:(scripts) normalize every shell script with shfmt

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -28,15 +28,15 @@ repo_root=$(git rev-parse --show-toplevel)
 # 時 (origin/main 無し等) は安全側に倒して verify する。
 range_base=$(git merge-base origin/main HEAD 2>/dev/null || true)
 if [ -n "$range_base" ]; then
-    if git diff --name-only "$range_base..HEAD" 2>/dev/null | grep -q '^chezmoi/'; then
-        : # chezmoi/ を含む push → verify へ進む
-    else
-        exit 0 # chezmoi/ を触らない push → 検査スキップ
-    fi
+  if git diff --name-only "$range_base..HEAD" 2>/dev/null | grep -q '^chezmoi/'; then
+    : # chezmoi/ を含む push → verify へ進む
+  else
+    exit 0 # chezmoi/ を触らない push → 検査スキップ
+  fi
 fi
 
 if chezmoi --source "$repo_root/chezmoi" verify; then
-    exit 0
+  exit 0
 fi
 
 # 乖離検知。warn-only: push は止めない (exit 0)。

--- a/chezmoi/dot_local/bin/executable_git-stale-check
+++ b/chezmoi/dot_local/bin/executable_git-stale-check
@@ -25,23 +25,23 @@ upstream=$(git rev-parse --abbrev-ref --symbolic-full-name '@{upstream}' 2>/dev/
 #    LOCAL check below is current on a later invocation. Keyed per repo.
 throttle_secs=600
 cache_dir="${XDG_CACHE_HOME:-$HOME/.cache}/git-stale-check"
-key=${repo_root//\//_}            # pure-bash, no subprocess (chpwd hot path)
+key=${repo_root//\//_} # pure-bash, no subprocess (chpwd hot path)
 stamp="$cache_dir/${key:-root}"
 now=$(date +%s)
 last=0
 [ -f "$stamp" ] && last=$(cat "$stamp" 2>/dev/null || printf 0)
-case "$last" in *[!0-9]*|'') last=0 ;; esac
-if [ "$(( now - last ))" -ge "$throttle_secs" ]; then
+case "$last" in *[!0-9]* | '') last=0 ;; esac
+if [ "$((now - last))" -ge "$throttle_secs" ]; then
   if mkdir -p "$cache_dir" 2>/dev/null; then
     printf '%s' "$now" >"$stamp" 2>/dev/null || true
   fi
   # detach: subshell + background so neither prompt nor agent session waits
-  ( git -C "$repo_root" fetch --quiet >/dev/null 2>&1 & ) >/dev/null 2>&1
+  (git -C "$repo_root" fetch --quiet >/dev/null 2>&1 &) >/dev/null 2>&1
 fi
 
 # 3) local behind-count (no network) against the last-known upstream ref
 behind=$(git rev-list --count 'HEAD..@{upstream}' 2>/dev/null) || exit 0
-case "$behind" in ''|0) exit 0 ;; esac
+case "$behind" in '' | 0) exit 0 ;; esac
 
 printf '⚠️  git-stale-check: %s is %s commit(s) behind %s — run: git pull --rebase\n' \
   "${repo_root##*/}" "$behind" "$upstream"

--- a/chezmoi/dot_local/bin/executable_zmk-log
+++ b/chezmoi/dot_local/bin/executable_zmk-log
@@ -13,40 +13,47 @@ TODAY="$LOGDIR/zmk-$(date +%F).log"
 EVENTS='ZOMBIE|ZR-EPISODE|zombie-check|give-up|self-reboot|bounce|latch|refill|Booting Zephyr|ble_hid_host up|disconnected:|bond|berr=[1-9]|err'
 
 case "${1:-}" in
-    ""|tail)
-        exec tail -n 50 -F "$TODAY"
-        ;;
-    today)
-        exec cat "$TODAY"
-        ;;
-    days)
-        for f in "$LOGDIR"/zmk-*.log; do
-            [ -e "$f" ] || continue
-            b=${f##*/}; b=${b#zmk-}
-            echo "${b%.log}"
-        done
-        ;;
-    find)
-        N="${2:-3}"
-        files=("$LOGDIR"/zmk-*.log)
-        [ -e "${files[0]}" ] || exit 0
-        start=$(( ${#files[@]} - N ))
-        [ "$start" -lt 0 ] && start=0
-        cat "${files[@]:start}" 2>/dev/null | grep -E "$EVENTS"
-        ;;
-    since)
-        [ -n "${2:-}" ] || { echo "usage: zmk-log since \"HH:MM\"" >&2; exit 2; }
-        awk -v t="$(date +%F) ${2}" '$0 >= t' "$TODAY"
-        ;;
-    around)
-        [ -n "${2:-}" ] || { echo "usage: zmk-log around \"HH:MM\"" >&2; exit 2; }
-        C=$(date -j -f "%F %H:%M" "$(date +%F) ${2}" +%s) || exit 2
-        FROM=$(date -j -f %s $((C - 120)) '+%F %T')
-        TO=$(date -j -f %s $((C + 120)) '+%F %T')
-        awk -v a="$FROM" -v b="$TO" '$0 >= a && $0 <= b' "$TODAY"
-        ;;
-    *)
-        echo "usage: zmk-log [tail|today|find [N]|since HH:MM|around HH:MM|days]" >&2
-        exit 2
-        ;;
+"" | tail)
+  exec tail -n 50 -F "$TODAY"
+  ;;
+today)
+  exec cat "$TODAY"
+  ;;
+days)
+  for f in "$LOGDIR"/zmk-*.log; do
+    [ -e "$f" ] || continue
+    b=${f##*/}
+    b=${b#zmk-}
+    echo "${b%.log}"
+  done
+  ;;
+find)
+  N="${2:-3}"
+  files=("$LOGDIR"/zmk-*.log)
+  [ -e "${files[0]}" ] || exit 0
+  start=$((${#files[@]} - N))
+  [ "$start" -lt 0 ] && start=0
+  cat "${files[@]:start}" 2>/dev/null | grep -E "$EVENTS"
+  ;;
+since)
+  [ -n "${2:-}" ] || {
+    echo "usage: zmk-log since \"HH:MM\"" >&2
+    exit 2
+  }
+  awk -v t="$(date +%F) ${2}" '$0 >= t' "$TODAY"
+  ;;
+around)
+  [ -n "${2:-}" ] || {
+    echo "usage: zmk-log around \"HH:MM\"" >&2
+    exit 2
+  }
+  C=$(date -j -f "%F %H:%M" "$(date +%F) ${2}" +%s) || exit 2
+  FROM=$(date -j -f %s $((C - 120)) '+%F %T')
+  TO=$(date -j -f %s $((C + 120)) '+%F %T')
+  awk -v a="$FROM" -v b="$TO" '$0 >= a && $0 <= b' "$TODAY"
+  ;;
+*)
+  echo "usage: zmk-log [tail|today|find [N]|since HH:MM|around HH:MM|days]" >&2
+  exit 2
+  ;;
 esac

--- a/chezmoi/dot_local/bin/executable_zmk-log-capture.sh
+++ b/chezmoi/dot_local/bin/executable_zmk-log-capture.sh
@@ -13,35 +13,35 @@ PRODUCT="BLE HID Host"
 mkdir -p "$LOGDIR"
 
 find_dev() {
-    # locationID (decimal) of the USB device -> hex prefix -> /dev/cu.usbmodem<prefix>*
-    local loc prefix
-    loc=$(ioreg -p IOUSB -l -w0 | grep -A20 "\"USB Product Name\" = \"$PRODUCT\"" \
-        | grep -m1 '"locationID"' | grep -oE '[0-9]+$')
-    [ -n "$loc" ] || return 1
-    prefix=$(printf '%x' "$loc" | sed 's/0*$//')
-    local devs=("/dev/cu.usbmodem${prefix}"*)
-    [ -e "${devs[0]}" ] || return 1
-    echo "${devs[0]}"
+  # locationID (decimal) of the USB device -> hex prefix -> /dev/cu.usbmodem<prefix>*
+  local loc prefix
+  loc=$(ioreg -p IOUSB -l -w0 | grep -A20 "\"USB Product Name\" = \"$PRODUCT\"" |
+    grep -m1 '"locationID"' | grep -oE '[0-9]+$')
+  [ -n "$loc" ] || return 1
+  prefix=$(printf '%x' "$loc" | sed 's/0*$//')
+  local devs=("/dev/cu.usbmodem${prefix}"*)
+  [ -e "${devs[0]}" ] || return 1
+  echo "${devs[0]}"
 }
 
 prune() {
-    find "$LOGDIR" -name 'zmk-*.log' -mtime +"$RETAIN_DAYS" -delete 2>/dev/null
+  find "$LOGDIR" -name 'zmk-*.log' -mtime +"$RETAIN_DAYS" -delete 2>/dev/null
 }
 
 echo "$(date '+%F %T') capture: starting (product=\"$PRODUCT\")" >&2
 
 while :; do
-    prune
-    DEV=$(find_dev)
-    if [ -z "$DEV" ]; then
-        sleep 5
-        continue
-    fi
-    echo "$(date '+%F %T') capture: attached $DEV" >&2
-    # cat ends on USB re-enumeration (I/O error) -> loop re-resolves the device.
-    cat "$DEV" 2>/dev/null | while IFS= read -r line; do
-        printf '%s %s\n' "$(date '+%F %T')" "$line" >> "$LOGDIR/zmk-$(date +%F).log"
-    done
-    echo "$(date '+%F %T') capture: detached $DEV" >&2
-    sleep 2
+  prune
+  DEV=$(find_dev)
+  if [ -z "$DEV" ]; then
+    sleep 5
+    continue
+  fi
+  echo "$(date '+%F %T') capture: attached $DEV" >&2
+  # cat ends on USB re-enumeration (I/O error) -> loop re-resolves the device.
+  cat "$DEV" 2>/dev/null | while IFS= read -r line; do
+    printf '%s %s\n' "$(date '+%F %T')" "$line" >>"$LOGDIR/zmk-$(date +%F).log"
+  done
+  echo "$(date '+%F %T') capture: detached $DEV" >&2
+  sleep 2
 done

--- a/chezmoi/private_dot_claude/modify_settings.json
+++ b/chezmoi/private_dot_claude/modify_settings.json
@@ -110,9 +110,9 @@ out=$(printf '%s\n' "$input" | jq --arg cmd "$cmd" --arg stop "$cmd_stop" '
 # change rebuilds. Give it room: a timed-out hook is fail-open (the command runs
 # unwrapped), but it is noisy, and a rebuild happens exactly when the tool is
 # being worked on.
-if command -v rundiff >/dev/null 2>&1 \
-  && snippet=$(rundiff hook print --json 2>/dev/null) \
-  && printf '%s' "$snippet" | jq -e '.hooks.PreToolUse[0].hooks[0].command' >/dev/null 2>&1; then
+if command -v rundiff >/dev/null 2>&1 &&
+  snippet=$(rundiff hook print --json 2>/dev/null) &&
+  printf '%s' "$snippet" | jq -e '.hooks.PreToolUse[0].hooks[0].command' >/dev/null 2>&1; then
   merged=$(printf '%s\n' "$out" | jq --argjson add "$snippet" '
     ($add.hooks.PreToolUse[0].hooks[0] | .timeout = 30) as $h
     | ( if ( [ (.hooks.PreToolUse // [])[]?.hooks[]?

--- a/chezmoi/run_onchange_install-vscode-extensions.sh
+++ b/chezmoi/run_onchange_install-vscode-extensions.sh
@@ -27,11 +27,13 @@ fi
 # shellcheck disable=SC2043  # 1 要素なのは今だけ — 拡張を足す時に行を増やす拡張点として
 #                             ループの形を保つ（潰すと足す側が構造ごと書き直すことになる）
 for ext in \
-  anthropic.claude-code
-do
+  anthropic.claude-code; do
   "$CODE_BIN" --install-extension "$ext" --force >/dev/null &
   ext_pid=$!
-  ( sleep 120; kill "$ext_pid" 2>/dev/null ) >/dev/null 2>&1 &
+  (
+    sleep 120
+    kill "$ext_pid" 2>/dev/null
+  ) >/dev/null 2>&1 &
   ext_watchdog=$!
   if wait "$ext_pid" 2>/dev/null; then
     kill "$ext_watchdog" 2>/dev/null || :

--- a/install.sh
+++ b/install.sh
@@ -55,12 +55,12 @@ MODE=full
 SKIP_CLONE=0
 for arg in "$@"; do
   case "$arg" in
-    --phase2) MODE=phase2 ;;
-    --skip-clone) SKIP_CLONE=1 ;;
-    *)
-      printf 'install.sh: 未知のオプション: %s (使えるのは --phase2 / --skip-clone のみ)\n' "$arg" >&2
-      exit 2
-      ;;
+  --phase2) MODE=phase2 ;;
+  --skip-clone) SKIP_CLONE=1 ;;
+  *)
+    printf 'install.sh: 未知のオプション: %s (使えるのは --phase2 / --skip-clone のみ)\n' "$arg" >&2
+    exit 2
+    ;;
   esac
 done
 
@@ -77,12 +77,12 @@ DF_EVENTS="$DF_RUN_DIR/events.tsv"
 DF_SUMMARY="$DF_RUN_DIR/summary.txt"
 DF_DETAIL="$DF_RUN_DIR/detail"
 
-if ! mkdir -p "$DF_DETAIL" 2>/dev/null || ! : > "$DF_LOG" 2>/dev/null; then
+if ! mkdir -p "$DF_DETAIL" 2>/dev/null || ! : >"$DF_LOG" 2>/dev/null; then
   echo "FATAL: ログ出力先を用意できない: $DF_RUN_DIR" >&2
   exit 1
 fi
-: > "$DF_EVENTS"
-printf '#ts\ttype\tname\trc\n' >> "$DF_EVENTS"
+: >"$DF_EVENTS"
+printf '#ts\ttype\tname\trc\n' >>"$DF_EVENTS"
 ln -sfn "$DF_RUN_ID" "$DF_LOG_ROOT/latest"
 
 # リダイレクト前に実端末へ出す（後段でハングしても在り処が分かる）
@@ -93,12 +93,12 @@ DF_FIFO_DIR="$(mktemp -d "${TMPDIR:-/tmp}/dfinstall.XXXXXX")"
 mkfifo -m 600 "$DF_FIFO_DIR/pipe"
 # tee は SIG_IGN を継承して Ctrl-C を生き延び、FIFO を最後まで drain する
 trap '' INT
-tee -a "$DF_LOG" < "$DF_FIFO_DIR/pipe" &
+tee -a "$DF_LOG" <"$DF_FIFO_DIR/pipe" &
 DF_TEE_PID=$!
 trap - INT
 # fd 3 = 実端末（tee を畳んだ後でも人間向けに 1 行出せる）
 exec 3>&1
-exec > "$DF_FIFO_DIR/pipe" 2>&1
+exec >"$DF_FIFO_DIR/pipe" 2>&1
 rm -f "$DF_FIFO_DIR/pipe"
 rmdir "$DF_FIFO_DIR" 2>/dev/null || :
 
@@ -113,7 +113,7 @@ df_say() { printf '[%s] %s\n' "$(date +%H:%M:%S)" "$*"; }
 
 df_phase() {
   DF_PHASE="$1"
-  printf '%s\tPHASE\t%s\t-\n' "$(df_now)" "$1" >> "$DF_EVENTS"
+  printf '%s\tPHASE\t%s\t-\n' "$(df_now)" "$1" >>"$DF_EVENTS"
   printf '\n[%s] ===== PHASE %s =====\n' "$(date +%H:%M:%S)" "$1"
 }
 
@@ -123,19 +123,19 @@ df_phase() {
 # df_step_try = リトライ前提の 1 試行。events には TRY で記録し DF_STEP_FAILURES に
 #   数えない（数えると「attempt 1 失敗 → attempt 2 成功」の正常回復まで RESULT が
 #   FAILED になる偽失敗が出る。成否の正本は各 phase 末尾の df_check_ok/fail）。
-df_step()     { df_step_impl STEP "$@"; }
+df_step() { df_step_impl STEP "$@"; }
 df_step_try() { df_step_impl TRY "$@"; }
 df_step_impl() {
   df_step_evt="$1"
   df_step_name="$2"
   df_step_mode="$3"
   shift 3
-  printf '%s\tSTEP_START\t%s\t-\n' "$(df_now)" "$df_step_name" >> "$DF_EVENTS"
+  printf '%s\tSTEP_START\t%s\t-\n' "$(df_now)" "$df_step_name" >>"$DF_EVENTS"
   df_say "--- step $df_step_name"
   if [ "$df_step_mode" = quiet ]; then
     df_step_out="$DF_DETAIL/$df_step_name.log"
-    if "$@" > "$df_step_out" 2>&1; then df_step_rc=0; else df_step_rc=$?; fi
-    df_say "    output -> detail/$df_step_name.log ($(wc -l < "$df_step_out" | tr -d ' ') lines)"
+    if "$@" >"$df_step_out" 2>&1; then df_step_rc=0; else df_step_rc=$?; fi
+    df_say "    output -> detail/$df_step_name.log ($(wc -l <"$df_step_out" | tr -d ' ') lines)"
     if [ "$df_step_rc" -ne 0 ]; then
       df_say "    tail of detail/$df_step_name.log:"
       tail -n 30 "$df_step_out" | sed 's/^/    | /'
@@ -143,7 +143,7 @@ df_step_impl() {
   else
     if "$@"; then df_step_rc=0; else df_step_rc=$?; fi
   fi
-  printf '%s\t%s\t%s\t%s\n' "$(df_now)" "$df_step_evt" "$df_step_name" "$df_step_rc" >> "$DF_EVENTS"
+  printf '%s\t%s\t%s\t%s\n' "$(df_now)" "$df_step_evt" "$df_step_name" "$df_step_rc" >>"$DF_EVENTS"
   if [ "$df_step_rc" -ne 0 ]; then
     if [ "$df_step_evt" = STEP ]; then
       DF_STEP_FAILURES=$((DF_STEP_FAILURES + 1))
@@ -158,7 +158,7 @@ df_step_impl() {
 # 事後条件違反の記録（fail しても flow は止めない。RESULT は必ず FAILED になる）
 df_check_fail() {
   DF_STEP_FAILURES=$((DF_STEP_FAILURES + 1))
-  printf '%s\tCHECK\t%s\t1\n' "$(df_now)" "$1" >> "$DF_EVENTS"
+  printf '%s\tCHECK\t%s\t1\n' "$(df_now)" "$1" >>"$DF_EVENTS"
   df_say "  ✘ CHECK [$1] $2"
 }
 df_check_ok() { df_say "  ok [$1] $2"; }
@@ -180,28 +180,33 @@ df_finish() {
   if [ "$df_rc" -ne 0 ]; then
     df_verdict=FAILED
   elif [ "$DF_REACHED_END" != "1" ]; then
-    df_verdict=ABORTED; df_rc=99
+    df_verdict=ABORTED
+    df_rc=99
   elif [ "$DF_STEP_FAILURES" -gt 0 ]; then
-    df_verdict=FAILED; df_rc=1
+    df_verdict=FAILED
+    df_rc=1
   elif [ "$SKIP_CLONE" = 1 ]; then
     df_verdict=PARTIAL
   else
     df_verdict=OK
   fi
-  printf '%s\tEND\t%s\t%s\n' "$(df_now)" "$df_verdict" "$df_rc" >> "$DF_EVENTS"
+  printf '%s\tEND\t%s\t%s\n' "$(df_now)" "$df_verdict" "$df_rc" >>"$DF_EVENTS"
 
   printf '\n[%s] ================ RESULT ================\n' "$(date +%H:%M:%S)"
   printf 'RESULT: %s (exit %s)\n' "$df_verdict" "$df_rc"
   awk -F'\t' '($2=="STEP"||$2=="CHECK") && $4!="0"{printf "FAIL %s\n", $3}' "$DF_EVENTS"
   case "$df_verdict" in
-    OK)
-      printf '\n✓ 完了。全 phase + 事後条件検証を通過。新しいターミナルを開いて使用開始。\n' ;;
-    PARTIAL)
-      printf '\nPARTIAL: --skip-clone のため未完（ghq-get-mine と claude-memory link が残っている）\n' ;;
-    *)
-      printf '\nNEXT: 上の FAIL を直し、同じコマンドを再実行（冪等）。\n'
-      printf '     SSH gate (P-onepassword) 起因なら 1Password の サインイン / SSH agent ON /\n'
-      printf '     鍵承認 を確認して "sh %s/install.sh --phase2" が最短。詳細: %s\n' "$REPO_DIR" "$DF_SUMMARY" ;;
+  OK)
+    printf '\n✓ 完了。全 phase + 事後条件検証を通過。新しいターミナルを開いて使用開始。\n'
+    ;;
+  PARTIAL)
+    printf '\nPARTIAL: --skip-clone のため未完（ghq-get-mine と claude-memory link が残っている）\n'
+    ;;
+  *)
+    printf '\nNEXT: 上の FAIL を直し、同じコマンドを再実行（冪等）。\n'
+    printf '     SSH gate (P-onepassword) 起因なら 1Password の サインイン / SSH agent ON /\n'
+    printf '     鍵承認 を確認して "sh %s/install.sh --phase2" が最短。詳細: %s\n' "$REPO_DIR" "$DF_SUMMARY"
+    ;;
   esac
   printf 'summary: %s\nlog:     %s\n' "$DF_SUMMARY" "$DF_LOG"
 
@@ -231,7 +236,7 @@ df_finish() {
     done
     echo "--- last 40 log lines ---"
     tail -n 40 "$DF_LOG" 2>/dev/null
-  } > "$DF_SUMMARY" 2>&1
+  } >"$DF_SUMMARY" 2>&1
 
   printf 'install.sh(%s): RESULT %s (exit %s) — %s\n' "$MODE" "$df_verdict" "$df_rc" "$DF_SUMMARY" >&3
   exit "$df_rc"
@@ -317,16 +322,19 @@ run_verify_system() {
 
   # V2: user layer の実体。期待リストは手書きせず現世代から導出（drift しない）
   if [ -n "$expect_gen" ] && [ -d "$expect_gen/home-files" ]; then
-    ( cd "$expect_gen/home-files" && find . \( -type f -o -type l \) | sed 's|^\./||' ) \
-      > "$DF_RUN_DIR/expected-home-files"
+    (cd "$expect_gen/home-files" && find . \( -type f -o -type l \) | sed 's|^\./||') \
+      >"$DF_RUN_DIR/expected-home-files"
     v2_missing=0
     while IFS= read -r rel; do
-      [ -e "$HOME/$rel" ] || { v2_missing=$((v2_missing + 1)); df_say "    missing: ~/$rel"; }
-    done < "$DF_RUN_DIR/expected-home-files"
+      [ -e "$HOME/$rel" ] || {
+        v2_missing=$((v2_missing + 1))
+        df_say "    missing: ~/$rel"
+      }
+    done <"$DF_RUN_DIR/expected-home-files"
     if [ "$v2_missing" -gt 0 ]; then
       df_check_fail V2-home-files "$v2_missing 件の home file 欠落"
     else
-      df_check_ok V2-home-files "$(wc -l < "$DF_RUN_DIR/expected-home-files" | tr -d ' ') files"
+      df_check_ok V2-home-files "$(wc -l <"$DF_RUN_DIR/expected-home-files" | tr -d ' ') files"
     fi
   else
     df_check_fail V2-home-files "期待ファイル一覧を導出できない（世代パス不明 = V1 を先に直す）"
@@ -355,23 +363,23 @@ run_verify_system() {
   if [ -x /opt/homebrew/bin/brew ]; then
     for kind in brews casks; do
       env PATH="$HM_PATH:$PATH" nix eval --impure --json \
-        "$REPO_DIR#darwinConfigurations.${FLAKE_HOST}.config.homebrew.${kind}" 2>/dev/null \
-        | env PATH="$HM_PATH:$PATH" jq -r '.[] | if type=="string" then . else .name end' \
-        | sed 's|.*/||' | sort > "$DF_RUN_DIR/expected-$kind" || :
+        "$REPO_DIR#darwinConfigurations.${FLAKE_HOST}.config.homebrew.${kind}" 2>/dev/null |
+        env PATH="$HM_PATH:$PATH" jq -r '.[] | if type=="string" then . else .name end' |
+        sed 's|.*/||' | sort >"$DF_RUN_DIR/expected-$kind" || :
       if [ "$kind" = brews ]; then
-        /opt/homebrew/bin/brew list --formula 2>/dev/null | sort > "$DF_RUN_DIR/actual-$kind" || :
+        /opt/homebrew/bin/brew list --formula 2>/dev/null | sort >"$DF_RUN_DIR/actual-$kind" || :
       else
-        /opt/homebrew/bin/brew list --cask 2>/dev/null | sort > "$DF_RUN_DIR/actual-$kind" || :
+        /opt/homebrew/bin/brew list --cask 2>/dev/null | sort >"$DF_RUN_DIR/actual-$kind" || :
       fi
       if [ ! -s "$DF_RUN_DIR/expected-$kind" ]; then
         df_check_fail "V6-$kind" "期待 $kind を flake から導出できない"
         continue
       fi
-      comm -23 "$DF_RUN_DIR/expected-$kind" "$DF_RUN_DIR/actual-$kind" > "$DF_RUN_DIR/missing-$kind"
+      comm -23 "$DF_RUN_DIR/expected-$kind" "$DF_RUN_DIR/actual-$kind" >"$DF_RUN_DIR/missing-$kind"
       if [ -s "$DF_RUN_DIR/missing-$kind" ]; then
-        df_check_fail "V6-$kind" "未 install: $(tr '\n' ' ' < "$DF_RUN_DIR/missing-$kind")"
+        df_check_fail "V6-$kind" "未 install: $(tr '\n' ' ' <"$DF_RUN_DIR/missing-$kind")"
       else
-        df_check_ok "V6-$kind" "全 $(wc -l < "$DF_RUN_DIR/expected-$kind" | tr -d ' ') 件"
+        df_check_ok "V6-$kind" "全 $(wc -l <"$DF_RUN_DIR/expected-$kind" | tr -d ' ') 件"
       fi
     done
   else
@@ -398,11 +406,14 @@ run_clone_phases() {
   fi
   gate_out="$DF_RUN_DIR/ssh-gate.out"
   ssh -n -o StrictHostKeyChecking=accept-new -o ConnectTimeout=15 -T git@github.com \
-    > "$gate_out" 2>&1 &
+    >"$gate_out" 2>&1 &
   gate_pid=$!
   # watchdog の fd を FIFO から切り離す（>/dev/null 2>&1）。切り離さないと kill 後も
   # orphan の sleep が FIFO の write 端を掴み、df_finish の wait(tee) が最大 75 秒止まる
-  ( sleep 75; kill "$gate_pid" 2>/dev/null ) >/dev/null 2>&1 &
+  (
+    sleep 75
+    kill "$gate_pid" 2>/dev/null
+  ) >/dev/null 2>&1 &
   gate_watchdog=$!
   wait "$gate_pid" 2>/dev/null || :
   kill "$gate_watchdog" 2>/dev/null || :
@@ -447,14 +458,14 @@ run_clone_phases() {
   # 取り、200 超で検証が空振りになる縮退を検出できるようにする）
   if env PATH="$HM_PATH:$PATH" gh auth status >/dev/null 2>&1; then
     env PATH="$HM_PATH:$PATH" gh repo list "$GITHUB_USERNAME" --no-archived --limit 1000 \
-      --json nameWithOwner --jq '.[].nameWithOwner' 2>/dev/null | sort > "$DF_RUN_DIR/expected-repos" || :
-    env PATH="$HM_PATH:$PATH" ghq list 2>/dev/null | sed 's|^github.com/||' | sort > "$DF_RUN_DIR/actual-repos" || :
+      --json nameWithOwner --jq '.[].nameWithOwner' 2>/dev/null | sort >"$DF_RUN_DIR/expected-repos" || :
+    env PATH="$HM_PATH:$PATH" ghq list 2>/dev/null | sed 's|^github.com/||' | sort >"$DF_RUN_DIR/actual-repos" || :
     if [ -s "$DF_RUN_DIR/expected-repos" ]; then
-      comm -23 "$DF_RUN_DIR/expected-repos" "$DF_RUN_DIR/actual-repos" > "$DF_RUN_DIR/missing-repos"
+      comm -23 "$DF_RUN_DIR/expected-repos" "$DF_RUN_DIR/actual-repos" >"$DF_RUN_DIR/missing-repos"
       if [ -s "$DF_RUN_DIR/missing-repos" ]; then
-        df_check_fail V5b-clone "未 clone: $(tr '\n' ' ' < "$DF_RUN_DIR/missing-repos")"
+        df_check_fail V5b-clone "未 clone: $(tr '\n' ' ' <"$DF_RUN_DIR/missing-repos")"
       else
-        df_check_ok V5b-clone "全 $(wc -l < "$DF_RUN_DIR/expected-repos" | tr -d ' ') repo clone 済み"
+        df_check_ok V5b-clone "全 $(wc -l <"$DF_RUN_DIR/expected-repos" | tr -d ' ') repo clone 済み"
       fi
     else
       df_check_fail V5b-clone "gh repo list が空。clone 完全性を検証できていない"
@@ -548,9 +559,9 @@ fi
 # ※ Defaults !use_pty 案（宣言側）との優劣は Tart VM probe で最終確定（VM-gated seam）。
 DOTFILES_SUDO_RULE="${DOTFILES_SUDO_RULE:-$USER ALL=(ALL) NOPASSWD:SETENV: ALL}"
 df_sudo_tmp="$DF_RUN_DIR/sudoers-dropin"
-printf '%s\n' "$DOTFILES_SUDO_RULE" > "$df_sudo_tmp"
-if sudo -n /usr/sbin/visudo -cf "$df_sudo_tmp" >/dev/null 2>&1 \
-  && sudo -n /usr/bin/install -m 0440 -o root -g wheel "$df_sudo_tmp" "$SUDOERS_DROPIN"; then
+printf '%s\n' "$DOTFILES_SUDO_RULE" >"$df_sudo_tmp"
+if sudo -n /usr/sbin/visudo -cf "$df_sudo_tmp" >/dev/null 2>&1 &&
+  sudo -n /usr/bin/install -m 0440 -o root -g wheel "$df_sudo_tmp" "$SUDOERS_DROPIN"; then
   DF_SUDO_RULE_PLANTED=1
   df_check_ok P1-sudoers "bootstrap drop-in 設置（終了時に自動削除）"
 else
@@ -566,10 +577,10 @@ CLT_SENTINEL=/tmp/.com.apple.dt.CommandLineTools.installondemand.in-progress
 clt_pick_label() {
   # macOS 26 は複数ラベルを同時提示する（26.5 / 26.6 を実測）。beta を除き最新を
   # sort -V で選ぶ（lexical だと 26.9 > 26.10 になる罠）。
-  /usr/sbin/softwareupdate --list 2>&1 \
-    | sed -n 's/^[* -]*Label: \(Command Line Tools for Xcode[^,]*\).*$/\1/p' \
-    | grep -iv beta \
-    | sort -V | tail -n 1
+  /usr/sbin/softwareupdate --list 2>&1 |
+    sed -n 's/^[* -]*Label: \(Command Line Tools for Xcode[^,]*\).*$/\1/p' |
+    grep -iv beta |
+    sort -V | tail -n 1
 }
 if clt_ok; then
   df_say "CLT 導入済み → skip"
@@ -629,8 +640,8 @@ fi
 nix_pkg="$DF_RUN_DIR/Determinate.pkg"
 nix_pkg_download() {
   curl --proto '=https' --tlsv1.2 -fsSL -o "$nix_pkg.part" \
-    https://install.determinate.systems/determinate-pkg/stable/Universal \
-    && mv -f "$nix_pkg.part" "$nix_pkg"
+    https://install.determinate.systems/determinate-pkg/stable/Universal &&
+    mv -f "$nix_pkg.part" "$nix_pkg"
 }
 if command -v nix >/dev/null 2>&1 && [ -d /nix ]; then
   df_say "nix 導入済み → skip"
@@ -640,10 +651,16 @@ else
     nix_attempt=$((nix_attempt + 1))
     df_say "Determinate .pkg install 試行 $nix_attempt/2"
     if [ ! -f "$nix_pkg" ]; then
-      df_step_try "nix-pkg-download-$nix_attempt" plain nix_pkg_download || { sleep 10; continue; }
+      df_step_try "nix-pkg-download-$nix_attempt" plain nix_pkg_download || {
+        sleep 10
+        continue
+      }
     fi
     df_step_try "nix-pkg-install-$nix_attempt" quiet \
-      sudo -n /usr/sbin/installer -pkg "$nix_pkg" -target / || { sleep 10; continue; }
+      sudo -n /usr/sbin/installer -pkg "$nix_pkg" -target / || {
+      sleep 10
+      continue
+    }
     break
   done
   if [ -f /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh ]; then
@@ -694,22 +711,22 @@ else
   if [ -x /opt/homebrew/bin/brew ]; then
     for bf_kind in taps brews casks; do
       env PATH="$HM_PATH:$PATH" nix eval --impure --json \
-        "$REPO_DIR#darwinConfigurations.${FLAKE_HOST}.config.homebrew.${bf_kind}" 2>/dev/null \
-        | env PATH="$HM_PATH:$PATH" jq -r '.[] | if type=="string" then . else .name end' \
-        | while IFS= read -r bf_item; do
-        [ -z "$bf_item" ] && continue
-        case "$bf_kind" in
-          taps)  bf_cmd="tap" ;;
+        "$REPO_DIR#darwinConfigurations.${FLAKE_HOST}.config.homebrew.${bf_kind}" 2>/dev/null |
+        env PATH="$HM_PATH:$PATH" jq -r '.[] | if type=="string" then . else .name end' |
+        while IFS= read -r bf_item; do
+          [ -z "$bf_item" ] && continue
+          case "$bf_kind" in
+          taps) bf_cmd="tap" ;;
           brews) bf_cmd="install --formula" ;;
           casks) bf_cmd="install --cask" ;;
-        esac
-        # shellcheck disable=SC2086  # bf_cmd の語分割は意図的
-        if /opt/homebrew/bin/brew $bf_cmd "$bf_item" >/dev/null 2>&1; then
-          df_say "  ✓ $bf_kind $bf_item"
-        else
-          df_say "  ✘ $bf_kind $bf_item 失敗"
-        fi
-      done
+          esac
+          # shellcheck disable=SC2086  # bf_cmd の語分割は意図的
+          if /opt/homebrew/bin/brew $bf_cmd "$bf_item" >/dev/null 2>&1; then
+            df_say "  ✓ $bf_kind $bf_item"
+          else
+            df_say "  ✘ $bf_kind $bf_item 失敗"
+          fi
+        done
     done
   fi
   df_step darwin-switch-retry plain switch_cmd || df_say "switch retry も失敗（RESULT は FAILED になる。verify で実害を特定）"

--- a/system/modules/scripts/add-homebrew.sh
+++ b/system/modules/scripts/add-homebrew.sh
@@ -22,12 +22,18 @@ NAME=""
 DESC=""
 for arg in "$@"; do
   case "$arg" in
-    --name=*) NAME="${arg#--name=}" ;;
-    --desc=*) DESC="${arg#--desc=}" ;;
-    *) echo "unknown arg: $arg (使い方: --name=... [--desc=...])" >&2; exit 1 ;;
+  --name=*) NAME="${arg#--name=}" ;;
+  --desc=*) DESC="${arg#--desc=}" ;;
+  *)
+    echo "unknown arg: $arg (使い方: --name=... [--desc=...])" >&2
+    exit 1
+    ;;
   esac
 done
-[ -z "$NAME" ] && { echo "--name は必須" >&2; exit 1; }
+[ -z "$NAME" ] && {
+  echo "--name は必須" >&2
+  exit 1
+}
 
 # flake dir 解決
 FLAKE_DIR="${DOTFILES_FLAKE_DIR:-}"
@@ -35,7 +41,10 @@ if [ -z "$FLAKE_DIR" ] && command -v ghq >/dev/null 2>&1; then
   FLAKE_DIR=$(ghq list -p github.com/akira-toriyama/dotfiles 2>/dev/null | head -1)
 fi
 [ -z "$FLAKE_DIR" ] && [ -d "$HOME/dotfiles" ] && FLAKE_DIR="$HOME/dotfiles"
-[ -z "$FLAKE_DIR" ] && { echo "flake が見つからない" >&2; exit 1; }
+[ -z "$FLAKE_DIR" ] && {
+  echo "flake が見つからない" >&2
+  exit 1
+}
 HB="$FLAKE_DIR/system/modules/homebrew.nix"
 
 # cask / formula 判定 (formula 優先 = CLI が多いため)
@@ -63,14 +72,14 @@ insert_after_block() {
   awk -v sec="$section" -v ln="$line" '
     $0 == "    " sec " = [" { print; print ln; next }
     { print }
-  ' "$HB" > "$HB.tmp" && mv "$HB.tmp" "$HB"
+  ' "$HB" >"$HB.tmp" && mv "$HB.tmp" "$HB"
 }
 
 # tap formula/cask (owner/repo/name 形式) なら tap も宣言する。
 # nix-darwin homebrew は宣言された tap からしか解決しないので、これが無いと
 # 新 PC の switch で "No available formula/cask" になる (既存 omniwm と同じ理由)。
 if [[ "$NAME" == */*/* ]]; then
-  TAP="${NAME%/*}"   # owner/repo/name → owner/repo
+  TAP="${NAME%/*}" # owner/repo/name → owner/repo
   if grep -q "\"$TAP\"" "$HB"; then
     echo "tap 宣言済み: $TAP"
   else

--- a/system/modules/scripts/check-dotfiles-drift.sh
+++ b/system/modules/scripts/check-dotfiles-drift.sh
@@ -88,12 +88,12 @@ count_lines() { if [ -z "$1" ]; then echo 0; else echo "$1" | wc -l | tr -d ' ';
 # 1. homebrew drift
 # ============================================================
 declared_casks=$(
-  nix eval --json "$FLAKE_DIR#darwinConfigurations.default.config.homebrew.casks" --impure 2>/dev/null \
-    | jq -r '.[] | if type == "object" then .name else . end' 2>/dev/null | sort || true
+  nix eval --json "$FLAKE_DIR#darwinConfigurations.default.config.homebrew.casks" --impure 2>/dev/null |
+    jq -r '.[] | if type == "object" then .name else . end' 2>/dev/null | sort || true
 )
 declared_brews=$(
-  nix eval --json "$FLAKE_DIR#darwinConfigurations.default.config.homebrew.brews" --impure 2>/dev/null \
-    | jq -r '.[] | if type == "object" then .name else . end' 2>/dev/null | sort || true
+  nix eval --json "$FLAKE_DIR#darwinConfigurations.default.config.homebrew.brews" --impure 2>/dev/null |
+    jq -r '.[] | if type == "object" then .name else . end' 2>/dev/null | sort || true
 )
 installed_casks=$(brew list --cask 2>/dev/null | sort || true)
 installed_brews=$(brew leaves 2>/dev/null | sort || true)
@@ -118,7 +118,7 @@ while IFS= read -r name; do
   else
     undeclared_brews="${undeclared_brews}${name}"$'\n'
   fi
-done <<< "$extra_brews_all"
+done <<<"$extra_brews_all"
 dup_brews=$(echo "$dup_brews" | grep -v '^$' || true)
 undeclared_brews=$(echo "$undeclared_brews" | grep -v '^$' || true)
 
@@ -159,9 +159,9 @@ if [ "$n_dirty" -gt 0 ]; then
     [ -e "$full" ] || continue
     m=$(stat -f %m "$full" 2>/dev/null || echo 0)
     [ "$m" -gt "$newest" ] && newest=$m
-  done <<< "$dirty"
+  done <<<"$dirty"
   if [ "$newest" -gt 0 ]; then
-    age_days=$(( (now - newest) / 86400 ))
+    age_days=$(((now - newest) / 86400))
     [ "$age_days" -ge "$STALE_DAYS" ] && n_stale=$n_dirty
   fi
 fi
@@ -169,7 +169,7 @@ fi
 # ============================================================
 # 集約: 何も無ければ静かに終了 (+ 残通知を消す)
 # ============================================================
-total=$(( n_ec + n_mc + n_dup + n_ub + n_mb + n_cz + n_unpushed + n_stale ))
+total=$((n_ec + n_mc + n_dup + n_ub + n_mb + n_cz + n_unpushed + n_stale))
 if [ "$total" -eq 0 ]; then
   echo "[$(date)] no drift"
   rm -f "$DETAIL_FILE" "$HOME/.local/state/dotfiles/drift-notified.sha"
@@ -178,14 +178,14 @@ fi
 
 # subtitle: 件数サマリ
 subtitle_parts=""
-[ "$n_ec" -gt 0 ]       && subtitle_parts="${subtitle_parts}未宣言cask${n_ec} / "
-[ "$n_mc" -gt 0 ]       && subtitle_parts="${subtitle_parts}未installcask${n_mc} / "
-[ "$n_dup" -gt 0 ]      && subtitle_parts="${subtitle_parts}Nix二重brew${n_dup} / "
-[ "$n_ub" -gt 0 ]       && subtitle_parts="${subtitle_parts}未宣言brew${n_ub} / "
-[ "$n_mb" -gt 0 ]       && subtitle_parts="${subtitle_parts}未installbrew${n_mb} / "
-[ "$n_cz" -gt 0 ]       && subtitle_parts="${subtitle_parts}chezmoi乖離${n_cz} / "
+[ "$n_ec" -gt 0 ] && subtitle_parts="${subtitle_parts}未宣言cask${n_ec} / "
+[ "$n_mc" -gt 0 ] && subtitle_parts="${subtitle_parts}未installcask${n_mc} / "
+[ "$n_dup" -gt 0 ] && subtitle_parts="${subtitle_parts}Nix二重brew${n_dup} / "
+[ "$n_ub" -gt 0 ] && subtitle_parts="${subtitle_parts}未宣言brew${n_ub} / "
+[ "$n_mb" -gt 0 ] && subtitle_parts="${subtitle_parts}未installbrew${n_mb} / "
+[ "$n_cz" -gt 0 ] && subtitle_parts="${subtitle_parts}chezmoi乖離${n_cz} / "
 [ "$n_unpushed" -gt 0 ] && subtitle_parts="${subtitle_parts}未push${n_unpushed} / "
-[ "$n_stale" -gt 0 ]    && subtitle_parts="${subtitle_parts}滞留未commit${n_stale} / "
+[ "$n_stale" -gt 0 ] && subtitle_parts="${subtitle_parts}滞留未commit${n_stale} / "
 subtitle="${subtitle_parts% / }"
 
 # 詳細レポートの description 取得
@@ -260,7 +260,7 @@ fence() { printf '```sh\n%s\n```\n' "$1"; }
       echo "- **$name**${desc:+ — $desc}"
       fence "brew uninstall $name"
       echo
-    done <<< "$dup_brews"
+    done <<<"$dup_brews"
     echo
   fi
 
@@ -278,7 +278,7 @@ fence() { printf '```sh\n%s\n```\n' "$1"; }
       echo "- 削除"
       fence "brew uninstall $name"
       echo
-    done <<< "$undeclared_brews"
+    done <<<"$undeclared_brews"
     echo
   fi
 
@@ -294,7 +294,7 @@ fence() { printf '```sh\n%s\n```\n' "$1"; }
       echo "- 削除"
       fence "brew uninstall --cask $name"
       echo
-    done <<< "$extra_casks"
+    done <<<"$extra_casks"
     echo
   fi
 
@@ -309,7 +309,7 @@ fence() { printf '```sh\n%s\n```\n' "$1"; }
       fence "brew install --cask $name"
       echo "- 宣言取消: \`homebrew.nix\` の casks から該当行を削除"
       echo
-    done <<< "$missing_casks"
+    done <<<"$missing_casks"
     echo
   fi
 
@@ -324,7 +324,7 @@ fence() { printf '```sh\n%s\n```\n' "$1"; }
       fence "brew install $name"
       echo "- 宣言取消: \`homebrew.nix\` の brews から該当行を削除"
       echo
-    done <<< "$missing_brews"
+    done <<<"$missing_brews"
     echo
   fi
 
@@ -334,7 +334,7 @@ fence() { printf '```sh\n%s\n```\n' "$1"; }
   fence "$RECHECK"
   echo "- 実行ログ"
   fence "tail -30 /tmp/dotfiles-drift.log"
-} > "$DETAIL_FILE"
+} >"$DETAIL_FILE"
 
 # ============================================================
 # 通知。
@@ -350,15 +350,16 @@ if command -v osascript >/dev/null 2>&1; then
   dialog_msg="${subtitle}
 
 「詳細を開く」で対応コマンド付きレポートを表示します。"
-  btn=$(osascript <<OSA 2>/dev/null
+  btn=$(
+    osascript <<OSA 2>/dev/null
 display dialog "${dialog_msg}" with title "⚠ dotfiles drift" buttons {"閉じる", "詳細を開く"} default button "詳細を開く" with icon caution
 OSA
-) || true
+  ) || true
   case "$btn" in
-    *"詳細を開く"*)
-      /opt/homebrew/bin/code -n "$DETAIL_FILE" >/dev/null 2>&1 \
-        || open "$DETAIL_FILE" >/dev/null 2>&1 || true
-      ;;
+  *"詳細を開く"*)
+    /opt/homebrew/bin/code -n "$DETAIL_FILE" >/dev/null 2>&1 ||
+      open "$DETAIL_FILE" >/dev/null 2>&1 || true
+    ;;
   esac
   echo "[$(date)] notified (dialog): $subtitle (詳細: $DETAIL_FILE)"
 else

--- a/system/modules/scripts/claude-maint.sh
+++ b/system/modules/scripts/claude-maint.sh
@@ -52,22 +52,32 @@ if [ -z "$FLAKE_DIR" ] && [ -d "$HOME/dotfiles" ]; then
   FLAKE_DIR="$HOME/dotfiles"
 fi
 if [ -z "$FLAKE_DIR" ] || [ ! -e "$FLAKE_DIR/flake.nix" ]; then
-  log "dotfiles repo not found, skipping"; exit 0
+  log "dotfiles repo not found, skipping"
+  exit 0
 fi
 log "repo = $FLAKE_DIR"
 
 # --- 前提コマンド --------------------------------------------------------------
 for c in claude git gh jq; do
-  command -v "$c" >/dev/null 2>&1 || { log "missing command: $c — skipping"; exit 0; }
+  command -v "$c" >/dev/null 2>&1 || {
+    log "missing command: $c — skipping"
+    exit 0
+  }
 done
 
 # --- ~/.claude のソース (chezmoi 管理) のパス ----------------------------------
 # 移行中の命名 divergence (private_dot_claude vs dot_claude) を両対応。
 CLAUDE_SRC=""
 for cand in "chezmoi/private_dot_claude" "chezmoi/dot_claude"; do
-  [ -d "$FLAKE_DIR/$cand" ] && { CLAUDE_SRC="$cand"; break; }
+  [ -d "$FLAKE_DIR/$cand" ] && {
+    CLAUDE_SRC="$cand"
+    break
+  }
 done
-[ -n "$CLAUDE_SRC" ] || { log "claude source dir not found under $FLAKE_DIR/chezmoi — skipping"; exit 0; }
+[ -n "$CLAUDE_SRC" ] || {
+  log "claude source dir not found under $FLAKE_DIR/chezmoi — skipping"
+  exit 0
+}
 log "claude source = $CLAUDE_SRC"
 
 YM=$(date '+%Y-%m')
@@ -75,7 +85,8 @@ BRANCH="chore/claude-maint-${YM}"
 
 # 既に今月の PR/branch があるなら二重起動しない (月内の再実行ガード)。
 if [ "$DRY_RUN" -eq 0 ] && git -C "$FLAKE_DIR" ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
-  log "branch $BRANCH already on origin — this month already processed, skipping"; exit 0
+  log "branch $BRANCH already on origin — this month already processed, skipping"
+  exit 0
 fi
 
 # ============================================================================
@@ -86,7 +97,8 @@ PROJECTS="$HOME/.claude/projects"
 # 候補の列挙: 実体のある自作分だけ (symlink = plugin 由来は自動除外)。
 # skills: 直下の実ディレクトリ / commands: 直下の実 .md。
 # (macOS の bash は 3.2 で mapfile が無いため while-read で配列化)
-SKILLS=(); COMMANDS=()
+SKILLS=()
+COMMANDS=()
 while IFS= read -r line; do [ -n "$line" ] && SKILLS+=("$line"); done \
   < <(find "$HOME/.claude/skills" -maxdepth 1 -mindepth 1 -type d -exec basename {} \; 2>/dev/null | sort)
 while IFS= read -r line; do [ -n "$line" ] && COMMANDS+=("$line"); done \
@@ -95,26 +107,26 @@ while IFS= read -r line; do [ -n "$line" ] && COMMANDS+=("$line"); done \
 # skill 起動の集計 (name=Skill の tool_use の .input.skill)。count + last-used。
 # rg は launchd PATH に無いので grep -r を使う (/usr/bin/grep は常在)。
 SKILL_STATS=$(
-  grep -rhI --include='*.jsonl' '"name":"Skill"' "$PROJECTS" 2>/dev/null \
-  | jq -r '.timestamp as $t | (.message.content[]? | select(.type=="tool_use" and .name=="Skill") | .input.skill) | "\(.)\t\($t // "-")"' 2>/dev/null \
-  | awk -F'\t' '{c[$1]++; if($2>last[$1]) last[$1]=$2} END{for(k in c) printf "%s\t%d\t%s\n", k, c[k], substr(last[k],1,10)}' \
-  || true
+  grep -rhI --include='*.jsonl' '"name":"Skill"' "$PROJECTS" 2>/dev/null |
+    jq -r '.timestamp as $t | (.message.content[]? | select(.type=="tool_use" and .name=="Skill") | .input.skill) | "\(.)\t\($t // "-")"' 2>/dev/null |
+    awk -F'\t' '{c[$1]++; if($2>last[$1]) last[$1]=$2} END{for(k in c) printf "%s\t%d\t%s\n", k, c[k], substr(last[k],1,10)}' ||
+    true
 )
 # command 起動の集計 (<command-name>/foo)。最終日は付けない (count 主体)。
 CMD_STATS=$(
-  grep -rhoEI --include='*.jsonl' 'command-name>/[A-Za-z0-9_-]+' "$PROJECTS" 2>/dev/null \
-  | sed 's#.*command-name>/##' \
-  | sort | uniq -c | awk '{printf "%s\t%d\n", $2, $1}' \
-  || true
+  grep -rhoEI --include='*.jsonl' 'command-name>/[A-Za-z0-9_-]+' "$PROJECTS" 2>/dev/null |
+    sed 's#.*command-name>/##' |
+    sort | uniq -c | awk '{printf "%s\t%d\n", $2, $1}' ||
+    true
 )
 # 観測期間 (トランスクリプト .jsonl の最古〜最新 mtime を proxy に。全 timestamp 走査は重い)。
 WINDOW=$(
-  find "$PROJECTS" -name '*.jsonl' -type f -exec stat -f '%Sm' -t '%Y-%m-%d' {} + 2>/dev/null \
-  | sort | awk 'NR==1{f=$0} {l=$0} END{if(f)printf "%s 〜 %s", f, l; else printf "(no data)"}'
+  find "$PROJECTS" -name '*.jsonl' -type f -exec stat -f '%Sm' -t '%Y-%m-%d' {} + 2>/dev/null |
+    sort | awk 'NR==1{f=$0} {l=$0} END{if(f)printf "%s 〜 %s", f, l; else printf "(no data)"}'
 )
 
 lookup_skill() { echo "$SKILL_STATS" | awk -F'\t' -v k="$1" '$1==k{print $2" 回 / 最終 "$3; f=1} END{if(!f)print "0 回"}'; }
-lookup_cmd()   { echo "$CMD_STATS"   | awk -F'\t' -v k="$1" '$1==k{print $2" 回"; f=1} END{if(!f)print "0 回"}'; }
+lookup_cmd() { echo "$CMD_STATS" | awk -F'\t' -v k="$1" '$1==k{print $2" 回"; f=1} END{if(!f)print "0 回"}'; }
 
 # 使用表 (markdown) を組む。
 USAGE_TABLE=$(
@@ -141,7 +153,7 @@ cleanup() { [ "$DRY_RUN" -eq 0 ] && git -C "$FLAKE_DIR" worktree remove --force 
 trap cleanup EXIT
 
 git -C "$FLAKE_DIR" worktree remove --force "$WT" >/dev/null 2>&1 || true
-git -C "$FLAKE_DIR" branch -D "$BRANCH" >/dev/null 2>&1 || true   # 前回失敗の残骸を掃除
+git -C "$FLAKE_DIR" branch -D "$BRANCH" >/dev/null 2>&1 || true # 前回失敗の残骸を掃除
 git -C "$FLAKE_DIR" fetch --quiet origin 2>/dev/null || true
 # ベースは origin/main (PR を最新 main 相手に出す)。CLAUDE_MAINT_BASE で上書き可 (テスト用)。
 BASE="${CLAUDE_MAINT_BASE:-origin/main}"
@@ -160,7 +172,8 @@ REPORT_REL="docs/claude-maint-reports/${YM}.md"
 ARCHIVE_LIST="$WT/.claude-maint-archive.list"
 mkdir -p "$WT/$(dirname "$REPORT_REL")"
 
-PROMPT=$(cat <<EOF
+PROMPT=$(
+  cat <<EOF
 あなたは ~/.claude の自作ドキュメント保守担当。作業ツリーは現在の作業ディレクトリ。
 
 ## 対象 (自作分のみ。plugin / symlink は対象外)
@@ -199,14 +212,14 @@ EOF
 log "running claude (budget \$${MAX_BUDGET_USD}) ..."
 CLAUDE_RC=0
 RUN_LOG="$WT/.claude-maint-run.log"
-( cd "$WT" && claude --print \
-    --permission-mode acceptEdits \
-    --allowedTools "Read Edit Write WebFetch Glob Grep" \
-    --max-budget-usd "$MAX_BUDGET_USD" \
-    --output-format text \
-    "$PROMPT" ) >"$RUN_LOG" 2>&1 || CLAUDE_RC=$?
+(cd "$WT" && claude --print \
+  --permission-mode acceptEdits \
+  --allowedTools "Read Edit Write WebFetch Glob Grep" \
+  --max-budget-usd "$MAX_BUDGET_USD" \
+  --output-format text \
+  "$PROMPT") >"$RUN_LOG" 2>&1 || CLAUDE_RC=$?
 sed "s/^/$LOG_PREFIX claude| /" "$RUN_LOG" 2>/dev/null || true
-rm -f "$RUN_LOG"   # PR に含めない
+rm -f "$RUN_LOG" # PR に含めない
 [ "$CLAUDE_RC" -eq 0 ] || log "claude exited rc=$CLAUDE_RC (続行: レポート有無で判断)"
 
 # claude がレポートを書かなかった場合のフォールバック (常に PR を出すため最低限の md を置く)。
@@ -222,31 +235,35 @@ if [ ! -s "$WT/$REPORT_REL" ]; then
     echo '```'
     echo "$USAGE_TABLE"
     echo '```'
-  } > "$WT/$REPORT_REL"
+  } >"$WT/$REPORT_REL"
 fi
 
 # ============================================================================
 # ④ archive 移動 → commit → push → PR
 # ============================================================================
-ARCHIVE_DEST="archive/claude-docs"   # chezmoi 外 = $HOME に展開されない (履歴のみ残る)
+ARCHIVE_DEST="archive/claude-docs" # chezmoi 外 = $HOME に展開されない (履歴のみ残る)
 moved=0
 if [ -s "$ARCHIVE_LIST" ]; then
   while IFS= read -r rel; do
-    rel="${rel#./}"; [ -z "$rel" ] && continue
+    rel="${rel#./}"
+    [ -z "$rel" ] && continue
     src="$WT/$rel"
-    [ -e "$src" ] || { log "archive: not found, skip: $rel"; continue; }
+    [ -e "$src" ] || {
+      log "archive: not found, skip: $rel"
+      continue
+    }
     dest="$WT/$ARCHIVE_DEST/$(echo "$rel" | sed "s#^chezmoi/private_dot_claude/##; s#^chezmoi/dot_claude/##")"
     mkdir -p "$(dirname "$dest")"
-    ( cd "$WT" && git mv "$rel" "${dest#"$WT"/}" ) && moved=$((moved+1)) && log "archived: $rel"
-  done < "$ARCHIVE_LIST"
+    (cd "$WT" && git mv "$rel" "${dest#"$WT"/}") && moved=$((moved + 1)) && log "archived: $rel"
+  done <"$ARCHIVE_LIST"
 fi
-rm -f "$ARCHIVE_LIST"   # PR に含めない
+rm -f "$ARCHIVE_LIST" # PR に含めない
 
 if [ "$DRY_RUN" -eq 1 ]; then
   cp "$WT/$REPORT_REL" "${TMPDIR:-/tmp}/claude-maint-${YM}.md" 2>/dev/null || true
   log "DRY-RUN: report → ${TMPDIR:-/tmp}/claude-maint-${YM}.md / archived=${moved} / worktree 残置: $WT"
   log "DRY-RUN: 'git -C $WT status' で変更を確認できます"
-  trap - EXIT   # worktree を消さない
+  trap - EXIT # worktree を消さない
   exit 0
 fi
 
@@ -257,15 +274,18 @@ if git diff --cached --quiet; then
   exit 0
 fi
 git -c user.email="claude-maint@noreply" -c user.name="claude-maint" \
-    commit -q -m "chore: monthly Claude docs maintenance (${YM})" \
-    -m "archived: ${moved} / report: ${REPORT_REL}"
+  commit -q -m "chore: monthly Claude docs maintenance (${YM})" \
+  -m "archived: ${moved} / report: ${REPORT_REL}"
 git push -q -u origin "$BRANCH"
 
 # worktree は git remote 設定を共有するので gh は origin を自動検出する。
 PR_URL=$(gh pr create \
   --head "$BRANCH" --base main \
   --title "chore: Claude docs maintenance ${YM}" \
-  --body-file "$WT/$REPORT_REL" 2>&1) || { log "gh pr create failed: $PR_URL"; PR_URL=""; }
+  --body-file "$WT/$REPORT_REL" 2>&1) || {
+  log "gh pr create failed: $PR_URL"
+  PR_URL=""
+}
 log "PR: ${PR_URL:-(作成失敗・branch は push 済)}"
 
 # worktree を片付けてから通知 (dialog はクリックまでブロックするため先に掃除)。


### PR DESCRIPTION
**整形のみ。** [PR #277](https://github.com/akira-toriyama/dotfiles/pull/277) から `shfmt` だけを切り出した PR です。10 ファイル・1007 行の差分のうち大半が `install.sh` なので、型修正と混ぜず単独にしました（cold bootstrap の経路で、CI の守りが shellcheck しか無いため）。

設定の追加はありません — `shfmt` は既存の `.editorconfig`（`[*.{sh,bash}] indent_size = 2`）を読むので、**既に宣言されていた規則を実際に成立させるだけ**です。

## 「空白だけ」ではなかったので、意味の同一性を測りました

最初に `git diff -w` を取ったところ**空になりませんでした**（120 行の非空白変更）。中身は `a; b` → 改行、`\` 継続行 → 演算子を行末へ、といった shfmt の正規化です。「たぶん同じ」で通さず、次の手順で検証しました。

1. 各ファイルの**新旧を `shfmt -mn` で minify**（コメント・インデントが消える）
2. 継続行（`\` + 改行）を畳む
3. 空白の連続を 1 個に潰す（トークン境界は保つ）
4. リダイレクト演算子直後の空白を無視（`>/dev/null` と `> /dev/null` は同義）

→ **10/10 ファイルが一致**。3 まででも 8/10 が完全一致で、残り 2 件の差は `>` の後の空白 1 個だけでした。

## そのほかの検証

| 検査 | 結果 |
|---|---|
| `bash -n` / `sh -n`（10 ファイル） | 全て通過 |
| `shellcheck -x`（10 ファイル） | 全て通過 |
| Stop hook の fixture テスト | 9 件全通過 |
| `taplo fmt --check` | 通過 |
| `chezmoi apply` 後の live 突き合わせ | zmk-log / git-stale-check / op-sa 一致 |
| **`~/.claude/settings.json` の健全性** | `jq` で `.model` / `.effortLevel` / `.hooks.Stop` が生存を確認 |

最後の 1 行が今回いちばん危ない箇所でした。`settings.json` は **bash の `modify_` スクリプトが生成する**ので、整形の失敗は permission allowlist を無言で空にし得ます（そのスクリプト自身のコメントがそう書いています）。apply して読み直すまでは「通った」と言えない類の変更です。

SetStatus-task: https://github.com/akira-toriyama/projects/blob/main/.furrow/bodies/t-vk0w.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)