### PR TITLE
:memo:(docs) correct the audit drift: tree, ledger rows, and Don't call it scope

### DIFF
--- a/docs/chord.md
+++ b/docs/chord.md
@@ -28,7 +28,7 @@ ZMK ファームから届くチョードを macOS 側で捕まえてアクショ
 ```sh
 $EDITOR ~/.config/chord/config.toml         # 直接編集（eventfx 等と同じ運用）
 chord --validate                            # 動作確認（任意）
-chezmoi re-add ~/.config/chord/config.toml  # source に取り込み
+chezmoi re-add ~/.config/chord/config.toml  # 実体 → ソースへ re-add
 ```
 
 chord は vnode 監視で自動 reload するので明示 `chord --reload` は不要。

--- a/docs/claude-md-ledger.md
+++ b/docs/claude-md-ledger.md
@@ -52,7 +52,13 @@
 | Fable のファンアウト禁止（モデル運用節） | `fable-architect` 経由でのみ Fable を使う | — | [agents/fable-architect.md](../chezmoi/private_dot_claude/agents/fable-architect.md) の `tools:` に Agent 非搭載 → harness が拒否 | 🔒 Agent ツール経路のみ（Bash から `claude -p` を叩く迂回は構造では止まらない — 未実測） |
 | Fable% ≥ Weekly% 不変条件・約 4 日で 100%（モデル運用節） | `~/.claude.json` の枠を読み委譲判断 | 「これ Fable で」の発令 | なし | 📖 |
 | Opus 失敗の body 記録（モデル運用節） | 失敗の都度 task body に書く | — | なし | 📖 |
+| 版番号を書かない＝`opus[1m]` alias を pin しない（モデル運用節） | settings にも CLAUDE.md にも `claude-opus-4-8` 等の具体 ID を書かない | — | なし。[modify_settings.json](../chezmoi/private_dot_claude/modify_settings.json):97 が seed するのは alias `"opus[1m]"`（実測）だが、**具体 ID に書き換える事故を止める lint は無い** | 📖 一度ずれた実績があるルール |
+| 担当分担 Opus/Sonnet/Fable（モデル運用節） | メインループ=最新 Opus、機械的サブエージェント=Sonnet+`effort: low`、単独深考=`fable-architect` | — | なし（Fable のファンアウト禁止だけが上行で 🔒） | 📖 |
+| Fable セッションで既定継承させない（モデル運用節） | `/model fable` 中の workflow / サブエージェントは探索=`sonnet`+low、検証・judge=`opus` を明示指定する | `/model fable` への切替 | なし。サブエージェントは既定でメインループのモデルを継承するため、**指定漏れは黙って全員 Fable になる** | 📖 枠を直撃するのに無強制 |
+| 検証は常に Opus 側（モデル運用節） | Fable で書いたもののレビュー・検証は ultracode（opus / sonnet サブエージェント）で回す | — | なし | 📖 |
+| 枠が尽きたら追加課金に逃げない（モデル運用節） | Fable 枠が尽きたら Opus で粘る | 課金判断 | なし | 🙅 リスク受容・ユーザー裁量 |
 | SwiftUI+Sill・AppKit 原則禁止・最新 macOS のみ（Mac アプリ節） | 設計・実装時に適用 | — | なし（lint 化候補: `import AppKit` 検出等） | 📖 |
+| 不足パーツは Sill への PR を検討（Mac アプリ節） | アプリ側に one-off で足す前に共通化して Sill に上げられるか先に考える | Sill への PR merge 判断 | なし | 📖 |
 | 現在地ワンショット・pare/cifail/rundiff/revpost/wait4x/peekaboo を既定で使う（現在地・自作 CLI 節） | 生ログ・手書きループより先にツールへ手を伸ばす | — | 読み取り git allowlist と rundiff の test 自動 wrap（PreToolUse hook）は modify_settings.json が 🔒。**使う判断そのもの**は散文 | 🟡 |
 | 他 repo では repo の慣習に従う（「akira-toriyama 以外のリポジトリに対して」節） | その repo の CLAUDE.md / CONTRIBUTING / 既存履歴を先に読む | — | なし（gitmoji 規約・furrow・skill 等を他 repo に持ち込まないことを機械では止めていない） | 📖 |
 | 自作 CLI/アプリは source・brew 版禁止（source 節） | `brew install` しない | `brew install` しない | PATH 構造: brew 版が無ければ shadow は起きない（実測: furrow/cifail は nix profile のみ） | 🟡 導入操作自体は止まらない |
