### PR TITLE
:heavy_plus_sign:(homebrew) add sourcekitten and lint CLIs to brews

### DIFF
--- a/system/modules/homebrew.nix
+++ b/system/modules/homebrew.nix
@@ -24,6 +24,11 @@
       "steipete/tap"
     ];
     brews = [
+      "sourcekitten"  # Framework and command-line tool for interacting with SourceKit
+      "typos-cli"  # Source code spell checker
+      "shfmt"  # Autoformat shell script source code
+      "lychee"  # Fast, async, resource-friendly link checker
+      "gitleaks"  # Audit git repos for secrets
       # go は mise 管理へ移行（home/modules/mise.nix）。dev runtime は mise に一元化。
       "git-cliff"  # Highly customizable changelog generator
       "gifski"  # Highest-quality GIF encoder based on pngquant


### PR DESCRIPTION
Add sourcekitten plus the lint-stack CLIs (typos-cli, shfmt, lychee, gitleaks) to `homebrew.brews` so they are available interactively, matching the tools already wired into `scripts/lint`.

- `nix flake check --no-build` passed locally.
- Placement follows existing precedent in `homebrew.brews` (git-cliff, gifski).

---（和訳）

sourcekitten と lint 系 CLI（typos-cli / shfmt / lychee / gitleaks）を `homebrew.brews` に追加し、`scripts/lint` に組み込み済みのツールを対話利用でも使えるようにする。

SetStatus-task: https://github.com/akira-toriyama/projects/blob/main/.furrow/bodies/t-vk0w.md in-progress

🤖 Generated with [Claude Code](https://claude.com/claude-code)