### PR TITLE
:sparkles:(lint) check .sh.tmpl and .plist.tmpl after rendering them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
   # 旧 shellcheck job（ludeeus action）を置換。あれは実質 5 ファイルしか見ておらず、
   # Claude Stop hook 本体・pre-push・chezmoi/run_* が全部 lint 圏外だった。
   lint:
-    name: lint (ruff / mypy / shfmt / shellcheck / actionlint / typos / lychee / gitleaks)
+    name: lint (ruff / mypy / shfmt / shellcheck / tmpl / actionlint / typos / lychee / gitleaks)
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,7 @@ flowchart TD
 - **コミットメッセージは gitmoji-driven**（`<:gitmoji:>[(<scope>)][!] <subject>`。Conventional の `<type>` 語は退役済み）。規約の正本は [docs/commit-convention.md](docs/commit-convention.md) と `glyph rules`。**push 前に `glyph lint --range origin/main..HEAD`**（履歴には退役形式の commit が残っているので `git log` を手本にしない）。
 - **CI ジョブ（[.github/workflows/ci.yml](.github/workflows/ci.yml)、push と PR でトリガー）**:
   - `nix flake check --no-build` — Nix の型/eval 検査（Linux runner）
-  - `lint` — `scripts/lint` 一本（ruff / mypy --strict / shfmt / shellcheck / actionlint / typos / lychee --offline / gitleaks）。**ローカルでも同じコマンドが走る**: `nix develop .#lint --command scripts/lint`
+  - `lint` — `scripts/lint` 一本（ruff / mypy --strict / shfmt / shellcheck / actionlint / typos / lychee --offline / gitleaks / `.tmpl` は render 後に shellcheck・plist 構文）。**ローカルでも同じコマンドが走る**: `nix develop .#lint --command scripts/lint`
   - `script test` — Stop hook の fixture テスト + `scripts/` と `scripts/claude-md-eval/` の unittest
   - 規約検知 — `chezmoi/` 配下 shebang スクリプトの `executable_` 接頭辞 + 自作 command（`~/.claude/commands/`）の `my-` 接頭辞を強制
   - `chezmoi templates render` — 全 `.tmpl` の `execute-template` 検証

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -241,29 +241,41 @@ sh <(curl -fsSL https://raw.githubusercontent.com/akira-toriyama/dotfiles/main/i
 
 [.github/workflows/ci.yml](../.github/workflows/ci.yml) ＋ chord 専用 verify-* ワークフロー:
 
+`ci.yml` の job は 11 本。**表に無い job があれば ci.yml が正**（この表は説明用の写し）。
+
 | ジョブ | 内容 | runner |
 |---|---|---|
-| `nix flake check (eval only)` | Nix の eval/型検査 | Linux（速い） |
-| `darwin-rebuild build (macOS)` | 実 build（cask DL 含む） | macOS-15 |
-| `darwin-rebuild switch smoke (macOS)` | Tart VM で switch 試す | macOS-15 |
-| `Verify casks installed` | 宣言された cask が実際 install できるか | macOS-15 |
-| `lint` | `scripts/lint`（ruff / mypy / shfmt / shellcheck / actionlint / typos / lychee / gitleaks） | Linux |
-| `script test` | Stop hook の fixture + `scripts/**` の unittest | Linux |
-| `chezmoi templates render` | 全 `.tmpl` の execute-template 検証 | Linux |
-| `convention / executable_ prefix` | shebang スクリプトの +x 接頭辞強制 | Linux |
-| `validate` (verify-chord-validate.yml) | chord config strict validation | macOS-15 |
-| `verify` (verify-chord-doc.yml) | chord doc 同期検証 | Linux |
+| `nix flake check (eval only)` | Nix の eval/型検査 | ubuntu-latest |
+| `lint` | `scripts/lint --ci`（ruff / ruff-format / mypy / shellcheck / shfmt / exec-bit / tmpl-shellcheck / tmpl-plist / actionlint / typos / lychee / gitleaks の 12 ゲート） | ubuntu-latest |
+| `convention / executable_ prefix` | `chezmoi/` の shebang スクリプトに `executable_` 接頭辞を強制 | ubuntu-latest |
+| `convention / my- command prefix` | 自作 slash command に `my-` 接頭辞を強制 | ubuntu-latest |
+| `script test` | Stop hook の fixture + `scripts/**` と `scripts/claude-md-eval/` の unittest | ubuntu-latest |
+| `chezmoi templates render` | 全 `.tmpl` の execute-template 検証（get.chezmoi.io の最新版で） | ubuntu-latest |
+| `detect flake-affecting changes` | PR が flake/nix/ci.yml を触ったかを判定し、下 2 本の実行可否を出す | ubuntu-latest |
+| `darwin-rebuild build (macOS)` | 実 build（cask DL 含む・非破壊） | macos-latest |
+| `darwin-rebuild switch smoke (macOS)` | 実 switch＋PATH/cask 検証＋`chezmoi apply`（ephemeral runner なので副作用 OK） | macos-latest |
+| `ci-gate` | 上を全部 needs。**branch protection の必須チェックはこれ 1 本だけ** | ubuntu-latest |
+| `notify red main` | 非 PR の赤を固定タイトル issue に集約（PR では走らない） | ubuntu-latest |
+
+chord 専用の別ワークフロー:
+
+| ジョブ | 内容 | runner |
+|---|---|---|
+| `validate` (verify-chord-validate.yml) | chord config strict validation | macos-15（Swift 6 toolchain 必須） |
+| `verify` (verify-chord-doc.yml) | chord doc 同期検証 | ubuntu-latest |
 
 ### 5.6.1 lint を手元で回す / gitleaks が赤くなったら
 
 ```sh
 nix develop .#lint --command scripts/lint            # CI と同一コマンド・同一バイナリ
-nix develop .#lint --command scripts/lint python     # 一部だけ（python / shell / workflow / docs / secret）
+nix develop .#lint --command scripts/lint python     # 一部だけ（docs / python / secret / shell / tmpl / workflow）
 ```
 
 **素で `scripts/lint` を叩かないこと** —— PATH は `/opt/homebrew/bin` が nix profile より
 前なので、brew 版の shfmt / typos / lychee / gitleaks が混ざって CI と結果がずれる。
 ツールの版の正本は `flake.lock` 1 本で、`devShells.lint`（[flake.nix](../flake.nix)）が配る。
+**開発機で PATH に居るだけのツールを devShell の宣言と混同しないこと** —— `chezmoi` は
+`home.packages` からも来るので、devShell に足し忘れても手元は緑になり CI だけが落ちる。
 
 **gitleaks が真陽性を出したら**（履歴は書き換えない — 絶対ルール 4）:
 

--- a/flake.nix
+++ b/flake.nix
@@ -127,6 +127,10 @@
             pkgs.typos
             pkgs.lychee
             pkgs.gitleaks
+            # tmpl ゲートが .sh.tmpl / .plist.tmpl を render するのに要る。開発機では
+            # home.packages 側の chezmoi が PATH に居るので「入れ忘れても手元は緑」に
+            # なる —— CI (ubuntu runner) には無いのでここでの宣言が唯一の供給源。
+            pkgs.chezmoi
           ];
         };
       });