@@ -61,13 +67,24 @@
 
 機構化できない・Claude からは起こせない操作。**この一覧はここが初出**（各ルールの正本には分散して埋まっていた）。
 
+出所で 2 つに分ける — 上の台帳の対象は global CLAUDE.md だけ（:3-4）だが、実際に手を動かすのは
+ユーザー 1 人なので、**dotfiles 固有の手番も同じ場所で見えないと一覧の意味が無い**。混ざらないよう
+小見出しで分離する。
+
+### global CLAUDE.md 由来（全 repo 共通・上の台帳と同じ対象）
+
 - **セッション開始時の `/effort ultracode`** — 恒久化不能（モデル運用節）。ファンアウトさせたいセッションで 1 回。
 - **`/model` 切替と「これ Fable で」の発令** — メインループのモデルは Claude からは変えられない。セッション跨ぎの「何度も失敗している」記憶を持つのはユーザー側（モデル運用節）。
-- **ホスト側 sudo の実行** — `darwin-rebuild switch` / `--rollback` 等。Claude はコマンド提示まで（開発ポリシー節・dotfiles CLAUDE.md ルール 2）。
-- **破壊的 git の明示指示** — force push・履歴改変・push 済みへの amend はユーザーが明示した時だけ（dotfiles CLAUDE.md ルール 4）。
+- **VM 外（ホスト）の sudo 実行** — Claude はコマンド提示まで（開発ポリシー節。VM の中は全操作 OK）。
 - **好み・リスク受容・product 判断の裁定** — 一問一答への回答、「残り全部推奨で」の委任（作業依頼への返し方節）。
 - **作業開始の GO** — 質問・状況共有・相談への返答は GO ではない。保留中の作業は明示指示で再開（Workflow 節）。
