### PR TITLE
:sparkles:(eval) add --baseline so two revisions can be compared, not just presence

### DIFF
--- a/scripts/claude-md-eval/README.md
+++ b/scripts/claude-md-eval/README.md
@@ -19,7 +19,7 @@ python3 judge.py
 `run.py` が baseline（節なし）と candidate（節あり）の応答を作り、`judge.py` が盲検で
 判定してリリースゲートを適用する。ゲートが通れば exit 0、落ちれば exit 2。
 
-既定は 12 ケース × 2 試行 × 2 条件 = 応答 48 本、判定 24 ペア。実測で 10 分・$6 前後。
+既定は 15 ケース × 2 試行 × 2 条件 = 応答 60 本、判定 30 ペア。実測で 10 分・$6 前後。
 中断しても `results/responses.jsonl` を見て再開する（完了済みの行は作り直さない）。
 
 ```sh
@@ -27,6 +27,30 @@ python3 run.py --candidate sec.md --trials 3 --model claude-opus-5
 python3 judge.py --responses results/responses.jsonl --out results/verdicts.json
 python3 -m unittest test_eval          # ハーネス自身のテスト
 ```
+
+### 2 版を比べる（`--baseline`）
+
+`--baseline` を渡すと baseline 腕にも別のファイルが載る。既定の「節なし vs 節あり」が
+**足すか足さないか**しか測れないのに対し、こちらは**版 A vs 版 B** を測る。
+
+```sh
+git show <old-sha>:chezmoi/private_dot_claude/CLAUDE.md > /tmp/old.md
+python3 run.py --baseline /tmp/old.md --candidate chezmoi/private_dot_claude/CLAUDE.md \
+               --out results/reorder.jsonl
+python3 judge.py --responses results/reorder.jsonl --out results/reorder-verdicts.json
+```
+
+これが要るのは、**内容を足しも引きもしない編集**（節の並べ替え・1 bullet の分割・
+precedence の明示）が既定の腕構成ではコントラストを作れないため。それらは
+「測る必要が無い」のではなく **「測れなかった」**（PR #274 の構造再編がこれで、
+測らずに merge された）。
+
+全文 2 本を system prompt に載せるので、節だけの比較よりトークンは増える。
+
+**同じ `--out` を腕違いで使い回すと exit 3 で止まる。** 各行に `arms_key`
+（model + 両腕の本文の hash）が入っていて、別の比較の行が混ざったファイルへの追記を
+拒否する。`judge.py` は `(case_id, trial)` でペアにするだけで腕を見ないので、
+混ざると「誰も実行していない比較」の判定が出てしまう。
 
 ## 何を測っているか
 
@@ -79,6 +103,11 @@ named だけ減って unnamed が減らないなら、その規則は**文字列
 
 headless の単発応答の形だけ。対話の複数ターンにわたる挙動、ツールを使う実作業中の振る舞い、
 長いセッションでの遵守率は範囲外。判定者も LLM なので絶対ではない。
+
+**skill の description が発火するかは測れない。** 隔離のために `--setting-sources ""` と
+`--tools ""` を渡している以上、そのセッションには Skill ツール自体が存在しない。
+description を書き換えて「呼ばれやすくなったか」を見るには、ツールを持つ実セッションが
+要る＝このハーネスの外。
 
 work-close 系ケース（W1/W2）はこの制約の中での近似 —— 「作業を終えた状況」をプロンプトに
 書き込んだ単発応答で定型の発火を測る。実セッション末尾（長い文脈の後）での発火率は

--- a/scripts/claude-md-eval/judge.py
+++ b/scripts/claude-md-eval/judge.py
@@ -227,6 +227,15 @@ def main(argv: list[str] | None = None) -> int:
         if line.strip()
     ]
     rows = [r for r in rows if r.get("response")]
+    # A response whose case was renamed or deleted has no prompt to judge
+    # against. Skipping loudly beats the KeyError this used to raise, which
+    # threw away every completed pair in the file over one orphan row.
+    orphans = sorted({r["case_id"] for r in rows if r["case_id"] not in cases})
+    if orphans:
+        print(
+            f"warning: skipping {len(orphans)} unknown case id(s): {', '.join(orphans)}"
+        )
+        rows = [r for r in rows if r["case_id"] in cases]
     grouped: dict[Any, Any] = defaultdict(dict)
     for r in rows:
         r["prompt"] = cases[r["case_id"]]["prompt"]

