### PR TITLE
:sparkles:(hook) retire the verbatim closing template for a two-element contract

### DIFF
--- a/chezmoi/dot_local/bin/executable_claude-work-report-check
+++ b/chezmoi/dot_local/bin/executable_claude-work-report-check
@@ -1,18 +1,22 @@
 #!/usr/bin/env bash
-# claude-work-report-check — Claude Code Stop hook: validate the work-request
-# closing template (global CLAUDE.md「作業・task 依頼への返し方」).
+# claude-work-report-check — Claude Code Stop hook: validate the work-session
+# closing contract (global CLAUDE.md「作業の締め」).
 #
-# WHAT IT ENFORCES: when the final assistant message uses the closing template
-# (the fixed opener 「品質担保できる範囲まで…」 or a 「やり残しは task 化…」
-# line), the やり残し declaration must be VERIFIABLE — at least one furrow task
-# id (t-xxxx) or the literal 「なし」 on that line. Prose alone (「後で task 化
-# します」) cannot be checked with `furrow show`; ids can. On violation we emit
-# {"decision":"block","reason":…} so Claude gets exactly one repair round.
+# WHAT IT ENFORCES: a work-session close must carry two VERIFIABLE elements,
+# wording otherwise free (the verbatim template was retired 2026-07-28):
+#   1. a やり残し line with at least one furrow task id (t-xxxx) or 「なし」
+#   2. a counts line `closed N / created M`; when M > N (budget is
+#      created ≤ closed − 1, projects/CLAUDE.md「board を収束させる」), a
+#      reason must sit on the counts line or the line right after it.
+# Prose alone (「後で task 化します」) cannot be checked with `furrow show`;
+# ids and numbers can. On violation we emit {"decision":"block","reason":…}
+# so Claude gets exactly one repair round.
 #
-# WHAT IT CANNOT ENFORCE (scope decision, furrow t-m2bf): firing of the template
-# itself. Whether a turn was a work request needs semantic classification of the
-# conversation — the Stop payload carries no cheap, reliable signal for that.
-# This hook guarantees well-formedness WHEN the template is used, not usage.
+# WHAT IT CANNOT ENFORCE (scope decision, furrow t-m2bf): that a work session
+# closes with the contract at all. Whether a turn was a work request needs
+# semantic classification of the conversation — the Stop payload carries no
+# cheap, reliable signal for that. This hook guarantees well-formedness WHEN
+# a close is attempted, not that one happens.
 #
 # Loop safety: stop_hook_active=true → always allow (the repair round is
 # single; Claude Code would force-stop after repeated blocks anyway).
@@ -35,15 +39,24 @@ printf '%s' "$input" | jq -e . >/dev/null 2>&1 || exit 0
 msg=$(printf '%s' "$input" | jq -r '.last_assistant_message // empty')
 [ -n "$msg" ] || exit 0
 
-# Template detection — two independent markers, either one arms the check:
-#   a) the fixed opening line 「品質担保できる範囲まで」
-#   b) a やり残し declaration line (やり残し + task on the same line)
-# Ordinary conversation ABOUT the workflow can hit (b); the cost is one
-# spurious repair round, bounded by the stop_hook_active guard above.
+# Counts shape, shared by arming and the budget check below — one regex, not
+# two drifting copies.
+counts_re='closed[^0-9]{0,3}[0-9]+[^0-9]{0,3}/[^0-9]{0,3}created[^0-9]{0,3}[0-9]+'
+
+# Close detection — three independent markers, any one arms the check:
+#   a) the retired template opener 「品質担保できる範囲まで」 (backward compat)
+#   b) any line containing やり残し (no longer requires "task" on the line)
+#   c) a counts-shaped token — a counts line without a やり残し declaration is
+#      itself a violation, so it must arm rather than slip through
+# Wide on purpose: a false arm costs one bounded repair round (stop_hook_active
+# guard above), a miss is undetectable. Ordinary conversation ABOUT the
+# workflow can hit (b)/(c); same bounded cost.
 armed=0
 if printf '%s' "$msg" | grep -qF '品質担保できる範囲まで'; then
   armed=1
-elif printf '%s' "$msg" | grep -qiE 'やり残し.*task|task.*やり残し'; then
+elif printf '%s' "$msg" | grep -qF 'やり残し'; then
+  armed=1
+elif printf '%s' "$msg" | grep -qiE "$counts_re"; then
   armed=1
 fi
 [ "$armed" -eq 1 ] || exit 0
@@ -60,7 +73,7 @@ if [ -n "$decl" ]; then
 fi
 
 if [ "$ok_decl" -eq 0 ]; then
