### PR TITLE
:sparkles:(lint) check paths mentioned inside code spans, which lychee cannot see

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
   # 旧 shellcheck job（ludeeus action）を置換。あれは実質 5 ファイルしか見ておらず、
   # Claude Stop hook 本体・pre-push・chezmoi/run_* が全部 lint 圏外だった。
   lint:
-    name: lint (ruff / mypy / shfmt / shellcheck / tmpl / actionlint / typos / lychee / gitleaks)
+    name: lint (ruff / mypy / shfmt / shellcheck / tmpl / actionlint / typos / lychee / doc-paths / gitleaks)
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -179,13 +179,22 @@ jobs:
           persist-credentials: false
       - name: Run claude-work-report-check tests
         run: bash scripts/claude-work-report-check-test.sh
-      - uses: actions/setup-python@v6
-        with:
-          python-version: '3.13'
+
+      # setup-python ではなく lint devShell から Python を取る。理由は 2 つ:
+      #   ① test_doc_paths.py は chezmoi を呼ぶ（管理下の $HOME パス一覧を得るため）。
+      #      ツールが無いと ImportError でなく実行時エラーで落ちる ＝ 黙って skip
+      #      しない設計なので、供給側を用意するのが正しい対処。
+      #   ② Python の版が flake.lock 固定の 3.13 に揃い、setup-python の別系統の
+      #      版指定と drift しない。
+      - name: Install Nix (Determinate)
+        uses: DeterminateSystems/nix-installer-action@33c9ab3ef95cd57c164d9d6eb1f9a46338538d41 # main
+
       - name: Run python unit tests
         run: |
-          python3 -m unittest discover -s scripts -p 'test_*.py' -v
-          python3 -m unittest discover -s scripts/claude-md-eval -p 'test_*.py' -v
+          nix develop .#lint --command \
+            python3 -m unittest discover -s scripts -p 'test_*.py' -v
+          nix develop .#lint --command \
+            python3 -m unittest discover -s scripts/claude-md-eval -p 'test_*.py' -v
 
   # chezmoi テンプレートのレンダリング検証（構文エラー早期検出）
   chezmoi-templates:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,7 @@ flowchart TD
 - **コミットメッセージは gitmoji-driven**（`<:gitmoji:>[(<scope>)][!] <subject>`。Conventional の `<type>` 語は退役済み）。規約の正本は [docs/commit-convention.md](docs/commit-convention.md) と `glyph rules`。**push 前に `glyph lint --range origin/main..HEAD`**（履歴には退役形式の commit が残っているので `git log` を手本にしない）。
 - **CI ジョブ（[.github/workflows/ci.yml](.github/workflows/ci.yml)、push と PR でトリガー）**:
   - `nix flake check --no-build` — Nix の型/eval 検査（Linux runner）
-  - `lint` — `scripts/lint` 一本（ruff / mypy --strict / shfmt / shellcheck / actionlint / typos / lychee --offline / gitleaks / `.tmpl` は render 後に shellcheck・plist 構文）。**ローカルでも同じコマンドが走る**: `nix develop .#lint --command scripts/lint`
+  - `lint` — `scripts/lint` 一本（ruff / mypy --strict / shfmt / shellcheck / actionlint / typos / lychee --offline / gitleaks / `.tmpl` は render 後に shellcheck・plist 構文 / コードスパン内のパス実在）。**ローカルでも同じコマンドが走る**: `nix develop .#lint --command scripts/lint`
   - `script test` — Stop hook の fixture テスト + `scripts/` と `scripts/claude-md-eval/` の unittest
   - 規約検知 — `chezmoi/` 配下 shebang スクリプトの `executable_` 接頭辞 + 自作 command（`~/.claude/commands/`）の `my-` 接頭辞を強制
   - `chezmoi templates render` — 全 `.tmpl` の `execute-template` 検証

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -9,7 +9,7 @@
 <summary><b>1. <code>~/.config/&lt;app&gt;/...</code> を編集した場合（chezmoi）</b></summary>
 
 ### シナリオ
