### PR TITLE
:sparkles:(ci) check external URLs nightly without letting them block a PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,31 @@ jobs:
       - name: scripts/lint --ci
         run: nix develop .#lint --command scripts/lint --ci
 
+  # 外部 URL のリンク検査。**PR / push では走らせない**（nightly + 手動のみ）。
+  # 他人都合の 5xx や rate limit で PR が止まるのを避けるため、判定を分けている:
+  #   PR/push : scripts/lint の `lychee` ゲート = --offline（相対パス + アンカー・0 network）
+  #   ここ    : `external` グループ = --offline を外すだけ。対象も規則も lychee.toml 一本
+  # ci-gate の needs には**入れない**（PR を止めない）。notify-red-main には入れる
+  # （main の赤を見逃さない）。ここが唯一「PR を止めずに赤を検出する」経路。
+  docs-link-check-external:
+    name: docs link check (external URLs)
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # CI-only, never pushes — drop the persisted checkout token. t-yaxa
+          persist-credentials: false
+
+      - name: Install Nix (Determinate)
+        uses: DeterminateSystems/nix-installer-action@33c9ab3ef95cd57c164d9d6eb1f9a46338538d41 # main
+
+      # `external` を名指ししないと走らない（scripts/lint の OPT_IN_GROUPS）。
+      # 素の `scripts/lint` がネットワークを叩かないことは test_lint.py が固定する。
+      - name: scripts/lint external --ci
+        run: nix develop .#lint --command scripts/lint external --ci
+
   # 規約チェック: chezmoi 配下のスクリプトは executable_ 接頭辞を持つこと。
   # 例外: run_* / .chezmoiscripts/ 配下 (chezmoi 自身が実行 = $HOME に展開しない)。
   convention-executable-prefix:
@@ -383,6 +408,9 @@ jobs:
     needs:
       - nix-flake-check
       - lint