-  jq -n '{decision: "block", reason: "正常終了定型の「やり残し」宣言に task ID がありません（global CLAUDE.md「作業・task 依頼への返し方」— ID は furrow show で検証できるが、文だけでは検証できない）。やり残しを furrow で task 化して「やり残しは task 化済: t-xxxx, t-yyyy」と ID を列挙するか、本当に無ければ「なし」と書いてください。直したらそのまま停止してよい。"}'
+  jq -n '{decision: "block", reason: "作業の締めに検証可能な「やり残し」宣言がありません（global CLAUDE.md「作業の締め」— ID は furrow show で検証できるが、文だけでは検証できない）。「やり残し: t-xxxx, t-yyyy」と ID を列挙するか、本当に無ければ「やり残し: なし」と書いてください。作業の締めでないなら、その旨が分かる表現に直してよい。直したらそのまま停止してよい。"}'
   exit 0
 fi
 
@@ -75,21 +88,25 @@ fi
 # arithmetic to be self-consistent, and leaves the counting honest-by-convention
 # — same call as the id check, which cannot verify that an id was really filed
 # today either. An overrun stays possible; it just has to be said out loud.
-counts=$(printf '%s' "$msg" | grep -oiE 'closed[^0-9]{0,3}[0-9]+[^0-9]{0,3}/[^0-9]{0,3}created[^0-9]{0,3}[0-9]+' | head -1)
+counts=$(printf '%s' "$msg" | grep -oiE "$counts_re" | head -1)
 if [ -z "$counts" ]; then
-  jq -n '{decision: "block", reason: "締めに増減の実数がありません。global CLAUDE.md の定型どおり「closed N / created M」の行を足してください（board は放っておくと単調増加する — 実測で完了は週 100 件超なのに未完は 95 → 295 に増えた。数字を出さない限り収束しているか誰にも分からない）。直したらそのまま停止してよい。"}'
+  jq -n '{decision: "block", reason: "作業の締めに増減の実数がありません。「closed N / created M」の行を足してください（board は放っておくと単調増加する — 実測で完了は週 100 件超なのに未完は 95 → 295 に増えた。数字を出さない限り収束しているか誰にも分からない）。作業の締めでないなら、その旨が分かる表現に直してよい。直したらそのまま停止してよい。"}'
   exit 0
 fi
 
 closed_n=$(printf '%s' "$counts" | grep -oE '[0-9]+' | head -1)
 created_n=$(printf '%s' "$counts" | grep -oE '[0-9]+' | tail -1)
 
-# An overrun is allowed ONLY with a stated reason on some line — the escape
-# hatch for a blocker today's work genuinely created. Without one, the repair
-# round is the point: re-triage the new tasks to icebox, or fix them now.
+# An overrun is allowed ONLY with a stated reason ON THE COUNTS LINE or the
+# line right after it — the escape hatch for a blocker today's work genuinely
+# created. Scoped because the wording of the close is now free-form: a stray
+# 「理由」 anywhere in the message (e.g. an error explanation) must not
+# satisfy the check. Without a reason, the repair round is the point:
+# re-triage the new tasks to icebox, or fix them now.
 if [ "$created_n" -gt "$closed_n" ]; then
-  if ! printf '%s' "$msg" | grep -qE '理由|例外|blocker|ブロッカー'; then
-    jq -n --arg c "$closed_n" --arg m "$created_n" '{decision: "block", reason: ("生成予算を超えています（closed \($c) / created \($m)）。projects/CLAUDE.md「board を収束させる」— 予算は created ≤ closed − 1 で、超えてよいのは今日の作業が生んだ blocker だけです。新しい task を (a) その場で直す（effort ≤ 2 かつ今触っているコード内）(b) icebox に落とす（`furrow set <id> -s icebox`・復帰可能）のどちらかに振り直して数字を直すか、超過の理由を 1 行添えてください。直したらそのまま停止してよい。")}'
+  reason_zone=$(printf '%s' "$msg" | grep -iE -A1 "$counts_re" | head -2)
+  if ! printf '%s' "$reason_zone" | grep -qE '理由|例外|blocker|ブロッカー'; then
+    jq -n --arg c "$closed_n" --arg m "$created_n" '{decision: "block", reason: ("生成予算を超えています（closed \($c) / created \($m)）。projects/CLAUDE.md「board を収束させる」— 予算は created ≤ closed − 1 で、超えてよいのは今日の作業が生んだ blocker だけです。新しい task を (a) その場で直す（effort ≤ 2 かつ今触っているコード内）(b) icebox に落とす（`furrow set <id> -s icebox`・復帰可能）のどちらかに振り直して数字を直すか、超過の理由を counts 行かその直後の行に 1 行添えてください。直したらそのまま停止してよい。")}'
     exit 0
   fi
 fi

