### PR TITLE
:memo:(skills) correct the peekaboo schema by measurement and point AppKit floors at Sill

### DIFF
--- a/chezmoi/private_dot_claude/skills/mac-app-dev/SKILL.md
+++ b/chezmoi/private_dot_claude/skills/mac-app-dev/SKILL.md
@@ -10,6 +10,17 @@ description: Use when developing, modifying, or debugging a macOS app in Swift (
 ## 設計・並行性 → `software-architecture` skill 参照
 層分離（Core / Adapter / View）・ports & adapters・DDD・YAGNI 層判断・**並行性の設計則**（serial queue 一元化／cross-actor 非循環／value snapshot 受け渡し／非 Sendable 境界）は **`software-architecture` skill**（mac app 設計時に auto 発火）に集約＝二重管理しない。本 skill は以下の **macOS 固有の実装メカニクス**に専念する。
 
+## UI の既定は SwiftUI + Sill（AppKit は floor と legacy 保守だけ）
+- **新規 UI は SwiftUI ＋ [Sill](https://github.com/akira-toriyama/sill)**（共通 UI 基盤。theming コアと
+  共有 widget kit を提供する）。**どの library が在るかは Sill の `Package.swift` を読む** ——
+  ここにも global CLAUDE.md にも一覧を書き写さない（写した瞬間 drift する。正本は 1 箇所）。
+- **AppKit を書いてよいのは 2 つだけ**: ① SwiftUI で届かない **essential floor**（何が floor かの
+  判断基準と規律は `software-architecture` skill。floor の一覧を持つのは Sill 側であって skill ではない）
+  ② 既存 AppKit コードの **legacy 保守**。下の落とし穴節はこの 2 つに効く実装知識。
+- **足りない部品はアプリ側に one-off で足す前に Sill への PR を検討する**（共通化できるものを
+  各アプリに散らさない）。
+- OS サポートは**最新 macOS のみ**。古い OS 向けの availability 分岐は書かない。
+
 ## AppKit / AX 落とし穴
 - agent 系アプリ: `LSUIElement=true`（Dock 無し）＋非アクティブ化パネル。別 window を focus する**前に** key を返す（クリックで panel が key を握ったまま離れない事故を防ぐ）。
 - window title 等は **AX 解決**（`kAXTitle`・短 TTL キャッシュ・off-main）。backend が埋めると仮定しない。

--- a/chezmoi/private_dot_claude/skills/macos-gui-verify/SKILL.md
+++ b/chezmoi/private_dot_claude/skills/macos-gui-verify/SKILL.md
@@ -16,28 +16,47 @@ description: Use when verifying macOS app GUI behavior end-to-end — dump an ap
 ## 基本ループ（見る → 選ぶ → 押す）
 
 ```sh
-# 1) AX ツリーを JSON で見る（要素に opaque ID が振られ、snapshot が永続化される）
-peekaboo see --app "MyApp" --json          # 大きい tree は --max-depth / --max-elements
-# スクリーンショット不要なら: peekaboo inspect-ui --json
+# 1) AX ツリーを見る。Screen Recording が要らない方が inspect-ui:
+peekaboo inspect-ui --app "MyApp" --json   # 大きい tree は --max-depth / --max-elements / --max-children
+peekaboo see --app "MyApp" --json          # スクリーンショットも要るとき（Screen Recording 必須）
 
-# 2) jq で要素を選ぶ。要素は .data.ui_elements[]、各要素のキーは
-#    { id, role, label, role_description, bounds, is_actionable }。id は "elem_8" 形式。
-#    操作対象は is_actionable=true で絞るのが速い:
-peekaboo see --app "MyApp" --json | jq -r '.data.ui_elements[] | select(.is_actionable) | "\(.id)\t\(.role)\t\(.label)"'
-#    snapshot は .data.snapshot_id、ウィンドウ名は .data.window_title。
+# 2) 要素 ID を拾う。★ inspect-ui は構造化配列を返さない（下の「JSON の形」参照）:
+peekaboo inspect-ui --app "MyApp" --json | jq -r '.data.content[].text'
+#    → "elem_8 - \"保存\" - at (100, 200) size 80x24 - desc: \"...\"" 形式のテキスト塊。
+#      role ごとにグループ化され、非操作要素には [not actionable] が付く。
+#    snapshot は .data.meta.snapshot_id、ウィンドウ名は .data.meta.summary.window_title。
 
 # 3) 別プロセスからでも id で操作できる（snapshot 経由で live 再解決）
-peekaboo click --on elem_8 [--snapshot <snapshot-id|latest>]   # --on は .data.ui_elements[].id の値
+peekaboo click --on elem_8 [--snapshot <snapshot-id|latest>]
 peekaboo type "text" --app MyApp
 peekaboo press return / peekaboo hotkey cmd,s / peekaboo set-value / peekaboo perform-action / peekaboo menu
 ```
 
+### JSON の形（`inspect-ui` は 2026-07-27 に実測・peekaboo 3.9.4）
+
+- 成功: `.success = true` / `.data.isError = false`
+  - `.data.meta.snapshot_id` — **`.data.snapshot_id` ではない**
+  - `.data.meta.{element_count, actionable_count, truncated, used_cache}`
+  - `.data.meta.summary.{action, target_app, window_title, capture_app, capture_window}`
+  - `.data.content[].text`（= `.data.text`）— **人間可読のテキスト塊**。
+    **`.data.ui_elements[]` のような構造化配列は返らない**ので、
+    `id / role / label / bounds / is_actionable` を jq で直接 select することはできない。
+    絞り込みが要るなら `--max-elements` で減らすか、テキストを grep する。
+- 失敗: `.success = false` + `.error.{code, message}`、**exit 1**（成功は 0）
+  - ウィンドウを持たないアプリ → `VALIDATION_ERROR`「App 'X' is running but has no windows or dialogs」。
+    エラーでなく状態 — 対象アプリのウィンドウを開いてから撮る。
+    **`X` はローカライズ名で来る**（Notes → 「メモ」）ので文字列一致に使わない。
+  - Screen Recording 未付与で `see` → `PERMISSION_ERROR_SCREEN_RECORDING`・exit 1。
+- **`see --json` の成功時スキーマは未検証**（この機械は Screen Recording 未付与のため実測できていない）。
+  `inspect-ui` と同形とは限らないので、使う前に 1 回撮って確かめること。
+
 - 既定は background 配送（フォーカスを奪わない）。key window が要るときだけ `--foreground`。
-- snapshot が期限切れなら `SNAPSHOT_NOT_FOUND` → `see` を撮り直す。
-- `see` が `WINDOW_NOT_FOUND` を返すのはそのアプリに実ウィンドウが無いとき（Finder のデスクトップのみ等）。エラーでなく状態 — 対象アプリのウィンドウを開いてから撮る。
+- snapshot が期限切れなら `SNAPSHOT_NOT_FOUND` → 撮り直す。
+- **Electron / 非ネイティブアプリは 0 要素で返ることがある**（VS Code で実測: `element_count = 0` +
+  「No accessible UI elements found」）。AX 経路が無いだけなので、`see` の画像側に切り替える。
 
 ## 注意
 
 - **exit code は素の 0/1**（house の 0/1/2/3 ではない）。エラー詳細が要るときは必ず `--json` を付けて stderr でなく JSON エラーを読む。
-- 要素指定は `see` が返す `.id`（+ 必要なら `--snapshot`）で。`button 1 of window 1` 式の位置 index は tree 変化で壊れるので使わない。
+- 要素指定は tree dump が返す `elem_N` id（+ 必要なら `--snapshot`）で。`button 1 of window 1` 式の位置 index は tree 変化で壊れるので使わない。
 - Peekaboo が重い/変化が速すぎる等の実害が出たら fallback = facet の AX モジュールで薄い Swift CLI を自作する。※かつての仕様スケッチは `~/claude-cli-tools-memo.md` にあったが**このファイルは現存しない** — 実害が出た時点で task を切って設計し直すこと。

--- a/chezmoi/private_dot_claude/skills/software-architecture/SKILL.md
+++ b/chezmoi/private_dot_claude/skills/software-architecture/SKILL.md
@@ -30,7 +30,11 @@ The value is realized at three distinct moments — if none is plausible you may
 
 ## UI toolkit: default to the highest level, confine the escape hatches
 
-Which UI framework the **View** layer imports is an architectural choice, not a per-view whim. Default to the **highest-level toolkit** (on macOS, SwiftUI) and treat the lower-level one (AppKit) as an **escape hatch confined to a small, named set of essential floors** — the places the high-level toolkit genuinely can't reach:
+Which UI framework the **View** layer imports is an architectural choice, not a per-view whim. Default to the **highest-level toolkit** (on macOS, SwiftUI) and treat the lower-level one (AppKit) as an **escape hatch confined to a small, named set of essential floors** — the places the high-level toolkit genuinely can't reach.
+
+**The authoritative floor list does not live here.** Per the discipline below, it belongs to the project's own canon; in this house that is the shared UI library **[Sill](https://github.com/akira-toriyama/sill)** — check its `Package.swift` (the library contract) before declaring a floor, because a floor that Sill has since covered is no longer a floor. See the `mac-app-dev` skill for the house default (SwiftUI + Sill).
+
+Floors observed in one production codebase, kept here **only as calibration for what "essential" means** — not as a list to copy:
 
 - **IME / text-input core** — marked-text (composition) interception and pre-commit key routing (Return / Esc / arrows) the high-level field doesn't expose.
 - **A focus-preserving non-activating panel shell** — a floating window that takes key + input without stealing the frontmost app / menu bar (and popups overflowing their parent). The *shell* is low-level; its contents are hosted high-level views.


### PR DESCRIPTION
t-pd5r の「構造（判断幅あり）」から 3 項目。**skill の記述を実測に置き換える**のが主眼。

## 1. `macos-gui-verify` — `inspect-ui` のスキーマが実測と違っていた

基本ループは `.data.ui_elements[]` を jq で引き、`.data.snapshot_id` / `.data.window_title` を読めと書いていた。**peekaboo 3.9.4 で実測した結果**:

| skill の旧記述 | 実測 |
|---|---|
| `.data.ui_elements[]`（`{id, role, label, bounds, is_actionable}` の配列） | **存在しない**。要素は `.data.content[].text` の**人間可読テキスト塊**（`elem_1 - "グループ" - at (0, 0) size 3840x1620 - desc: "デスクトップ"` 形式・role ごとにグループ化・`[not actionable]` 付き） |
| `.data.snapshot_id` | `.data.meta.snapshot_id` |
| `.data.window_title` | `.data.meta.summary.window_title` |
| `see` のウィンドウ無しは `WINDOW_NOT_FOUND` | `inspect-ui` は `VALIDATION_ERROR`。**アプリ名はローカライズ名で来る**（Notes → 「メモ」）ので文字列一致に使わない |

あわせて実測できた分を追記:

- 成功 exit 0 / 失敗 exit 1、失敗時は `.success=false` + `.error.{code,message}`
- Screen Recording 未付与で `see --json` → `PERMISSION_ERROR_SCREEN_RECORDING`・exit 1
- **Electron 系は 0 要素で返る**（VS Code で実測: `element_count=0` +「No accessible UI elements found」）
- `inspect-ui` は Screen Recording が要らない ＝ AX だけ要るときはこちらが正しい入口

**未検証として明記したもの**: `see --json` の**成功時**スキーマ。この機械は Screen Recording が `Not Granted` のままで実測できていない（ユーザーは付与すると決定済み・付与後に別途実測して追記する）。`inspect-ui` と同形と仮定しないよう skill に書いた。

## 2. `software-architecture` — 自分の規則への自己違反

:43 が「**floor の正本リストは methodology でなく project canon に置け**」と書いているのに、:35-37 が 3 件を列挙していた（照合機構ゼロ・2 箇所一致）。正本を **[Sill](https://github.com/akira-toriyama/sill) の `Package.swift`** に向け、3 件は「essential とは何かの**較正用の例**」に格下げした（Sill が覆った floor はもう floor ではない、という判断順序も明記）。

## 3. `mac-app-dev` — skill 7 本で Sill 言及がゼロだった

「新規 UI は SwiftUI + Sill / AppKit は essential floor と legacy 保守だけ / 不足パーツは Sill への PR を先に検討 / 最新 macOS のみ」を追加。**13 library の名前は写していない** — global CLAUDE.md にある一覧をここへ複製すると drift するので、`Package.swift` を読めとだけ書いた。

## 検証

- `nix develop .#lint --command scripts/lint` → **13 gates passed**（実行済み）
- `glyph lint --range origin/main..HEAD` → exit 0（実行済み）
- `chezmoi/` 配下の変更なので **merge 後に `chezmoi apply` が要る**（この PR では live 未追従）

SetStatus-task: https://github.com/akira-toriyama/projects/blob/main/.furrow/bodies/t-pd5r.md in-progress

🤖 Generated with [Claude Code](https://claude.com/claude-code)