### PR TITLE
:memo:(claude) orient sessions with brief and note the v6 source-pull gotcha

### DIFF
--- a/chezmoi/private_dot_claude/CLAUDE.md
+++ b/chezmoi/private_dot_claude/CLAUDE.md
@@ -55,8 +55,11 @@
 
 - タスク管理は furrow + private repo `projects` に一本化。furrow は PATH の wrapper
   （常に source 反映）で叩く。furrow 自身を開発する時だけ source dir で
-  `go run ./cmd/furrow`。
-- 読む前・書いた後に `furrow sync`。
+  `go run ./cmd/furrow`。board の layout が上がった直後は各マシンで furrow の
+  source checkout を `git pull` してから叩く（古い HEAD のままだと `schema-too-new`
+  で board に書けない）。
+- 読む前・書いた後に `furrow sync`。session start は `furrow sync && furrow brief`
+  で orient（active epic・next の先頭・lint 件数が 1 読で出る）。
 - 進捗の正本はその task body 一本（memory・ブランチ上のファイルに複製しない）。
   中断時は body のチェックを更新し、次セッションへの希望を 1 行残す。
 - 起票の既定 lane は `icebox`（backlog 以上に置くのは「戻る価値」を 1 行で言えるものだけ。
@@ -65,7 +68,9 @@
 - code repo 内では global 既定ボードが repo を自動付与・自動フィルタする。
   **projects checkout の中だけは local `.furrow` が優先されて auto が効かない —
   tracker 自身の作業は明示 `-r projects` が必須**（正典に無い）。
-- 指示が無ければ `furrow next -r <repo>` の先頭から着手し、何を選んだか 1 行報告。
+- 指示が無ければ `furrow brief`（= next の先頭）から着手し、何を選んだか 1 行報告。
+  next は active epic の member + epic 未所属に絞られる（active が無ければ意図的に空）。
+  **active epic の切り替えは申請制 — 勝手に `furrow epic activate` しない**。
   質問・状況共有・相談への返答を作業開始の合図と読まない。
 - code repo の PR 本文に footer を 1 行:
   `SetStatus-task: https://github.com/akira-toriyama/projects/blob/main/.furrow/bodies/<id>.md <lane>`

--- a/docs/claude-md-ledger.md
+++ b/docs/claude-md-ledger.md
@@ -31,10 +31,10 @@
 | 生成予算 created ≤ closed − 1・icebox 既定（作業の締め節・Workflow 節） | 予算内に収める。起票既定は icebox（ユーザー明示依頼は対象外） | — | 同 Stop hook が実数と超過理由を強制。**lane 選択は見ていない** | 🟡 |
 | 質問・報告フロー（一問一答・推奨・委任）（作業の締め節） | 一問一答・推奨つき | 裁定・「残り全部推奨で」の委任 | なし | 📖 |
 | furrow 一本化・wrapper 使用（Workflow 節） | PATH の `furrow` を叩く | — | `packages.nix` の source-build wrapper。brew 版未導入なので shadow は構造的に不発 | 🟡 |
-| 着手前後の `furrow sync`（Workflow 節） | 読む前・書いた後に回す | — | なし | 📖 |
+| 着手前後の `furrow sync`・session start は `furrow sync && furrow brief`（Workflow 節） | 読む前・書いた後に sync。session start は sync && brief で orient | — | なし | 📖 |
 | 進捗の正本は body 一本・中断時 1 行（Workflow 節） | body 更新・複製しない | — | なし | 📖 |
 | projects checkout では明示 `-r projects`（Workflow 節・正典に無い） | 明示する | — | `furrow doctor` が `scope-shadowed` を info 報告するだけで止めない | 📖 |
-| 指示なし時は task を進める／状況共有を GO と読まない（Workflow 節） | 既定挙動として従う | 作業開始の GO を明示 | なし（memory 併用） | 📖 |
+| 指示なし時は `furrow brief` の先頭から着手／状況共有を GO と読まない／active epic の切り替えは申請制（Workflow 節） | 既定挙動として従う。勝手に `furrow epic activate` しない | 作業開始の GO・epic 切り替えの裁定 | furrow が next/brief を active epic に scope（epic-multi-active は lint error）。申請制そのものは散文 | 🟡 scope は機構・申請制は 📖 |
 | PR footer `SetStatus-task:`（Workflow 節） | footer を書く | — | [task-status.yml](../.github/workflows/task-status.yml) が lane 自動適用。書き忘れても落ちない | 🟡 |
 | 品質>速度・一貫性・破壊的変更 OK（開発ポリシー節） | 判断規範として適用 | 好み・リスク受容の裁定 | — | 🙅 |
 | 「できた」は実測とセット（開発ポリシー節） | 実測／未確認を分けて報告 | — | なし | 📖 |


### PR DESCRIPTION
## Why

The central board moved to furrow **v1.0.0 / layout v6** (epic as a first-class entity, active-per-repo enforcement — projects#15 updates the canonical rules). The global CLAUDE.md's Workflow section still taught the pre-brief ritual (`furrow next -r <repo>` as the session entry) and had no note about the wrapper's source-checkout going stale across a schema bump.

## What changed (Workflow section only)

- Session start: `furrow sync && furrow brief` — active epic, top pick, lint count in one read. With no instruction, start from brief's top pick; `next` now scopes to the active epic's members + unfiled tasks (deliberately empty with no active epic).
- **Switching the active epic is by request only** — never `furrow epic activate` unprompted (the canonical discipline, restated at the always-loaded layer).
- Distribution note: after a board layout bump, each machine must `git pull` its furrow source checkout first — the PATH wrapper builds whatever HEAD is checked out, so a stale checkout fails every write with `schema-too-new`.

Filing default (icebox), body-as-progress-record, and the PR footer are unchanged.

Rollout: merge → `chezmoi apply` on each machine.

SetStatus-task: https://github.com/akira-toriyama/projects/blob/main/.furrow/bodies/t-2yce.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)