### PR TITLE
:sparkles:(lint) widen ruff select to E,W,F,I,UP,B,C4,SIM,RET,PIE,EXE

### DIFF
--- a/chezmoi/.chezmoiignore
+++ b/chezmoi/.chezmoiignore
@@ -3,3 +3,8 @@
 # (README.md / install.sh / docs / .editorconfig / flake.nix / system/ / home/ 等)
 # はソースルート(chezmoi/)の外にあるため、ここで列挙する必要はない。
 # chezmoi/ 配下に $HOME へ出したくないものが出たらここへ追加する。
+
+# Python のバイトコードキャッシュ。git は .gitignore で無視するが chezmoi は
+# .gitignore を読まないので、chezmoi/ 配下で一度でも python を走らせると
+# __pycache__ が $HOME へ配られる（実測: importlib で読んだだけで生成された）。
+**/__pycache__

--- a/chezmoi/dot_local/share/azookey-bridge/executable_azookey-bridge.py
+++ b/chezmoi/dot_local/share/azookey-bridge/executable_azookey-bridge.py
@@ -34,7 +34,8 @@ CLAUDE_MODEL = "haiku"
 
 FORMAT_RULE = (
     "Respond with ONLY a compact JSON array of strings on one line, e.g. "
-    '["候補1", "候補2", "候補3"] — no markdown fences, no commentary, no object wrapper.'
+    '["候補1", "候補2", "候補3"] — no markdown fences, no commentary, '
+    "no object wrapper."
 )
 
 LANGUAGE_RULE = (
@@ -54,7 +55,10 @@ Input: "<ごめん>"
 Output: ["すみません", "ごめんなさい", "申し訳ありません"]"""
 
 DEFAULT_PROMPT_MARKER = "If the text in <> is a language name"
-LAST_STOCK_EXAMPLE = 'Output: ["Gracias", "Muchas gracias", "Te lo agradezco", "Mil gracias", "Gracias mil"]'
+LAST_STOCK_EXAMPLE = (
+    'Output: ["Gracias", "Muchas gracias", "Te lo agradezco", '
+    '"Mil gracias", "Gracias mil"]'
+)
 
 FENCE_RE = re.compile(r"^```[a-zA-Z]*\n(.*)\n```$", re.DOTALL)
 
@@ -144,7 +148,8 @@ class Handler(BaseHTTPRequestHandler):
             self.end_headers()
             self.wfile.write(payload)
             print(
-                f"[bridge] ok {time.monotonic() - started:.1f}s predictions={predictions}",
+                f"[bridge] ok {time.monotonic() - started:.1f}s "
+                f"predictions={predictions}",
                 file=sys.stderr,
                 flush=True,
             )

--- a/ruff.toml
+++ b/ruff.toml
@@ -14,8 +14,32 @@ exclude = [".git", "result", "result-*"]
 "chezmoi/dot_local/share/azookey-bridge/executable_azookey-bridge.py" = "py39"
 
 [lint]
-# 既定ルールセット（E4 / E7 / E9 + F）から始める。select の拡張（B, UP 等）は
-# 赤の増分を測ってから決める。最初から広げて既存コードを赤くしない。
+# 既定（E4/E7/E9 + F）から、1 グループずつ赤の増分を測って広げた結果がこれ。
+# 実測 2026-07-27（ruff 0.15 系・対象 = repo 全体 + 拡張子の無い `scripts/lint`）:
+#
+#   E 10 / I 2 / SIM 1 / EXE 1 / W・F・UP・B・C4・RET・PIE 0  → 計 14 件
+#
+# 14 件は全部直したので**ベースラインは 0**。以後この select が赤を出したら
+# それは新しく入った違反で、既存の借金ではない。
+select = ["E", "W", "F", "I", "UP", "B", "C4", "SIM", "RET", "PIE", "EXE"]
+
+# ── 選ばなかったもの（`--select ALL` は 231 件。実測 2026-07-27）───────────────
+# ignore に書くと「選んでいないのに ignore してある」死んだ設定になるので、
+# 理由はここに散文で残す。復活を検討する時はこの段落を読むこと。
+#
+# RUF001/002/003 (17) — 全角記号（（ ） ／）を ambiguous 扱いする。日本語で
+#   コメントを書く以上は不可避で、直す＝日本語をやめること。
+# PT009 (28) — unittest を pytest へ移せと言う。stdlib のみ・unittest 維持は
+#   決定事項（scripts のランタイム方針）なので正面衝突する。
+# T201 (23) — print 禁止。CLI の出力そのものなので意図的。
+# D1xx / ANN — docstring 強制・型注釈強制。今の規模（Python 7 ファイル）に過剰。
+#
+# EXE001 は chezmoi/ 配下では意味を持たない。$HOME 側の +x を供給するのは
+# `executable_` 接頭辞（CI の convention-executable-prefix job が強制）で、
+# source 側の git mode は無関係 —— 実際 chezmoi/ の executable_* 6 本のうち
+# 5 本は 100644。scripts/ 側では EXE001 を効かせたいので、per-file で外す。
+[lint.per-file-ignores]
+"chezmoi/**" = ["EXE001"]
 
 [format]
 # 既定（black 互換）。設定を持たないこと自体が意図 —— 形式の議論を機械に預ける。

--- a/scripts/claude-md-eval/judge.py
+++ b/scripts/claude-md-eval/judge.py
@@ -21,12 +21,12 @@ import argparse
 import hashlib
 import json
 import re
-from typing import Any
 import subprocess
 import sys
 from collections import Counter, defaultdict
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
+from typing import Any
 
 # Phrases a section may forbid by name. Extend when the section names others.
 NAMED = [
@@ -62,7 +62,11 @@ UNNAMED = [
     r"^はい[、,。]",
 ]
 
-JUDGE_PROMPT = """あなたは応答品質の審査員です。同じ質問への2つの応答 A / B を評価します。
+# 行継続の `\` はここだけの都合（E501 を避けるための版付け）で、文字列の中身は
+# 1 文字も変わらない。判定プロンプトは測定結果の一部なので、折返しのために
+# 本文を書き換えないこと。
+JUDGE_PROMPT = """\
+あなたは応答品質の審査員です。同じ質問への2つの応答 A / B を評価します。
 
 読み手の前提: 日本語で作業する上級エンジニア。長い前置き・締めの定型句を嫌い、
 スクロールせず読める長さを好む。ただし**正確さと安全性を犠牲にした簡潔さは価値がない**。
@@ -202,7 +206,8 @@ def gate(verdicts: list[dict[str, Any]]) -> tuple[bool, list[str]]:
         reasons.append(f"candidate did not beat baseline ({cand_wins} vs {base_wins})")
     if scored and cand_cut / len(scored) > 0.25:
         reasons.append(
-            f"candidate won by cutting needed content in {cand_cut}/{len(scored)} pairs (>25%)"
+            f"candidate won by cutting needed content in "
+            f"{cand_cut}/{len(scored)} pairs (>25%)"
         )
     return not reasons, reasons
 

--- a/scripts/claude-md-eval/run.py
+++ b/scripts/claude-md-eval/run.py
@@ -25,10 +25,10 @@ import hashlib
 import json
 import subprocess
 import sys
-from typing import Any
 from collections.abc import Mapping
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
+from typing import Any
 
 PREAMBLE = "以下はユーザーの global CLAUDE.md からの抜粋である。これに従うこと。\n\n"
 

--- a/scripts/gen-chord-doc.py
+++ b/scripts/gen-chord-doc.py
@@ -29,7 +29,12 @@ ROOT = Path(__file__).resolve().parents[1]
 CONFIG = ROOT / "chezmoi" / "dot_config" / "chord" / "private_config.toml"
 DOC = ROOT / "docs" / "chord.md"
 
-BEGIN = "<!-- AUTO-GENERATED (scripts/gen-chord-doc.py from chezmoi/dot_config/chord/private_config.toml) — do not edit -->"
+# 折返しは実装都合。この文字列は docs/chord.md のマーカーと 1 文字も違ってはならない
+# （違うと pattern.search が外れて SystemExit する）。
+BEGIN = (
+    "<!-- AUTO-GENERATED (scripts/gen-chord-doc.py from "
+    "chezmoi/dot_config/chord/private_config.toml) — do not edit -->"
+)
 END = "<!-- END AUTO-GENERATED -->"
 
 DOC_RE = re.compile(r"^#\s*doc:\s*(.+?)\s*$")
@@ -123,10 +128,9 @@ def build_block() -> str:
         if m:
             current_apps = parse_apps(m.group(1))
             continue
-        if line == "":
-            if in_binding and current_input is not None:
-                flush()
-                in_binding = False
+        if line == "" and in_binding and current_input is not None:
+            flush()
+            in_binding = False
     # flush trailing binding
     if in_binding:
         flush()

--- a/scripts/lint
+++ b/scripts/lint
@@ -8,8 +8,8 @@ drift する」形が構造的に作れない。ツールは flake.lock 固定�
     nix develop .#lint --command scripts/lint --ci
     nix develop .#lint --command scripts/lint shell python   # 一部だけ
 
-素で叩くと開発機の brew 版が混ざる（PATH は /opt/homebrew/bin が nix profile より前）ので、
-必ず `nix develop .#lint --command` を通すこと。
+素で叩くと開発機の brew 版が混ざる（PATH は /opt/homebrew/bin が nix profile
+より前）ので、必ず `nix develop .#lint --command` を通すこと。
 
 **ツール不在は skip でなく failure。** command -v で黙って skip して緑を出すのが
 いちばん危ない失敗の仕方なので、宣言したゲートが 1 つでも走らなければ非ゼロで終わる。
@@ -219,6 +219,11 @@ class Runner:
 
         chezmoi/ 側は CI の convention-executable-prefix job が prefix で見ているが、
         scripts/ は誰も見ていなかった。
+
+        ruff の EXE001 が入って .py と（明示指定している）このランナー自身は二重に
+        守られている。それでも残すのは、`claude-work-report-check-test.sh` のような
+        shell スクリプトを ruff は一切見ないから —— 重複を理由に外すと shell だけ
+        無防備になる。
         """
         gate = "exec-bit"
         if not self.begin(gate):
@@ -299,13 +304,16 @@ def main(argv: list[str] | None = None) -> int:
 
     # --- docs ---
     r.run("typos", ["typos", *(["--format", "brief"] if args.ci else [])])
-    # --offline 固定。外部 URL は他人都合の 5xx が入るので PR を止めさせない（nightly は別 task）。
+    # --offline 固定。外部 URL は他人都合の 5xx が入るので PR を止めさせない
+    # （nightly は別 task）。
     r.run("lychee", ["lychee", "--offline", "--no-progress", "."])
 
     # --- secret ---
-    # `dir` でなく `git`: dir は .gitignore を尊重しないので result symlink や scratch まで舐める。
+    # `dir` でなく `git`: dir は .gitignore を尊重しないので result symlink や
+    # scratch まで舐める。
     # --redact 必須（外すと secret が stdout に平文で出る）。
-    # --exit-code 9 必須（既定だと「検出」と「ツールエラー」がどちらも 1 で区別できない）。
+    # --exit-code 9 必須（既定だと「検出」と「ツールエラー」がどちらも 1 で
+    # 区別できない）。
     r.run("gitleaks", ["gitleaks", "git", "--redact", "--exit-code", "9", "."])
 
     # 宣言したゲートが全部走ったか。走らなかったものがあれば緑を出さない。


### PR DESCRIPTION
#279 shipped ruff on the **default** rule set (E4/E7/E9 + F) to keep the introducing PR unambiguously green. Measuring one group at a time now that the runner is stable:

| group | findings | | group | findings |
|---|---|---|---|---|
| `E` | 10 | | `B` | 0 |
| `I` | 2 | | `C4` | 0 |
| `SIM` | 1 | | `RET` | 0 |
| `EXE` | 1 | | `PIE` | 0 |
| `W` `F` `UP` | 0 | | **total** | **14** |

All 14 are fixed here, so **the baseline is zero**. Anything this select reports from now on is a new violation, not inherited debt.

## The four risky fixes

Four rewraps touch string literals whose *value* is load-bearing:

- two on-device model prompts in `azookey-bridge` (`FORMAT_RULE`, `LAST_STOCK_EXAMPLE`)
- `JUDGE_PROMPT` — part of every claude-md-eval measurement result
- `gen-chord-doc`'s `BEGIN` marker — must match `docs/chord.md` byte for byte or the generator raises `SystemExit`

Each was rewrapped **by layout only** (implicit concatenation, or a `"""\` continuation). Verified:

```
OK   FORMAT_RULE:        adaf719827282b50 -> adaf719827282b50
OK   LAST_STOCK_EXAMPLE: 5812810275cc2c91 -> 5812810275cc2c91
OK   JUDGE_PROMPT:       7cc894d42ac10d49 -> 7cc894d42ac10d49
OK   BEGIN:              4c82174c4ff51aca -> 4c82174c4ff51aca
```

`gen-chord-doc`'s `build_block()` still returns the same 1152 bytes and `--check` still reports 同期済み. The `SIM102` collapse in the same file was verified the same way.

## Rejected groups are prose, not dead `ignore` entries

`--select ALL` is 231 findings. The four families that make it unusable (`RUF001/2/3` = full-width Japanese punctuation, `PT009` = migrate to pytest which collides with the stdlib-only/unittest decision, `T201` = print, `D1xx`/`ANN`) are documented in `ruff.toml` **as comments**. Writing `ignore` for a rule that was never selected is dead config that reads like a live decision.

## EXE001 scope

Off under `chezmoi/` only: what supplies +x in `$HOME` there is the `executable_` prefix (enforced by `convention-executable-prefix`), and the source file's git mode is unrelated — **5 of the 6 `executable_*` files under chezmoi/ are 100644**. Under `scripts/` the rule stays on, and it does cover both `.py` files and the extensionless runner (verified by `chmod -x` on both).

The hand-rolled `exec-bit` gate stays: ruff never sees `claude-work-report-check-test.sh`, so dropping it for redundancy would leave shell scripts unguarded.

## Unrelated bug found while doing this

**chezmoi was deploying `__pycache__` to `$HOME`.** chezmoi does not read `.gitignore`, so running python against anything under `chezmoi/` — importing the bridge module to hash its constants was enough — leaves a directory that `chezmoi apply` then installs. Added to `.chezmoiignore`; verified by regenerating the cache and re-diffing (0 lines).

## Verification (measured)

- `scripts/lint` → 12 gates passed
- `scripts/` unittest 14 OK, `claude-md-eval` 32 OK, `claude-work-report-check-test.sh` 9 OK
- mutation probe with unsorted/unused imports + nested `if` + missing +x → 6 findings across E401/I001/F401/SIM102/EXE001
- `chezmoi apply` run: live == source (the bridge had been carrying #279's mypy annotations in source only), LaunchAgent back to `state = running`, `chezmoi diff` clean

SetStatus-task: https://github.com/akira-toriyama/projects/blob/main/.furrow/bodies/t-p94g.md done