--- a/scripts/claude-md-eval/run.py
+++ b/scripts/claude-md-eval/run.py
@@ -1,9 +1,16 @@
 #!/usr/bin/env python3
 """Generate baseline and candidate responses for a CLAUDE.md section under test.
 
-baseline  = the case prompt alone
-candidate = the same prompt with the section appended to the system prompt,
+candidate = the case prompt with --candidate appended to the system prompt,
             which is the closest analogue to how CLAUDE.md reaches a session
+baseline  = the case prompt alone, or — with --baseline — the same prompt with
+            a second file appended the same way
+
+The default (no --baseline) answers "does adding this section help?". With
+--baseline it answers "is version B better than version A?", which is the only
+way to measure edits that neither add nor remove content: reordering sections,
+splitting a bullet, making precedence explicit. Those were previously not
+"unnecessary to measure" but *impossible* to measure here.
 
 Both arms are isolated with --setting-sources "" so the operator's own
 CLAUDE.md, plugins, hooks and memory cannot leak in. Without that, the baseline
@@ -14,10 +21,12 @@ the section against itself.
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import subprocess
 import sys
 from typing import Any
+from collections.abc import Mapping
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
@@ -58,15 +67,29 @@ def build_cmd(model: str, section: str | None) -> list[str]:
     return cmd
 
 
+def arms_key(model: str, arms: Mapping[str, str | None]) -> str:
+    """Identity of one comparison: the model plus the exact text of both arms.
+
+    Stamped on every row so a resume cannot silently mix runs. Changing
+    --baseline while reusing the same --out would otherwise reuse the old
+    baseline responses and produce a comparison nobody ever ran.
+    """
+    h = hashlib.sha256()
+    for part in (model, arms["baseline"] or "", arms["candidate"] or ""):
+        h.update(part.encode())
+        h.update(b"\0")
+    return h.hexdigest()[:16]
+
+
 def call(
     case: dict[str, Any],
     condition: str,
     trial: int,
     model: str,
-    section: str,
+    arms: Mapping[str, str | None],
     retries: int,
 ) -> dict[str, Any]:
-    cmd = build_cmd(model, section if condition == "candidate" else None)
+    cmd = build_cmd(model, arms[condition])
     err = "no attempt made"
     for _ in range(retries + 1):
         # The prompt goes through stdin: --tools is variadic and swallows a
@@ -89,6 +112,7 @@ def call(
                     "response": d["result"],
                     "cost_usd": d.get("total_cost_usd"),
                     "model": model,
+                    "arms_key": arms_key(model, arms),
                 }
             err = f"is_error: {str(d)[:200]}"
         else:
@@ -101,19 +125,33 @@ def call(
         "response": None,
         "error": err,
         "model": model,
+        "arms_key": arms_key(model, arms),
     }
 
 
-def completed(path: Path) -> set[tuple[str, str, int]]:
+def completed(path: Path, key: str) -> tuple[set[tuple[str, str, int]], set[str]]:
+    """Rows this run may resume, and the foreign arms_key values found alongside.
+
+    Rows written before arms_key existed carry no key; they are treated as
+    foreign rather than assumed compatible — an unlabelled row could have come
+    from any pair of arms.
+    """
     if not path.exists():
-        return set()
-    done = set()
+        return set(), set()
+    done: set[tuple[str, str, int]] = set()
+    foreign: set[str] = set()
     for line in path.read_text().splitlines():
-        if line.strip():
-            r = json.loads(line)
-            if r.get("response"):
-                done.add((r["case_id"], r["condition"], r["trial"]))
-    return done
+        if not line.strip():
+            continue
+        r = json.loads(line)
+        if r.get("arms_key") != key:
+            foreign.add(
+                r.get("arms_key") or "(no arms_key — written before this check)"
+            )
+            continue
+        if r.get("response"):
+            done.add((r["case_id"], r["condition"], r["trial"]))
+    return done, foreign
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -124,6 +162,17 @@ def main(argv: list[str] | None = None) -> int:
         type=Path,
         required=True,
         help="Markdown file holding the section under test",
+    )
+    ap.add_argument(
+        "--baseline",
+        type=Path,
+        default=None,
+        help=(
+            "Markdown file for the baseline arm. Omit to compare against no "
+            "section at all (does adding this help?). Pass the old version to "
+            "compare two revisions (is B better than A?) — the only way to "
+            "measure reordering, splitting or precedence edits."
+        ),
     )
     ap.add_argument("--cases", type=Path, default=here / "cases.json")
     ap.add_argument("--out", type=Path, default=here / "results" / "responses.jsonl")
@@ -137,11 +186,25 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument("--workers", type=int, default=8)
     args = ap.parse_args(argv)
 
-    section = args.candidate.read_text()
+    arms: dict[str, str | None] = {
+        "baseline": args.baseline.read_text() if args.baseline else None,
+        "candidate": args.candidate.read_text(),
+    }
+    key = arms_key(args.model, arms)
     cases = json.loads(args.cases.read_text())
     args.out.parent.mkdir(parents=True, exist_ok=True)
 
-    done = completed(args.out)
+    done, foreign = completed(args.out, key)
+    if foreign:
+        # Appending here would leave one file holding two different comparisons,
+        # and judge.py pairs by (case_id, trial) without looking at the arms.
+        print(
+            f"{args.out} already holds rows from a different comparison "
+            f"({', '.join(sorted(foreign))}; this run is {key}).\n"
+            "Write to a fresh --out, or delete the file, so the two are not mixed.",
+            file=sys.stderr,
+        )
+        return 3
     jobs: list[tuple[dict[str, Any], str, int]] = [
         (c, cond, t)
         for c in cases
@@ -149,11 +212,15 @@ def main(argv: list[str] | None = None) -> int:
         for t in range(1, args.trials + 1)
         if (c["id"], cond, t) not in done
     ]
-    print(f"{len(jobs)} calls to make ({len(done)} already complete)", flush=True)
+    print(
+        f"{len(jobs)} calls to make ({len(done)} already complete)  "
+        f"arms={key} baseline={'file' if args.baseline else 'none'}",
+        flush=True,
+    )
 
     with ThreadPoolExecutor(max_workers=args.workers) as ex, args.out.open("a") as f:
         for r in ex.map(
-            lambda j: call(j[0], j[1], j[2], args.model, section, args.retries), jobs
+            lambda j: call(j[0], j[1], j[2], args.model, arms, args.retries), jobs
         ):
             f.write(json.dumps(r, ensure_ascii=False) + "\n")
             f.flush()

--- a/scripts/claude-md-eval/test_eval.py
+++ b/scripts/claude-md-eval/test_eval.py
@@ -7,6 +7,7 @@ quiet mistake turns into a wrong conclusion rather than a visible error.
 """
 
 import json
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -117,10 +118,117 @@ class TestIsolation(unittest.TestCase):
         self.assertTrue(cmd[cmd.index("--append-system-prompt") + 1].endswith("RULES"))
 
     def test_operator_settings_are_excluded_from_both_arms(self) -> None:
-        """Without this the baseline would already contain the rules under test."""
-        for section in (None, "RULES"):
+        """Without this the baseline would already contain the rules under test.
+
+        Covers the --baseline arm too: a file-backed baseline still goes
+        through build_cmd, and losing the isolation on that side would make
+        every A/B-of-two-revisions run meaningless in the same way.
+        """
+        for section in (None, "OLD RULES", "RULES"):
             cmd = run.build_cmd("m", section)
             self.assertEqual(cmd[cmd.index("--setting-sources") + 1], "")
+            self.assertEqual(cmd[cmd.index("--tools") + 1], "")
+            self.assertIn("--system-prompt", cmd)
+
+
+class TestBaselineArm(unittest.TestCase):
+    """--baseline turns the harness into an A/B of two revisions.
+
+    Without it the baseline arm is always "no section", so an edit that neither
+    adds nor removes content — reordering, splitting a bullet, spelling out
+    precedence — has no measurable contrast.
+    """
+
+    def test_a_file_backed_baseline_is_appended_like_the_candidate(self) -> None:
+        cmd = run.build_cmd("m", "OLD")
+        self.assertIn("--append-system-prompt", cmd)
+        self.assertTrue(cmd[cmd.index("--append-system-prompt") + 1].endswith("OLD"))
+
+    def test_the_two_arms_carry_different_text(self) -> None:
+        arms = {"baseline": "OLD", "candidate": "NEW"}
+        appended = {
+            cond: run.build_cmd("m", arms[cond])[
+                run.build_cmd("m", arms[cond]).index("--append-system-prompt") + 1
+            ]
+            for cond in arms
+        }
+        self.assertNotEqual(appended["baseline"], appended["candidate"])
+
+
+class TestArmsKey(unittest.TestCase):
+    """Guards the resume path: reusing --out across different arms would
+    recycle responses from a comparison nobody ran."""
+
+    def test_same_arms_same_key(self) -> None:
+        a = {"baseline": None, "candidate": "X"}
+        self.assertEqual(run.arms_key("m", a), run.arms_key("m", dict(a)))
+
+    def test_changing_the_baseline_changes_the_key(self) -> None:
+        no_file = {"baseline": None, "candidate": "X"}
+        with_file = {"baseline": "OLD", "candidate": "X"}
+        self.assertNotEqual(run.arms_key("m", no_file), run.arms_key("m", with_file))
+
+    def test_changing_the_model_changes_the_key(self) -> None:
+        a = {"baseline": None, "candidate": "X"}
+        self.assertNotEqual(run.arms_key("m1", a), run.arms_key("m2", a))
+
+    def test_the_arms_are_not_interchangeable(self) -> None:
+        """Swapping which side is which is a different experiment."""
+        self.assertNotEqual(
+            run.arms_key("m", {"baseline": "A", "candidate": "B"}),
+            run.arms_key("m", {"baseline": "B", "candidate": "A"}),
+        )
+
+
+class TestResume(unittest.TestCase):
+    KEY = "deadbeefdeadbeef"
+
+    def write(self, rows: list[dict[str, object]]) -> Path:
+        d = Path(tempfile.mkdtemp())
+        p = d / "responses.jsonl"
+        p.write_text("".join(json.dumps(r) + "\n" for r in rows))
+        return p
+
+    def row(self, **kw: object) -> dict[str, object]:
+        base: dict[str, object] = {
+            "case_id": "c",
+            "condition": "baseline",
+            "trial": 1,
+            "response": "text",
+            "arms_key": self.KEY,
+        }
+        base.update(kw)
+        return base
+
+    def test_matching_rows_are_resumable(self) -> None:
+        done, foreign = run.completed(self.write([self.row()]), self.KEY)
+        self.assertEqual(done, {("c", "baseline", 1)})
+        self.assertEqual(foreign, set())
+
+    def test_rows_from_another_comparison_are_reported_not_reused(self) -> None:
+        done, foreign = run.completed(
+            self.write([self.row(arms_key="other")]), self.KEY
+        )
+        self.assertEqual(done, set())
+        self.assertEqual(foreign, {"other"})
+
+    def test_unlabelled_rows_are_treated_as_foreign(self) -> None:
+        """Files written before arms_key existed could hold any pair of arms."""
+        row = self.row()
+        del row["arms_key"]
+        done, foreign = run.completed(self.write([row]), self.KEY)
+        self.assertEqual(done, set())
+        self.assertTrue(foreign)
+
+    def test_failed_rows_are_retried_not_skipped(self) -> None:
+        done, foreign = run.completed(self.write([self.row(response=None)]), self.KEY)
+        self.assertEqual(done, set())
+        self.assertEqual(foreign, set())
+
+    def test_a_missing_file_is_not_an_error(self) -> None:
+        self.assertEqual(
+            run.completed(Path("/nonexistent/x.jsonl"), self.KEY), (set(), set())
+        )
 
     def test_model_is_pinned_into_the_command(self) -> None:
         self.assertEqual(


### PR DESCRIPTION
`run.py` could build exactly one contrast: **no section vs section**. That answers "does adding this help?" and nothing else — so any edit that neither adds nor removes content (reordering, splitting a bullet, spelling out precedence) had no measurable contrast at all.

Those edits weren't *unnecessary to measure*. They were **impossible to measure here**. PR #274 — the structural reorder of the global CLAUDE.md — shipped unmeasured for exactly this reason.

## What `--baseline` does

```sh
git show <old-sha>:chezmoi/private_dot_claude/CLAUDE.md > /tmp/old.md
python3 run.py --baseline /tmp/old.md --candidate chezmoi/private_dot_claude/CLAUDE.md \
               --out results/reorder.jsonl
```

The baseline arm goes through the same `build_cmd` path, so both arms keep the `--setting-sources ""` / `--tools ""` / `--system-prompt` isolation. `test_eval` now asserts that isolation across **three** arm shapes instead of two — losing it on the baseline side would make every A/B-of-revisions run meaningless in exactly the way the original isolation comment warns about.

## The sharp edge this opens (and the guard)

`judge.py` pairs rows by `(case_id, trial)` and **never looks at which arms produced them**. Reusing one `--out` across different `--baseline` values would therefore judge a comparison nobody ran, silently and with a plausible-looking verdict.

Every row now carries `arms_key = sha256(model, baseline text, candidate text)`. A run that finds foreign or unlabelled rows in its `--out` exits **3** instead of appending. Rows predating the field count as foreign — an unlabelled row could have come from any pair of arms, so assuming compatibility is the one thing you must not do.

## Harness hygiene (blocked later measurement work — `t-ac9n` prep)

- `judge.py` skips unknown case ids with a warning. It used to raise `KeyError`, throwing away **every completed pair in the file** over one orphan row.
- README: `12 ケース` → **15** (cases.json has held 15 for a while).
- README "測れないこと" gains a real boundary: **skill descriptions cannot be measured here** — `--tools ""` means the session has no Skill tool to fire.

## Verification (measured)

| check | result |
|---|---|
| `python3 -m unittest test_eval` | 21 → **32** tests, green |
| live 2-call run with distinct arm files | both arms received their own file — baseline led with `結論：`, candidate led with a command, matching each arm's rule text |
| stale `arms_key` in `--out` | **exit 3**, refuses to append |
| fresh `--out`, same arms | exit 0 |
| `scripts/lint python docs` | 5 gates passed |

A full 15-case × 2-trial run of **PR #274 old vs new** is in flight to retro-validate that reorder; results will be recorded on `t-6671` / `t-pd5r` rather than held up in this PR.

SetStatus-task: https://github.com/akira-toriyama/projects/blob/main/.furrow/bodies/t-6671.md done