-`~/.config/chord/config.toml` や `~/.config/eventfx/config` を直接編集した、または上流（chord / wand 等）の最新挙動に合わせて手で変えた状態を、dotfiles リポへ流す。
+`~/.config/chord/config.toml` や `~/.config/wand/config.toml` を直接編集した、または上流（chord / wand 等）の最新挙動に合わせて手で変えた状態を、dotfiles リポへ流す。
 
 dot_config 配下の管理ファイルは **全て plain（`.tmpl` なし）** に統一済み。チェック内容に template 変数が登場しないので、`chezmoi re-add` で安全に取り込める。
 
@@ -24,7 +24,7 @@ chezmoi diff        # 何が違うか
 
 # ③ live を source に取り込む（実体 ──▶ source）
 chezmoi re-add ~/.config/chord/config.toml
-# 例: ~/.config/eventfx/config も同様
+# 例: ~/.config/wand/config.toml・~/.config/facet/config.toml・~/.config/halo/config.toml も同様
 #   ※ 実体を編集したら必ず re-add が先。先に apply すると古い source で
 #     実体を上書きして編集が消える。
 
@@ -246,7 +246,7 @@ sh <(curl -fsSL https://raw.githubusercontent.com/akira-toriyama/dotfiles/main/i
 | ジョブ | 内容 | runner |
 |---|---|---|
 | `nix flake check (eval only)` | Nix の eval/型検査 | ubuntu-latest |
-| `lint` | `scripts/lint --ci`（ruff / ruff-format / mypy / shellcheck / shfmt / exec-bit / tmpl-shellcheck / tmpl-plist / actionlint / typos / lychee / gitleaks の 12 ゲート） | ubuntu-latest |
+| `lint` | `scripts/lint --ci`（ruff / ruff-format / mypy / shellcheck / shfmt / exec-bit / tmpl-shellcheck / tmpl-plist / actionlint / typos / lychee / doc-paths / gitleaks の 13 ゲート） | ubuntu-latest |
 | `convention / executable_ prefix` | `chezmoi/` の shebang スクリプトに `executable_` 接頭辞を強制 | ubuntu-latest |
 | `convention / my- command prefix` | 自作 slash command に `my-` 接頭辞を強制 | ubuntu-latest |
 | `script test` | Stop hook の fixture + `scripts/**` と `scripts/claude-md-eval/` の unittest | ubuntu-latest |

--- a/scripts/doc_paths.py
+++ b/scripts/doc_paths.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Markdown のコードスパン内で言及されたパスが実在するかを検査する。
+
+lychee はリンク要素しか見ない。今日見つかった切れた参照 5 件のうち 3 件は
+`` `~/claude-cli-tools-memo.md` `` のように**導入時からバッククォートの中**にあり、
+markdown リンクだった時期が一度も無かった —— つまり lychee には構造的に見えない。
+そこを埋めるのがこのゲート。
+
+## 前提（この検査が成り立つ理由）
+
+**コードスパンに入れたパスは「実在する」という主張である。** 実在しないパスを
+書きたい時は、コードスパンに入れないか、`ALLOW` に理由付きで載せる。
+
+## 2 つのスコープ（混ぜると誤検知になる）
+
+- **この repo の文書**（`docs/` / ルートの `*.md` / `scripts/**`）
+  → repo 相対パスを検査する。
+- **`chezmoi/private_dot_claude/` 配下**（global CLAUDE.md と skills）
+  → repo 相対は**検査しない**。あそこはフリート全体の文書で、`scripts/check.sh` や
+  `.github/docs/…` は**別の repo**を指す（実測: 素朴に検査すると 3 件すべてが
+  この理由の誤検知だった）。`~/` の検査だけ効かせる。
+
+`~/` は全スコープ共通で、**chezmoi 管理下にあるか `ALLOW` にあること**を要求する。
+「実体があるか」で判定しないのは、CI の runner に $HOME が無いから —— 手元だけ緑に
+なる検査は、この repo で実害が出た失敗の形。
+
+    nix develop .#lint --command scripts/lint docs
+    python3 scripts/doc_paths.py            # 単体でも動く
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+# (file, line, span, なぜ駄目か)
+Problem = tuple[str, int, str, str]
+
+# この repo の top-level ディレクトリ。コードスパンの第 1 セグメントがここに
+# 一致した時だけ「repo 相対パスの主張」とみなす。
+#
+# これが `os/exec`・`store/fsstore`・`webpro/awesome-dotfiles`・`barutsrb/tap` の
+# ような他人のパスと区別する唯一の手がかり。scripts/test_doc_paths.py が実体の
+# top-level と突き合わせるので、ディレクトリを増やしたら気づける。
+ROOT_DIRS = (".githooks", ".github", "chezmoi", "docs", "home", "scripts", "system")
+
+# repo 相対の検査を掛けないディレクトリ。ここはフリート横断の文書。
+FLEET_DOCS = ("chezmoi/private_dot_claude/",)
+
+# フリート文書が **この repo のファイルを名指ししている**箇所。裸のファイル名なので
+# 第 1 セグメント方式では拾えず、かといって放置すると global CLAUDE.md 側だけが
+# 古い名前を指したまま残る（台帳が「リネーム時は同一 PR で追従」と書いているのに
+# 強制機構が無かった分）。
+#
+# キー = 文書に現れる表記、値 = この repo での実際の位置。**リネームすると値が
+# 消えてここが落ちる** —— それがこの表の存在理由なので、落ちたら表と文書の両方を
+# 直すこと（表だけ直すと文書が古いままになる）。
+FLEET_CLAIMS: dict[str, str] = {
+    "packages.nix": "home/modules/packages.nix",
+    "modify_settings.json": "chezmoi/private_dot_claude/modify_settings.json",
+    "dotfiles/scripts/claude-md-eval": "scripts/claude-md-eval",
+}
+
+# 実在を主張しないコードスパンの目印。1 つでも含めば検査対象から外す。
+# glob / プレースホルダ / コマンド行 / URL / シェル展開。
+NOT_A_PATH = re.compile(r"[\s*?\[\]{}<>|=$`]|\.\.\.|…|://")
+
+CODE_SPAN = re.compile(r"`{1,2}([^`\n]+?)`{1,2}")
+
+# chezmoi 管理外だが実在する `~/` パス。**誰が作るか**を必ず書くこと ——
+# それが書けないパスは、たぶん切れた参照。
+ALLOW: dict[str, str] = {
+    "~/.zshrc": "home-manager の programs.zsh が生成",
+    "~/.zprofile": "home-manager の programs.zsh が生成",
+    "~/.claude.json": "Claude Code 自身が実行時に書く（使用量・セッション状態）",
+    "~/.config/furrow/config.toml": "home-manager が生成（global 既定ボード）",
+    "~/Library/Fonts": "OS のディレクトリ。cask 版フォントの配置先",
+    "~/Library/Application Support": "OS のディレクトリ",
+    "~/Library/Logs/azookey-bridge.log": "azookey-bridge が実行時に書く",
+    "~/.dotfiles-install/latest": "install.sh が実行時に作る symlink",
+    "~/.claude/commands": (
+        "未作成。作る前提で convention-command-prefix job が待っている"
+        "（作らないなら job ごと撤去 — t-pd5r のユーザー判断）"
+    ),
+    "~/claude-cli-tools-memo.md": (
+        "現存しない。本文で「このファイルは現存しない」と明示した上での歴史的参照"
+    ),
+}
+
+
+def tracked_markdown() -> list[str]:
+    out = subprocess.run(
+        ["git", "ls-files", "-z", "*.md"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    return sorted(p for p in out.split("\0") if p)
+
+
+def managed_home_paths() -> set[str]:
+    """chezmoi が $HOME へ置くパスを `~/...` 表記で返す。
+
+    属性 prefix（`dot_` / `private_` / `executable_` …）の解釈を自前で書くと
+    chezmoi の実装と drift するので、chezmoi 自身に訊く。
+    """
+    proc = subprocess.run(
+        ["chezmoi", "--source", "./chezmoi", "managed", "--path-style", "absolute"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(f"chezmoi managed failed: {proc.stderr.strip()}")
+    home = str(Path.home())
+    return {
+        line.replace(home, "~", 1) if line.startswith(home) else line
+        for line in proc.stdout.split("\n")
+        if line.strip()
+    }
+
+
+def spans(text: str) -> list[str]:
+    """コードスパンのうち、実在を主張していそうなものだけ。"""
+    found = []
+    for m in CODE_SPAN.finditer(text):
+        s = m.group(1).strip().rstrip("/")
+        if s and not NOT_A_PATH.search(s):
+            found.append(s)
+    return found
+
+
+def problems_in(rel: str, text: str, managed: set[str]) -> list[Problem]:
+    """1 ファイル分の判定。行ごとに走査するので行番号が実際の位置になる。
+
+    コードスパンは改行をまたげない（CODE_SPAN が \n を除外している）ので、
+    行単位で見ても全文で見ても拾う集合は同じ。同じパスが複数行に出た時に
+    最初の行を 3 回報告する、という形を避けるためにこちらを採る。
+    """
+    fleet = rel.startswith(FLEET_DOCS)
+    out: list[Problem] = []
+    for lineno, line in enumerate(text.split("\n"), 1):
+        for s in spans(line):
+            if s.startswith("~/"):
+                if s not in managed and s not in ALLOW:
+                    out.append(
+                        (rel, lineno, s, "chezmoi 管理下でも ALLOW でもない $HOME パス")
+                    )
+            elif fleet:
+                target = FLEET_CLAIMS.get(s)
+                if target and not (ROOT / target).exists():
+                    out.append(
+                        (
+                            rel,
+                            lineno,
+                            s,
+                            f"この repo の {target} を指しているが実在しない"
+                            "（リネームしたら文書と FLEET_CLAIMS の両方を直す）",
+                        )
+                    )
+            elif s.split("/")[0] in ROOT_DIRS and not (ROOT / s).exists():
+                out.append((rel, lineno, s, "repo にこのパスが無い"))
+    return out
+
+
+def check(managed: set[str] | None = None) -> list[Problem]:
+    """(file, line, span, なぜ駄目か) を返す。空なら合格。"""
+    if managed is None:
+        managed = managed_home_paths()
+    problems: list[Problem] = []
+    for rel in tracked_markdown():
+        problems += problems_in(rel, (ROOT / rel).read_text(encoding="utf-8"), managed)
+    return problems
+
+
+def main(argv: list[str] | None = None) -> int:
+    ci = "--ci" in (argv if argv is not None else sys.argv[1:])
+    problems = check()
+    for rel, line, span, why in problems:
+        msg = f"{why}: `{span}`"
+        where = f"file={rel},line={line}"
+        print(f"::error {where}::{msg}" if ci else f"  {rel}:{line}: {msg}")
+    print(f"  checked {len(tracked_markdown())} markdown file(s)")
+    return 1 if problems else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/lint
+++ b/scripts/lint
@@ -42,6 +42,7 @@ GATES: dict[str, str] = {
     "actionlint": "workflow",
     "typos": "docs",
     "lychee": "docs",
+    "doc-paths": "docs",
     "lychee-external": "external",
     "gitleaks": "secret",
 }
@@ -317,6 +318,16 @@ def main(argv: list[str] | None = None) -> int:
     # --offline 固定。外部 URL は他人都合の 5xx が入るので PR を止めさせない
     # （外部込みは下の lychee-external ＝ opt-in グループ）。
     r.run("lychee", ["lychee", "--offline", "--no-progress", "."])
+    # lychee はリンク要素しか見ない。バッククォート内のパス言及は構造的に見えず、
+    # 実際そこで 3 件の切れた参照が長期間生き延びた。その穴を埋める自前ゲート。
+    r.run(
+        "doc-paths",
+        [
+            sys.executable,
+            str(ROOT / "scripts" / "doc_paths.py"),
+            *(["--ci"] if args.ci else []),
+        ],
+    )
 
     # --- external（既定では走らない）---
     # --offline を外すだけ。対象も規則（accept の 429・projects の exclude・

--- a/scripts/test_doc_paths.py
+++ b/scripts/test_doc_paths.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""scripts/doc_paths.py の回帰テスト。
+
+守りたいのは 2 つ。
+1. **誤検知を出さないこと** —— 誤検知が続くゲートは無視されるようになり、
+   本物の切れた参照も一緒に無視される。ここで潰した誤検知の型を固定する。
+2. **見逃さないこと** —— 実在しない repo 相対パスと、素性の分からない `~/` パスは
+   必ず捕まえる。
+"""
+
+from __future__ import annotations
+
+import subprocess
+import unittest
+from pathlib import Path
+
+import doc_paths
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+class TestRootDirs(unittest.TestCase):
+    def test_matches_the_real_top_level_of_the_repo(self) -> None:
+        """top-level を増やしたらここが落ちる（＝ ROOT_DIRS の更新を強制する）。
+
+        更新を忘れると、その新ディレクトリ配下のパス言及だけ黙って無検査になる。
+        """
+        out = subprocess.run(
+            ["git", "ls-files"], cwd=ROOT, capture_output=True, text=True, check=True
+        ).stdout
+        live = {p.split("/")[0] for p in out.split("\n") if "/" in p}
+        self.assertEqual(set(doc_paths.ROOT_DIRS), live)
+
+
+class TestSpanFiltering(unittest.TestCase):
+    """コードスパンのうち「実在を主張しているもの」だけを拾えているか。"""
+
+    def spans(self, text: str) -> list[str]:
+        return doc_paths.spans(f"`{text}`")
+
+    def test_a_plain_path_is_picked_up(self) -> None:
+        self.assertEqual(self.spans("docs/operations.md"), ["docs/operations.md"])
+
+    def test_a_trailing_slash_is_stripped(self) -> None:
+        self.assertEqual(self.spans("docs/"), ["docs"])
+
+    def test_globs_are_not_paths(self) -> None:
+        for s in ("chezmoi/private_*.tmpl", "home/modules/*.nix", "Sources/*"):
+            self.assertEqual(self.spans(s), [], s)
+
+    def test_placeholders_are_not_paths(self) -> None:
+        for s in ("system/hosts/<hostname>.nix", "bodies/<id>.md", "chezmoi/..."):
+            self.assertEqual(self.spans(s), [], s)
+
+    def test_command_lines_are_not_paths(self) -> None:
+        for s in (
+            "glyph lint --range origin/main..HEAD",
+            "nix develop .#lint --command scripts/lint",
+            "go run ./cmd/furrow <args>",
+        ):
+            self.assertEqual(self.spans(s), [], s)
+
+    def test_urls_are_not_paths(self) -> None:
+        # lychee の担当。ここで二重に見ると報告が重複する。
+        self.assertEqual(self.spans("https://github.com/akira-toriyama/dotfiles"), [])
+
+    def test_shell_expansions_are_not_paths(self) -> None:
+        for s in ('$(op read "op://Vault/Item/field")', "GHQ_ROOT=/Volumes/workspace"):
+            self.assertEqual(self.spans(s), [], s)
+
+
+class TestRepoRelativeRule(unittest.TestCase):
+    def test_only_first_segments_in_root_dirs_are_checked(self) -> None:
+        """他人の repo のパスを掴まないこと。
+
+        skills は Go や fleet の話をするので `os/exec` や `store/fsstore` が出る。
+        素朴に「/ を含むもの」を検査すると全部誤検知になる。
+        """
+        for s in ("os/exec", "store/fsstore", "webpro/awesome-dotfiles", "owner/repo"):
+            self.assertEqual(doc_paths.ROOT_DIRS.count(s.split("/")[0]), 0, s)
+
+    def test_a_bare_filename_is_not_checked(self) -> None:
+        """`packages.nix` はルートに無いがサブディレクトリには在る。
+
+        第 1 セグメントが ROOT_DIRS に無いので対象外 —— 曖昧な参照を無理に
+        解決しにいかない、という設計上の割り切り。
+        """
+        self.assertEqual(doc_paths.spans("`packages.nix`"), ["packages.nix"])
+        self.assertNotIn("packages.nix", doc_paths.ROOT_DIRS)
+
+
+class TestHomeRule(unittest.TestCase):
+    def test_a_chezmoi_managed_path_is_accepted_without_an_allow_entry(self) -> None:
+        managed = doc_paths.managed_home_paths()
+        self.assertIn("~/.claude/CLAUDE.md", managed)
+        self.assertNotIn("~/.claude/CLAUDE.md", doc_paths.ALLOW)
+
+    def test_every_allow_entry_carries_a_reason(self) -> None:
+        """理由を書けないパスは、たぶん切れた参照。空文字を通さない。"""
+        for path, reason in doc_paths.ALLOW.items():
+            self.assertTrue(reason.strip(), path)
+            self.assertTrue(path.startswith("~/"), path)
+
+    def test_allow_does_not_duplicate_what_chezmoi_already_manages(self) -> None:
+        """管理下に入ったのに ALLOW に残っていると、外した時に検知できなくなる。"""
+        managed = doc_paths.managed_home_paths()
+        overlap = sorted(set(doc_paths.ALLOW) & managed)
+        self.assertEqual(overlap, [], "chezmoi 管理下に入ったので ALLOW から外すこと")
+
+
+class TestFleetClaims(unittest.TestCase):
+    """global CLAUDE.md / skills が名指しした dotfiles のファイルが実在するか。
+
+    台帳は「リネーム時は同一 PR で追従」と書いていたが強制機構が無く、
+    global CLAUDE.md だけ古い名前を指したまま残る形が空いていた。
+    """
+
+    def fleet_text(self) -> str:
+        out = subprocess.run(
+            ["git", "ls-files", "-z", "chezmoi/private_dot_claude/"],
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout
+        return "\n".join(
+            (ROOT / p).read_text(encoding="utf-8")
+            for p in out.split("\0")
+            if p.endswith(".md")
+        )
+
+    def test_every_claimed_target_exists(self) -> None:
+        for span, target in doc_paths.FLEET_CLAIMS.items():
+            with self.subTest(span=span):
+                self.assertTrue((ROOT / target).exists(), f"{span} -> {target}")
+
+    def test_every_claim_is_actually_mentioned(self) -> None:
+        """使われなくなったキーが残ると、守っているつもりで何も守らなくなる。"""
+        text = self.fleet_text()
+        for span in doc_paths.FLEET_CLAIMS:
+            with self.subTest(span=span):
+                self.assertIn(f"`{span}`", text)
+
+    def test_a_renamed_target_is_caught(self) -> None:
+        saved = dict(doc_paths.FLEET_CLAIMS)
+        try:
+            doc_paths.FLEET_CLAIMS["packages.nix"] = "home/modules/renamed-away.nix"
+            problems = doc_paths.check(managed=set())
+            self.assertTrue(
+                any(s == "packages.nix" for _, _, s, _ in problems),
+                "リネームを検知できていない",
+            )
+        finally:
+            doc_paths.FLEET_CLAIMS.clear()
+            doc_paths.FLEET_CLAIMS.update(saved)
+
+
+class TestTheRepoIsClean(unittest.TestCase):
+    def test_no_dangling_path_mentions(self) -> None:
+        """このゲートが今の repo で緑であること（回帰の入口）。"""
+        self.assertEqual(doc_paths.check(), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Of the five dead references found on 2026-07-27, **three** were `` `~/claude-cli-tools-memo.md` `` written inside backticks and never once a markdown link. lychee only parses link *elements*, so those were structurally invisible to it and survived for months.

The premise this gate enforces: **a path inside a code span is a claim that the path exists.** To name something that doesn't exist, leave it out of a code span or list it in `ALLOW` with a reason.

## Two scopes — mixing them produces nothing but false positives

| scope | repo-relative | `~/` |
|---|---|---|
| this repo's docs (`docs/`, root `*.md`, `scripts/**`) | ✅ resolved, must exist | ✅ |
| `chezmoi/private_dot_claude/` (global CLAUDE.md + skills) | ❌ off | ✅ |

The fleet docs describe the *whole fleet*, so `scripts/check.sh` and `.github/docs/...` refer to **other repositories**. Measured: checking them naively produced 3 findings, **all false positives for exactly that reason**.

What separates "our path" from "someone else's" is that the first segment must be a top-level directory of this repo — that's what keeps `os/exec`, `store/fsstore`, `webpro/awesome-dotfiles` and `barutsrb/tap` out. A test pins `ROOT_DIRS` against the live top level, so adding a directory forces an update rather than silently leaving it unchecked.

## `~/` paths: managed-or-explained, not exists-on-disk

Existence on disk is deliberately *not* the test — the CI runner has no such home, and a check that's only green locally is a failure mode this repo has already paid for.

The managed set comes from `chezmoi managed`, not a re-parse of the attribute prefixes, so it can't drift from chezmoi's own naming rules. Writing an `ALLOW` entry means **naming who creates the file**; a path whose creator you can't name is probably a dead reference. A test rejects `ALLOW` entries chezmoi already manages — it caught **six of my own redundant entries** (`~/.ssh/config` really is managed, just under a different source name).

## `FLEET_CLAIMS` — the check the ledger asked for but never got

The global CLAUDE.md names dotfiles files as **bare filenames** (`packages.nix`, `modify_settings.json`), which the first-segment rule can't see, so a rename would leave the fleet document pointing at nothing. The map is checked **both ways**: every target must exist, and every key must still be mentioned — a stale key can't sit there looking like protection.

## Bug found and fixed

`docs/operations.md` used `~/.config/eventfx/config` as its worked example in two places. **That directory does not exist on this machine.** Replaced with `~/.config/wand/config.toml` and the other managed configs. (This was an open item on `t-pd5r`.)

## script-test now uses the lint devShell

`test_doc_paths.py` shells out to chezmoi, which `setup-python` doesn't provide. Verified it fails **loudly** (`FileNotFoundError`, 3 errors) without chezmoi on PATH rather than skipping, and passes under an arbitrary foreign `HOME`. Side benefit: Python is now the flake.lock-pinned 3.13 instead of a second version source.

## Verification (measured)

- `scripts/lint` → **13 gates passed**; `test_lint` + `test_doc_paths` → **37 tests**, green
- **Mutation-verified end to end**: renaming `home/modules/packages.nix` turns the run red with **9 findings** — 5 repo-doc lines and 4 fleet-doc lines, each at its true line number
- Negative control in the same run: `os/exec`, `docs/*.md` (glob) and a real path stay silent
- Probe with a fabricated repo path and a fabricated `~/` path → both caught, exit 1

Closes `t-5c12`, and the "CI に実在検査 1 本" item on `t-m8fp`.

SetStatus-task: https://github.com/akira-toriyama/projects/blob/main/.furrow/bodies/t-5c12.md done