--- a/scripts/lint
+++ b/scripts/lint
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import plistlib
 import subprocess
 import sys
 from collections.abc import Sequence
@@ -36,6 +37,8 @@ GATES: dict[str, str] = {
     "shellcheck": "shell",
     "shfmt": "shell",
     "exec-bit": "shell",
+    "tmpl-shellcheck": "tmpl",
+    "tmpl-plist": "tmpl",
     "actionlint": "workflow",
     "typos": "docs",
     "lychee": "docs",
@@ -60,9 +63,10 @@ def tracked(*patterns: str) -> list[str]:
 def shell_files() -> list[str]:
     """shebang が sh/bash のファイル。拡張子に頼らない。
 
-    `.tmpl` は chezmoi のテンプレ構文が混ざるので raw では検査できない（render 後の
-    検査は別 task）。`modify_settings.json` のように拡張子が嘘をつくものがあるため、
-    ここは必ず 1 行目を読む。
+    `.tmpl` は chezmoi のテンプレ構文が混ざるので raw では検査できない。render して
+    から検査する経路が tmpl グループ（`tmpl-shellcheck` / `tmpl-plist`）。
+    `modify_settings.json` のように拡張子が嘘をつくものがあるため、ここは必ず
+    1 行目を読む。
     """
     found = []
     for rel in tracked():
@@ -77,6 +81,33 @@ def shell_files() -> list[str]:
         if first.startswith(b"#!") and (b"sh" in first or b"bash" in first):
             found.append(rel)
     return found
+
+
+# tmpl ゲートが「今日はたまたま 0 件だった」で緑にならないよう、対象が存在すること
+# 自体を scripts/test_lint.py が固定する。ここは suffix → 期待件数の下限ではなく
+# 「この suffix を見る」という宣言だけを持つ。
+TMPL_SUFFIXES = (".sh.tmpl", ".plist.tmpl")
+
+
+def tmpl_files(suffix: str) -> list[str]:
+    return sorted(p for p in tracked() if p.endswith(suffix))
+
+
+def render_tmpl(rel: str) -> tuple[bool, str, str]:
+    """chezmoi execute-template に通した結果を返す。(ok, stdout, stderr)。
+
+    CI の chezmoi-templates job と同じ呼び方（`--source ./chezmoi`）。include が
+    source dir 起点で解決されるので、この引数は省略できない。
+    """
+    with (ROOT / rel).open("rb") as fh:
+        proc = subprocess.run(
+            ["chezmoi", "--source", "./chezmoi", "execute-template"],
+            cwd=ROOT,
+            stdin=fh,
+            capture_output=True,
+            text=True,
+        )
+    return proc.returncode == 0, proc.stdout, proc.stderr
 
 
 class Runner:
@@ -107,6 +138,82 @@ class Runner:
             if self.ci:
                 print(f"::error title={gate}::{gate} failed (exit {proc.returncode})")
 
+    def begin(self, gate: str) -> bool:
+        """このゲートを走らせるなら見出しを出して True。走らせないなら False。"""
+        if not self.wants(gate):
+            return False
+        print(f"::group::{gate}" if self.ci else f"── {gate}", flush=True)
+        return True
+
+    def end(self, gate: str, bad: Sequence[str], unit: str) -> None:
+        if self.ci:
+            print("::endgroup::", flush=True)
+        self.ran.add(gate)
+        if bad:
+            self.failed.append(f"{gate} ({len(bad)} {unit})")
+
+    def error(self, rel: str, msg: str) -> None:
+        print(
+            f"::error file={rel}::{msg}" if self.ci else f"  {rel}: {msg}", flush=True
+        )
+
+    def check_templates(self) -> None:
+        """`.tmpl` を render してから検査する。
+
+        raw の `.tmpl` は chezmoi のテンプレ構文が混ざって parse できないので
+        `shell_files()` から外れており、shellcheck も plist の構文検査も掛かって
+        いなかった（＝守りがゼロで、たまたまクリーンなだけの状態）。
+
+        shfmt は掛けない。整形結果を書き戻す先が render 後にしか無く、ソースに
+        反映できない差分を毎回報告することになるため。
+        """
+        sh_gate, plist_gate = "tmpl-shellcheck", "tmpl-plist"
+
+        if self.begin(sh_gate):
+            bad: list[str] = []
+            targets = tmpl_files(".sh.tmpl")
+            for rel in targets:
+                ok, out, err = render_tmpl(rel)
+                if not ok:
+                    self.error(rel, f"template render failed: {err.strip()}")
+                    bad.append(rel)
+                    continue
+                # `-x`（source 追跡）は stdin では効かないので付けない。
+                proc = subprocess.run(
+                    ["shellcheck", "--shell=sh", "-"],
+                    cwd=ROOT,
+                    input=out,
+                    capture_output=True,
+                    text=True,
+                )
+                if proc.returncode != 0:
+                    # 行番号は render 後の出力に対するもの（テンプレ展開で source と
+                    # ずれ得る）ので、annotation には行を載せない。
+                    self.error(rel, "shellcheck failed on rendered output")
+                    print(proc.stdout or proc.stderr, flush=True)
+                    bad.append(rel)
+            print(f"  checked {len(targets)} rendered shell template(s)", flush=True)
+            self.end(sh_gate, bad, "file(s)")
+
+        if self.begin(plist_gate):
+            bad = []
+            targets = tmpl_files(".plist.tmpl")
+            for rel in targets:
+                ok, out, err = render_tmpl(rel)
+                if not ok:
+                    self.error(rel, f"template render failed: {err.strip()}")
+                    bad.append(rel)
+                    continue
+                # macOS の `plutil -lint` 相当を stdlib で。CI は ubuntu なので
+                # plutil は使えない（= 手元だけ通って CI で空振り、を避ける）。
+                try:
+                    plistlib.loads(out.encode())
+                except Exception as exc:  # noqa: BLE001 — plistlib の例外型は多岐
+                    self.error(rel, f"invalid plist after render: {exc}")
+                    bad.append(rel)
+            print(f"  checked {len(targets)} rendered plist template(s)", flush=True)
+            self.end(plist_gate, bad, "file(s)")
+
     def check_exec_bit(self) -> None:
         """scripts/ 配下の shebang スクリプトが +x か。
 
@@ -114,9 +221,8 @@ class Runner:
         scripts/ は誰も見ていなかった。
         """
         gate = "exec-bit"
-        if not self.wants(gate):
+        if not self.begin(gate):
             return
-        print(f"── {gate}" if not self.ci else f"::group::{gate}", flush=True)
         bad = []
         for rel in tracked("scripts/*"):
             path = ROOT / rel
@@ -128,13 +234,8 @@ class Runner:
             if not os.access(path, os.X_OK):
                 bad.append(rel)
         for rel in bad:
-            msg = f"shebang script without +x: {rel}"
-            print(f"::error file={rel}::{msg}" if self.ci else f"  {msg}", flush=True)
-        if self.ci:
-            print("::endgroup::", flush=True)
-        self.ran.add(gate)
-        if bad:
-            self.failed.append(f"{gate} ({len(bad)} file(s))")
+            self.error(rel, "shebang script without +x")
+        self.end(gate, bad, "file(s)")
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -185,6 +286,9 @@ def main(argv: list[str] | None = None) -> int:
     # 正本が 2 箇所になるので足さないこと。
     r.run("shfmt", ["shfmt", "-l", "-d", *sh])
     r.check_exec_bit()
+
+    # --- tmpl ---
+    r.check_templates()
 
     # --- workflow ---
     fmt = (

--- a/scripts/test_lint.py
+++ b/scripts/test_lint.py
@@ -90,11 +90,60 @@ class TestShellFileDiscovery(unittest.TestCase):
         self.assertIn(".githooks/pre-push", found)
 
     def test_templates_are_excluded(self) -> None:
-        # .tmpl は chezmoi 構文が混ざるので raw では検査できない。
+        # .tmpl は chezmoi 構文が混ざるので raw では検査できない
+        # （render 後に見るのは tmpl グループ = TestTemplateDiscovery）。
         self.assertFalse([f for f in lint.shell_files() if f.endswith(".tmpl")])
 
     def test_python_files_are_not_in_the_shell_set(self) -> None:
         self.assertFalse([f for f in lint.shell_files() if f.endswith(".py")])
+
+
+class TestTemplateDiscovery(unittest.TestCase):
+    """tmpl ゲートが「0 件を検査して緑」にならないことを固定する。
+
+    shell_files() が .tmpl を除外している以上、tmpl 側の対象集合が空に縮退しても
+    lint は ✓ を出してしまう（ゲート自体は「走った」ので missing にもならない）。
+    実在ファイルを名指しで押さえるのがいちばん確実な歯止め。
+    """
+
+    def test_shell_templates_are_found(self) -> None:
+        found = lint.tmpl_files(".sh.tmpl")
+        self.assertIn("chezmoi/run_onchange_after_chord-validate.sh.tmpl", found)
+        self.assertIn("chezmoi/run_onchange_after_azookey-bridge.sh.tmpl", found)
+
+    def test_plist_templates_are_found(self) -> None:
+        found = lint.tmpl_files(".plist.tmpl")
+        self.assertIn(
+            "chezmoi/private_Library/LaunchAgents/"
+            "com.akira-toriyama.azookey-bridge.plist.tmpl",
+            found,
+        )
+
+    def test_every_declared_suffix_has_at_least_one_target(self) -> None:
+        for suffix in lint.TMPL_SUFFIXES:
+            with self.subTest(suffix=suffix):
+                self.assertTrue(
+                    lint.tmpl_files(suffix),
+                    f"{suffix} の対象が 0 件。ゲートが空振りしている",
+                )
+
+    def test_declared_suffixes_cover_every_tracked_template(self) -> None:
+        """新種の .tmpl（例: .toml.tmpl）が増えたら気づけるように。
+
+        カバーしていない .tmpl は CI の chezmoi-templates job が render 検証だけは
+        するので落ちはしないが、中身の検査は誰もしていない状態になる。
+        """
+        uncovered = sorted(
+            p
+            for p in lint.tracked("*.tmpl")
+            if not any(p.endswith(s) for s in lint.TMPL_SUFFIXES)
+        )
+        self.assertEqual(
+            uncovered,
+            [],
+            "TMPL_SUFFIXES が見ていない .tmpl がある。検査を足すか、"
+            "検査不要ならこの期待値に理由付きで足すこと",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`.tmpl` files sat outside every shell gate — chezmoi template syntax can't be parsed raw — so two `run_onchange_` scripts and one LaunchAgent plist had zero static checking. Clean by luck, not by construction.

## What this adds

A `tmpl` group in `scripts/lint` with two gates that render first:

| gate | how |
|---|---|
| `tmpl-shellcheck` | `chezmoi execute-template` → `shellcheck --shell=sh -` |
| `tmpl-plist` | `chezmoi execute-template` → stdlib `plistlib.loads` |

`plutil -lint` is macOS-only and the lint job runs on ubuntu, so the plist check is stdlib instead —手元だけ通って CI で空振り、を避ける。

shfmt is deliberately **not** applied: its output would have to be written back to the rendered form, which has no source to land in.

## The devShell trap this hit

`pkgs.chezmoi` had to join `devShells.lint`. Locally `chezmoi` is already on PATH from `home.packages`, so omitting it would have been **green on the dev machine and red only in CI** — exactly the drift the pinned devShell exists to prevent. Noted in `docs/operations.md §5.6.1`.

## Not-silently-zero

`test_lint.py` pins that every declared suffix has ≥1 target and that no tracked `.tmpl` falls outside `TMPL_SUFFIXES`. Without this the gates could degrade to checking zero files and still print ✓ (they'd count as "ran", so the missing-gate check wouldn't catch it either).

## Drive-by

`docs/operations.md §5.6` CI table had drifted from the current 11-job `ci.yml`: it listed a *step* (`Verify casks installed`) as a job, missed four jobs, and named wrong runners. Fixed — this was an open item on `t-pd5r`.

## Verification (measured)

- `nix develop .#lint --command scripts/lint` → `✓ 12 gates passed (docs, python, secret, shell, tmpl, workflow)`
- `python3 -m unittest discover -s scripts` → 14 tests OK
- `nix flake check --no-build` → OK
- **Mutation-verified**: appending `rm -rf $CFG` to the chord-validate template and breaking `</dict>` → both gates fail, exit 1

SetStatus-task: https://github.com/akira-toriyama/projects/blob/main/.furrow/bodies/t-2n7n.md done