### PR TITLE
:arrow_up:(release) adopt glyph v0.12.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,9 +51,9 @@ jobs:
           persist-credentials: false
 
       - name: install glyph
-        uses: akira-toriyama/glyph/.github/actions/install@v0.11.2
+        uses: akira-toriyama/glyph/.github/actions/install@v0.12.0
         with:
-          version: v0.11.2
+          version: v0.12.0
           token: ${{ github.token }}
 
       - name: Compose the verdict and upsert the rolling DRAFT


### PR DESCRIPTION
Moves this repo's glyph references from `v0.11.2` to `v0.12.0` — the ones fleet-sync does not distribute.

fleet-sync already moved `commit-lint.yml` and `version-preview.yml` here ([akira-toriyama/.github#137](https://github.com/akira-toriyama/.github/pull/137), then `fleet-sync.yml -f dry-run=false`). These are runbook step 5: the `release.yml` caller, the `actions/install` `@tag`, and — where the step has one — the `version:` input **two lines below it** that says which binary gets installed. Both move in the same edit, always: a repo on a new action installing an old binary enforces a convention nobody chose, which is how seven repos sat three releases behind in July 2026.

`glyph-pin-audit.yml` in the hub is red until every repo lands this.

SetStatus-task: https://github.com/akira-toriyama/projects/blob/main/.furrow/bodies/t-89n5.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)