--- a/scripts/claude-work-report-check-test.sh
+++ b/scripts/claude-work-report-check-test.sh
@@ -6,9 +6,12 @@
 # CI: .github/workflows/ci.yml job `hook-scripts-test`.
 #
 # Contract under test: the hook emits {"decision":"block",...} when (and only
-# when) the work-request closing template is used without a verifiable
-# やり残し declaration (a t-xxxx furrow id or the literal 「なし」 on the
-# declaration line). Everything else — including malformed input — must allow.
+# when) a work-session close is attempted (armed by the retired template
+# opener, a やり残し line, or a closed/created counts token) without the two
+# verifiable elements — ①a やり残し line carrying a t-xxxx furrow id or the
+# literal 「なし」 ②a `closed N / created M` line, with any budget-overrun
+# reason on the counts line or the line right after it. Everything else —
+# including malformed input — must allow.
 set -u
 
 script="$(cd "$(dirname "$0")/.." && pwd)/chezmoi/dot_local/bin/executable_claude-work-report-check"
@@ -94,6 +97,30 @@ run "全角混じり・語順どおりなら読める → allow" \
 やり残しは task 化済: t-ab3d
 このセッションの増減: closed 4 / created 0
 別セッションで作業お願いします。')" allow
+
+# ---- 契約化（2026-07-28 逐語定型の退役）: 文面自由・必須 2 要素 ---------------
+# arming は ①旧 opener（後方互換） ②やり残し行 ③counts トークン のいずれか。
+
+run "自由文でも 2 要素が揃っていれば → allow" \
+  "$(mk '修正を merge しました。
+やり残し: なし
+closed 2 / created 0')" allow
+
+run "counts 行だけで やり残し宣言が無い（counts が arm する新経路）→ block" \
+  "$(mk '作業完了です。closed 3 / created 1')" block
+
+run "「task」語なしの やり残し行でも arm され、ID/なし が無い → block" \
+  "$(mk 'やり残しがあります。次のセッションでやります。')" block
+
+run "超過理由が counts 行の直後の行にあれば → allow" \
+  "$(mk 'やり残し: t-ab3d
+closed 1 / created 2
+理由: 今日の作業が生んだ blocker')" allow
+
+run "超過理由が counts 行から離れた行にしか無い → block" \
+  "$(mk '失敗の理由は依存の破損でした。修正済みです。
+やり残し: t-ab3d
+closed 1 / created 2')" block
 
 run "stop_hook_active=true は違反があっても素通し → allow" \
   "$(jq -n '{stop_hook_active: true, last_assistant_message: "やり残しは task 化済:（あとで）"}')" allow


### PR DESCRIPTION
## What

Stop hook `claude-work-report-check` の arming を逐語定型前提から **2 要素契約**（文面自由）へ移行する第 1 段。

- arming を 3 マーカー OR に: ①旧冒頭文「品質担保できる範囲まで」（後方互換） ②`やり残し` 行単独（「task」同一行要求を撤廃） ③`closed N / created M` トークン（counts 行だけの不完全な締めも捕まえる新経路）
- counts regex を変数 1 本に統合（arming と検査で 2 本持たない）
- 超過理由の探索を全文 → **counts 行とその直後 1 行**に限定（自由文化で偶然マッチが増えるため）
- block 文言を新契約向けに更新 + 誤発火時の逃げ道 1 文を追加

## Why

t-xx7g: 数分で完了した作業に逐語定型を強いると実態と矛盾する締めになる。検証可能な核（やり残し ID + 実数）だけを必須にし文面を自由化する。CLAUDE.md 側の契約文言は後続 PR（全面再構成）で差し替え — 本 PR は後方互換 arming なので先行して安全に出せる。

## Verification

- fixture 19 ケース全緑（新規 5: counts 単独 arm / 自由文 allow / task 語なし arm / 理由ゾーン正負）
- **変異検証 3/3**: ①やり残し単独 arm を旧仕様に戻す ②counts arm を消す ③理由スコープを全文に戻す — 各変異で対応する新ケースだけが fail、復元後 19/19 緑
- `nix develop .#lint --command scripts/lint` 13 ゲート緑

SetStatus-task: https://github.com/akira-toriyama/projects/blob/main/.furrow/bodies/t-xx7g.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)