-- **PR merge の判断（Claude 主導運用を明示していない repo）** — dotfiles は repo CLAUDE.md ルール 5 で Claude が merge してよい。明示の無い repo では従来どおりユーザー。
+- **カナリア／フリート進行の判断** — 段の正本は [fleet-change-policy.md](https://github.com/akira-toriyama/.github/blob/main/docs/fleet-change-policy.md)（開発ポリシー節）。
+
+### dotfiles の repo CLAUDE.md 由来（**上の台帳の対象外** — この repo だけの手番）
+
+- **`darwin-rebuild switch` / `--rollback` の実行** — sudo が要るのでコマンド提示までが Claude（ルール 2）。
+- **破壊的 git の明示指示** — force push・履歴改変・push 済みへの amend はユーザーが明示した時だけ（ルール 4）。
+- **PR merge の判断（Claude 主導運用を明示していない repo）** — dotfiles はルール 5 で Claude が merge してよい。明示の無い repo では従来どおりユーザー。
 
 ## 検証状態
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -23,6 +23,13 @@ dotfiles を構成する各パーツの **正規の呼び名** をまとめた�
 > 各エントリの形式: **正規名**, 1〜2 行の定義, 設定 / コードでの所在,
 > そして `Don't call it:` 行 — このエントリが置き換える誤った呼び名のリスト。
 
+**`Don't call it:` の効き方（誤読しやすいので明記）**: 禁じているのは
+「**そのエントリの概念を、その名前で呼ぶこと**」であって、その語の一般使用ではない。
+たとえば `darwin-rebuild switch` の `Don't call it: apply` は「switch を apply と呼ぶな」の意味で、
+`chezmoi apply`（それ自体が正規名）を禁じない。同様に `適用` `取り込み` `ビルド確認` のような
+一般語も、**別の正規名を持つ操作を指す時にだけ**違反になる。
+この非対称性のため、**単純な grep では強制できない**（台帳の印は 📖）。
+
 ---
 
 ## 全体像
@@ -257,6 +264,8 @@ PR 経由で `main` に squash-merge する（直 push なし）。
 ### feature branch
 **短命**ブランチ。命名は `<type>/<topic>` で `type` は `docs` / `feat` /
 `fix` / `refactor` / `chore` 等。PR → CI green → `gh pr merge --squash`。
+- 散文中の **「feature ブランチ」は同じものの日本語表記として可**（正規名を英語で保つ
+  規則 :15-17 に沿う混在表記）。`feature branch` と揺れていても違反ではない。
 - **Don't call it:** topic branch, work branch, 作業ブランチ
 
 ### pre-push hook
@@ -305,7 +314,25 @@ PR 経由で `main` に squash-merge する（直 push なし）。
 config 文法を released chord より先行させると `verify-chord-validate.yml`
 （tap の chord で strict 検証）が落ちる。
 - 参照: [`docs/chord.md`](chord.md)
-- **Don't call it:** chord config, hotkey config, ホットキー設定
+- **`chord config` は禁止語ではない** — chord CLI の実サブコマンド名
+  （`chord config --validate`）であり、設定ファイルそのものを指す語としても正しい。
+  禁じるのは **bridge 本体**を「chord config」と呼ぶこと。
+- **Don't call it:**（bridge 本体の呼び名として）hotkey config, ホットキー設定
+
+### `halo` / `facet` / `wand` (in dotfiles context)
+
+dotfiles が **config だけを持つ**自作 macOS アプリ 3 本（アプリ本体は各 repo）。
+`chord` と同じく `chezmoi/dot_config/<name>/config.toml` が chezmoi 管理下にあり、
+**アプリ側は読むだけ**（dotfiles からアプリを起動・ビルドしない）。
+
+| 名前 | 何をするか | config |
+|---|---|---|
+| `halo` | アクティブウィンドウの枠（border ring）を描く | [`chezmoi/dot_config/halo/config.toml`](../chezmoi/dot_config/halo/config.toml) — 未知キーは既定値に落ちるので typo で壊れない |
+| `facet` | デスクトップ演出（focus ring / pets 等）。`#:schema` 行で taplo 補完が効く | [`chezmoi/dot_config/facet/config.toml`](../chezmoi/dot_config/facet/config.toml) — schema sidecar は `facet --emit-schema` 由来 |
+| `wand` | パネル / カード UI。GUI 設定を持たず config が唯一の正本 | [`chezmoi/dot_config/wand/config.toml`](../chezmoi/dot_config/wand/config.toml) |
+
+- **Don't call it:** WM スタック（旧 borders/rift/focusfx は drop 済みで別物）、
+  ランチャー、オーバーレイ設定
 
 ### `azookey-bridge`
 **azooKey いい感じ変換（変換中 Ctrl+S）を Foundation Models で動かすローカル

--- a/docs/reproduction-architecture.md
+++ b/docs/reproduction-architecture.md
@@ -21,10 +21,10 @@
 | Nix でビルド可能な CLI（jq, gh, ghq, direnv, ripgrep 等） | **home-manager** `home.packages` | クロスプラットフォーム・宣言的 |
 | GUI アプリ / cask / Mac App Store | **nix-darwin** `homebrew.casks` / `masApps` | Nix は cask をビルド不可 |
 | Homebrew 本体 | **nix-homebrew** モジュール | brew バイナリ導入も再現可能に（任意だが推奨） |
-| カスタム tap のツール（borders, rift, skhd, krp 等） | **nix-darwin** `homebrew.brews` + `taps` | nixpkgs に無い→ brew 維持 |
+| カスタム tap のツール（現行は `steipete/tap/peekaboo` のみ） | **nix-darwin** `homebrew.brews` + `taps` | nixpkgs に無い→ brew 維持 |
 | macOS defaults（Dock/Finder/NSGlobalDomain 等） | **nix-darwin** `system.defaults` / `CustomUserPreferences` | 宣言的に再現。system-inventory が入力 |
 | zsh / starship / git のプログラム設定（DSL あり） | **home-manager** `programs.zsh` / `starship` / `git` | DSL で生成。現 `.zshrc` は刷新（後述） |
-| アプリ固有の手編集 dotfile（borders, rift, focusfx, claude） | **chezmoi** | Nix DSL が無い・アプリ所有の生 JSON。現状維持 |
+| アプリ固有の手編集 dotfile（chord, facet, halo, wand, claude） | **chezmoi** | Nix DSL が無い・アプリ所有の生 TOML/JSON。現状維持 |
 | シークレット（SSH 鍵, PAT, トークン） | **chezmoi + 1Password** `onepasswordRead` テンプレート | リポジトリに置かず apply 時に注入 |
 | 効果音等の不透明アセット（dot_local/share/sounds） | **chezmoi** | バイナリ資産 |
 | LaunchAgent（border-cycle 等） | **chezmoi**（現状の run_onchange 方式）/ システム級は nix-darwin | 既存資産を尊重 |
@@ -42,21 +42,32 @@ dotfiles/                       # 1リポジトリに flake と chezmoi 源を�
 ├── .chezmoiroot   → "chezmoi"  # ★これにより直下の Nix 群が $HOME に流出しない
 ├── flake.nix  flake.lock
 ├── system/                     # nix-darwin
-│   ├── hosts/<hostname>.nix    #   マシン別エントリ
-│   ├── modules/                #   homebrew.nix / defaults.nix / nix.nix
-│   └── profiles/               #   役割別（任意）
+│   ├── hosts/generic.nix       #   マシン別エントリ
+│   └── modules/                #   homebrew.nix / defaults.nix / power.nix /
+│                               #   launchd-drift.nix / claude-maint.nix / zmk-log.nix
 ├── home/                       # home-manager
-│   └── modules/                #   zsh.nix / git.nix / packages.nix
+│   └── modules/                #   zsh.nix / git.nix / packages.nix / mise.nix /
+│                               #   chezmoi.nix / furrow.nix
 ├── chezmoi/                    # ★ chezmoi source root（.chezmoiroot の指す先）
-│   ├── .chezmoiignore  .chezmoi.toml.tmpl
-│   ├── dot_config/{borders,rift,focusfx}/...   # 現 dot_config を移動
-│   ├── dot_claude/settings.json
-│   ├── dot_local/share/sounds/...
-│   ├── private_dot_ssh/private_id_*.tmpl   # ★ op から注入する秘密
-│   └── run_onchange_border-cycle.sh.tmpl
-├── docs/  README.md  .editorconfig  LICENSE
-└── (任意) .justfile             # タスクランナー（just）
+│   ├── .chezmoiignore  .chezmoiversion
+│   ├── dot_config/{chord,facet,halo,wand}/...  # アプリ所有の生設定
+│   ├── private_dot_claude/     #   CLAUDE.md / agents / skills /
+│   │                           #   modify_settings.json（★ live を書き換える modify_ スクリプト）
+│   ├── dot_local/bin/executable_*   # 手書きの helper（claude-work-report-check 等）
+│   ├── dot_local/share/{sounds,azookey-bridge}/...
+│   ├── private_Library/{LaunchAgents,private_Containers}/...
+│   ├── private_dot_ssh/{private_config,create_private_known_hosts}
+│   └── run_onchange_after_*.sh(.tmpl)
+├── scripts/                    # repo 運用スクリプト（lint / doc_paths.py / claude-md-eval 等）
+├── docs/  README.md  CLAUDE.md  install.sh  LICENSE
+└── .githooks/  .github/  ruff.toml  lychee.toml  _typos.toml  .taplo.toml
 ```
+
+> このツリーは **2026-07-27 時点の現物**（`ls -A` で実測）。設計当初に置く予定だった
+> `.chezmoi.toml.tmpl` は採用せず（単一機のため prompt 化不要 — [roadmap.md](roadmap.md) 参照）、
+> 代わりに `.chezmoiversion` を置いている。`.justfile` は「埋める材料が無い＝YAGNI」で
+> クローズ済み。`dot_config/{borders,rift,focusfx}` は WM スタックごと drop 済み
+> （[roadmap.md](roadmap.md) の「カスタム tap 由来 brew は全 drop」）。
 
 ### ⚠️ 重要な設計判断: `.chezmoiroot` を採用（過去決定の見直し）
 
@@ -153,7 +164,11 @@ SSH gate（`P-onepassword`）が 1Password agent の実署名を要求するた�
 
 ---
 
-## 5. 現状からの移行メモ
+## 5. 現状からの移行メモ（歴史的記録・移行は完了済み）
+
+> ⚠️ **この節は移行前（2026-05）のスナップショット**。当時の `dot_Brewfile` と旧 WM スタックを
+> 前提に書かれており、**現物の所在としては読まない**（現在の配置は §2 のツリー、所有レイヤーは
+> [CLAUDE.md](../CLAUDE.md) の責務分担表が正）。移行判断の経緯を残すために保存している。
 
 **Nix 化する（現 `dot_Brewfile` から）**
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -31,7 +31,7 @@
 - [x] **`.chezmoiroot=chezmoi` 採用**（ユーザー決定 / commit f9b1800）
   - `git mv` で `dot_*` `Library/` `run_onchange_*` `.chezmoi*` を `chezmoi/` へ集約
   - 検証ゲート通過: 再配置前後で `chezmoi managed`(28件) と `chezmoi diff` が**完全一致**（$HOME 不変。※既存の未適用 .Brewfile 差分は再配置と無関係に元から存在）
-- [x] flake スケルトン作成（適用しない・ビルド確認のみ / commit 546d2c8）
+- [x] flake スケルトン作成（switch せず `darwin-rebuild build` のみ / commit 546d2c8）
   - `flake.nix`（nix-darwin/master + home-manager + nix-homebrew, follows 固定）
   - `system/hosts/<hostname>.nix`（旧: 当初は LocalHostName 固定モジュール。後にホスト依存をやめ `system/hosts/generic.nix` に統一）
   - `system/modules/` `home/modules/` 雛形（空）。Determinate 共存で `nix.enable=false`


### PR DESCRIPTION
2026-07-27 の 6 レンズ監査で挙がった残りのうち、**測定不要な事実訂正だけ**をまとめた（応答の形を変える散文は触っていない — そちらは claude-md-eval で測ってから別 PR）。

## 1. `docs/reproduction-architecture.md` — 設計当時のツリーが現物と乖離

`ls -A` で実測して §2 を書き直した。乖離していたもの:

| 記載 | 実体 |
|---|---|
| `.chezmoi.toml.tmpl` | **不在**（単一機のため prompt 化を採用せず）。代わりに `.chezmoiversion` |
| `dot_config/{borders,rift,focusfx}` | `dot_config/{chord,facet,halo,wand}`（WM スタックは drop 済み） |
| `dot_claude/settings.json` | `private_dot_claude/modify_settings.json` |
| `.justfile`（任意） | 「埋める材料が無い＝YAGNI」でクローズ済み |

`scripts/` `install.sh` `.githooks/` 等の未記載も補った。§5「現状からの移行メモ」は**移行前 (2026-05) のスナップショット**である旨を先頭に明示 —— 現在の配置として読まれないようにするため（内容は歴史的記録として保存）。

## 2. `docs/claude-md-ledger.md` — 未収載 6 ルール + スコープの食い違い

モデル運用節に台帳の行が無かったルールを追加:

- 版番号を書かない（`opus[1m]` を具体 ID に pin しない）
- 担当分担（Opus / Sonnet+low / `fable-architect`）
- Fable セッションで既定継承させない（**指定漏れは黙って全員 Fable**）
- 検証は常に Opus 側
- 枠が尽きたら追加課金に逃げない（🙅）
- Mac アプリ節「不足パーツは Sill への PR を検討」

「ユーザーの手番」一覧が :3-4 の **global 限定**というスコープ宣言と食い違っていた（dotfiles repo CLAUDE.md 由来の sudo / 破壊的 git / merge 判断が混ざっていた）。手を動かすのは 1 人なので削らず、**出所ごとの小見出しに分離**した。

## 3. `docs/glossary.md` — `Don't call it` の効き方と死語まわり

- **`chord config` の禁止自体が誤りだった**。これは chord CLI の実サブコマンド名（`chord config --validate`）で、設定ファイルの呼び名としても正しい。8 箇所の用例ではなく禁止の方を直した（bridge 本体の呼び名に限定）。
- `Don't call it` が禁じるのは「**その概念をその名前で呼ぶこと**」で語の一般使用ではない、と明記（`switch` では `apply` が禁止語だが `chezmoi apply` は正規名）。**この非対称性のため grep では強制できない**（台帳の印が 📖 である理由）。
- **`halo` / `facet` / `wand` のエントリを新設** — chezmoi 管理下に `config.toml` があるのに全 .md で言及ゼロだった。
- `feature branch`: 「feature ブランチ」は揺れではなく許容表記と明記。
- 実違反 2 件を修正: `docs/chord.md` の「取り込み」→ re-add / `docs/roadmap.md` の「ビルド確認」→ `darwin-rebuild build`。

## 検証

- `nix develop .#lint --command scripts/lint` → **13 gates passed**（実行済み・上記変更込み）
- `glyph lint --range origin/main..HEAD` → exit 0（実行済み）
- ドキュメントのみの変更で `chezmoi/` 配下は触っていない＝ `chezmoi apply` 不要

**未検証**: `docs/system-inventory.md` に残る `borders` / `focusfx` の記述はこの PR で触っていない（システム棚卸しの歴史的記録で、ツリーとは別物のため）。

SetStatus-task: https://github.com/akira-toriyama/projects/blob/main/.furrow/bodies/t-pd5r.md in-progress

🤖 Generated with [Claude Code](https://claude.com/claude-code)