+      # ci-gate には**入れない**（PR を止めない）が、ここには入れる。
+      # PR/push では skipped で、skipped は failure ではないので誤発火しない。
+      - docs-link-check-external
       - convention-executable-prefix
       - convention-command-prefix
       - script-test

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -241,7 +241,7 @@ sh <(curl -fsSL https://raw.githubusercontent.com/akira-toriyama/dotfiles/main/i
 
 [.github/workflows/ci.yml](../.github/workflows/ci.yml) ＋ chord 専用 verify-* ワークフロー:
 
-`ci.yml` の job は 11 本。**表に無い job があれば ci.yml が正**（この表は説明用の写し）。
+`ci.yml` の job は 12 本。**表に無い job があれば ci.yml が正**（この表は説明用の写し）。
 
 | ジョブ | 内容 | runner |
 |---|---|---|
@@ -251,6 +251,7 @@ sh <(curl -fsSL https://raw.githubusercontent.com/akira-toriyama/dotfiles/main/i
 | `convention / my- command prefix` | 自作 slash command に `my-` 接頭辞を強制 | ubuntu-latest |
 | `script test` | Stop hook の fixture + `scripts/**` と `scripts/claude-md-eval/` の unittest | ubuntu-latest |
 | `chezmoi templates render` | 全 `.tmpl` の execute-template 検証（get.chezmoi.io の最新版で） | ubuntu-latest |
+| `docs link check (external URLs)` | 外部 URL 込みの lychee。**nightly / 手動のみ**・`ci-gate` の needs 外 | ubuntu-latest |
 | `detect flake-affecting changes` | PR が flake/nix/ci.yml を触ったかを判定し、下 2 本の実行可否を出す | ubuntu-latest |
 | `darwin-rebuild build (macOS)` | 実 build（cask DL 含む・非破壊） | macos-latest |
 | `darwin-rebuild switch smoke (macOS)` | 実 switch＋PATH/cask 検証＋`chezmoi apply`（ephemeral runner なので副作用 OK） | macos-latest |
@@ -269,7 +270,13 @@ chord 専用の別ワークフロー:
 ```sh
 nix develop .#lint --command scripts/lint            # CI と同一コマンド・同一バイナリ
 nix develop .#lint --command scripts/lint python     # 一部だけ（docs / python / secret / shell / tmpl / workflow）
+nix develop .#lint --command scripts/lint external   # 外部 URL のリンク検査（既定では走らない）
 ```
+
+**`external` は opt-in**。ネットワークを叩くゲートは他人のサーバの 5xx / rate limit で
+落ちるので、PR の合否に混ぜない（`ci-gate` の needs に入っていない）。回すのは nightly と
+`workflow_dispatch` の `docs link check (external URLs)` job で、赤は `notify-red-main` が
+issue に集約する。素の `scripts/lint` がネットワークを叩かないことは `test_lint.py` が固定。
 
 **素で `scripts/lint` を叩かないこと** —— PATH は `/opt/homebrew/bin` が nix profile より
 前なので、brew 版の shfmt / typos / lychee / gitleaks が混ざって CI と結果がずれる。

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,9 +1,15 @@
 # lychee.toml — Markdown のリンク切れ + 見出しアンカー検査（repo 所有）。
 # cwd から自動ロードされる（--config 不要）。
 #
-# 実行モードは CLI 側で決める:
-#   PR / push : lychee --offline --no-progress .   相対パス + アンカーのみ（0 network）
-#   nightly   : lychee --no-progress .             外部 URL 込み（未配線・task 送り）
+# 実行モードは scripts/lint のグループで決める（CLI 直叩きではない）:
+#   PR / push : `lychee` ゲート       = --offline    相対パス + アンカーのみ（0 network）
+#   nightly   : `lychee-external`     = --offline 無し 外部 URL 込み
+#               = OPT_IN_GROUPS の "external"。名指ししないと走らない。
+#
+# 【罠】RFC 2606 の予約 TLD（.invalid / .test / .example）と example.com は lychee が
+# 既定で Excluded にする。ゲートの動作確認に .invalid を使うと「1 件 Excluded が
+# 増えて緑」になり、**ゲートが壊れていても気づけない**（実測 2026-07-27）。
+# 検証には実在ホストの 404 を使うこと。
 
 # 見出しアンカー (#section) を検査する。日本語見出しも解決できることを実測済み
 # （全角括弧・「」・/ は落ち、空白は - になる。GitHub の slug と一致するのは

--- a/scripts/lint
+++ b/scripts/lint
@@ -42,10 +42,17 @@ GATES: dict[str, str] = {
     "actionlint": "workflow",
     "typos": "docs",
     "lychee": "docs",
+    "lychee-external": "external",
     "gitleaks": "secret",
 }
 
 GROUPS = sorted(set(GATES.values()))
+
+# 名指ししない限り走らないグループ。ここに入るのは **ネットワークを叩くもの**で、
+# 判定が他人のサーバの機嫌に依存する（5xx / rate limit）＝ PR を止める資格がない。
+# 既定に混ぜないことが要点なので、test_lint.py がこの性質を固定する。
+OPT_IN_GROUPS = frozenset({"external"})
+DEFAULT_GROUPS = sorted(set(GROUPS) - OPT_IN_GROUPS)
 
 
 def tracked(*patterns: str) -> list[str]:
@@ -252,7 +259,10 @@ def main(argv: list[str] | None = None) -> int:
         nargs="*",
         choices=GROUPS,
         default=None,
-        help="走らせるグループ（既定: 全部）",
+        help=(
+            f"走らせるグループ（既定: {' '.join(DEFAULT_GROUPS)}）。"
+            f"{' '.join(sorted(OPT_IN_GROUPS))} は名指しした時だけ走る"
+        ),
     )
     ap.add_argument(
         "--ci",
@@ -260,7 +270,7 @@ def main(argv: list[str] | None = None) -> int:
         help="GitHub annotation 形式で出す（検査内容は変えない）",
     )
     args = ap.parse_args(argv)
-    groups = args.groups or GROUPS
+    groups = args.groups or DEFAULT_GROUPS
 
     r = Runner(ci=args.ci, groups=groups)
     # このランナー自身は拡張子が無いので ruff/mypy の自動探索に載らない。
@@ -305,8 +315,13 @@ def main(argv: list[str] | None = None) -> int:
     # --- docs ---
     r.run("typos", ["typos", *(["--format", "brief"] if args.ci else [])])
     # --offline 固定。外部 URL は他人都合の 5xx が入るので PR を止めさせない
-    # （nightly は別 task）。
+    # （外部込みは下の lychee-external ＝ opt-in グループ）。
     r.run("lychee", ["lychee", "--offline", "--no-progress", "."])
+
+    # --- external（既定では走らない）---
+    # --offline を外すだけ。対象も規則（accept の 429・projects の exclude・
+    # fragment 設定）も lychee.toml 一本のままなので、offline 版と drift しない。
+    r.run("lychee-external", ["lychee", "--no-progress", "."])
 
     # --- secret ---
     # `dir` でなく `git`: dir は .gitignore を尊重しないので result symlink や

--- a/scripts/test_lint.py
+++ b/scripts/test_lint.py
@@ -49,6 +49,40 @@ class TestGateDeclaration(unittest.TestCase):
         self.assertEqual(lint.GATES["gitleaks"], "secret")
 
 
+class TestOptInGroups(unittest.TestCase):
+    """ネットワークを叩くゲートが既定に混ざらないこと。
+
+    混ざると PR の合否が他人のサーバの機嫌（5xx / rate limit）で決まる。
+    「入れてはいけない」を散文で書いても守られないので、ここで固定する。
+    """
+
+    def test_opt_in_groups_are_real_groups(self) -> None:
+        self.assertTrue(set(lint.GROUPS) >= lint.OPT_IN_GROUPS)
+
+    def test_the_default_run_excludes_them(self) -> None:
+        self.assertEqual(
+            set(lint.DEFAULT_GROUPS), set(lint.GROUPS) - lint.OPT_IN_GROUPS
+        )
+        self.assertFalse(set(lint.DEFAULT_GROUPS) & lint.OPT_IN_GROUPS)
+
+    def test_the_external_link_check_is_opt_in(self) -> None:
+        self.assertEqual(lint.GATES["lychee-external"], "external")
+        self.assertIn("external", lint.OPT_IN_GROUPS)
+
+    def test_a_default_runner_does_not_want_the_external_gate(self) -> None:
+        r = lint.Runner(ci=False, groups=lint.DEFAULT_GROUPS)
+        self.assertFalse(r.wants("lychee-external"))
+        self.assertTrue(r.wants("lychee"))
+
+    def test_naming_the_group_turns_it_on(self) -> None:
+        r = lint.Runner(ci=False, groups=["external"])
+        self.assertTrue(r.wants("lychee-external"))
+
+    def test_the_offline_gate_is_not_opt_in(self) -> None:
+        # 相対パス + アンカーの検査は 0 network なので PR で走り続けること。
+        self.assertNotIn(lint.GATES["lychee"], lint.OPT_IN_GROUPS)
+
+
 class TestMissingGateIsNotGreen(unittest.TestCase):
     """宣言したゲートが走らなかったら緑を出さない、という一番大事な性質。"""
 


### PR DESCRIPTION
#279 wired lychee as `--offline` only — relative paths and heading anchors, zero network. External URLs were left out because a stranger's 5xx would fail an unrelated PR. But leaving them out means **nothing ever notices when a documentation link dies**.

## Split by opt-in group, not by CLI flag

The judgment stays in `scripts/lint`:

| gate | group | invocation | when |
|---|---|---|---|
| `lychee` | `docs` | `--offline` | every PR / push |
| `lychee-external` | `external` | no `--offline` | only when named |

`OPT_IN_GROUPS` holds the groups a bare `scripts/lint` must **never** run, and the rule is what they have in common: they touch the network, so their verdict depends on someone else's server.

`test_lint.py` pins that the default set excludes them, that naming the group turns it on, and that the offline gate isn't swept up by mistake.

Both gates read the same `lychee.toml`, so the accept list, the private-`projects` exclusion and the fragment settings cannot drift between modes.

## The job is deliberately asymmetric

- **absent** from `ci-gate`'s `needs` → a PR is never blocked
- **present** in `notify-red-main`'s → a red nightly still lands in the tracking issue

On PR/push it resolves to `skipped`, and skipped is not failure, so `notify-red-main` does not misfire. Wiring asserted programmatically:

```
ci-gate needs docs-link-check-external?  False   <- must be False
notify-red-main needs it?                True    <- must be True
```

## Trap found while verifying (this is the interesting part)

**lychee excludes the RFC 2606 reserved TLDs by default.** Probing the gate with a `.invalid` host merely bumps the `Excluded` count and reports green:

```
🔍 123 Total  ✅ 117 OK  🚫 0 Errors  👻 6 Excluded     ← .invalid probe: silently ignored
✓ 1 gates passed (external)
```

The gate would have looked alive while being dead. Recorded in `lychee.toml` so the next person doesn't verify it the same wrong way.

Re-verified with a real 404:

```
[404] https://github.com/akira-toriyama/dotfiles/blob/main/THIS-PATH-DOES-NOT-EXIST-xyz123.md | Rejected status code: 404 Not Found
✘ 1 gate(s) failed: lychee-external (exit 2)
```

…while `scripts/lint docs` stayed green on the same tree, as it must.

## Verification (measured)

- real external run on the current tree: **117 OK / 0 errors / 5 excluded / 3 redirects**
- default `scripts/lint` → 12 gates, `external` not among them
- `scripts/lint external` → 1 gate
- `test_lint.py` 14 → **20** tests, green

Docs: `operations.md` §5.6 CI table (now 12 jobs) + §5.6.1 opt-in note.

SetStatus-task: https://github.com/akira-toriyama/projects/blob/main/.furrow/bodies/t-tgx8.md done