### PR TITLE
:memo:(skills) add comment policy to go-dev and mac-app-dev

### DIFF
--- a/chezmoi/private_dot_claude/skills/go-dev/SKILL.md
+++ b/chezmoi/private_dot_claude/skills/go-dev/SKILL.md
@@ -71,6 +71,13 @@ description: Use when writing or modifying a Go CLI/tool (furrow・cifail・pare
 - gofmt/goimports 全 file、naming は MixedCaps・initialism 一貫（`URL`/`ID`/`HTTP`・`ServeHTTP`）・getter は `Get` 無し・error string は lowercase 無句点＝lint が強制するので手で議論しない（Go Code Review Comments）。
 - **fleet-managed file は per-repo で編集しない**（fleet-sync が上書きする）。canonical copy は `akira-toriyama/.github` の `fleet/`。**対象の正本は `.github/.github/workflows/fleet-sync.yml` の `MANIFEST=` 行**（2026-07-27 時点で 7 destination: `.github/workflows/` の task-status / commit-lint / taplo / zizmor / version-preview、`.github/zizmor.yml`、`docs/commit-convention.md`）。ここに一覧を写さない —— 増減は MANIFEST を読んで確認する（`dependabot.yml` は既に外れている）。
 
+## コメント方針（mandate 2026-07-29）
+- **コメントの読者は Claude Code。人間向けの説明コメントは書かない** — tutorial 調の
+  逐語説明・コードの言い換え・飾りの区切り見出しは書かない。既存コードで見つけたら削る。
+- 書く・残すのは**保守に効くコメントだけ**: コードに表せない制約・不変条件・
+  package/型冒頭の層契約（役割と禁止事項）・外部仕様への追随点・「なぜこうしないか」。
+- 迷ったら書かない。コードで表せる情報は naming・型・test に載せる。
+
 ## house が mainstream Go から意図的に外す点（知らずに"直さない"）
 - **port は core 側で宣言**（consumer 側でなく）＝stateful app＋swappable fs/mem adapter の hexagonal 選択。lib なら canonical（consumer 定義）が正。
 - **error は source で eager 分類**（`%w` で wrap して defer でなく）＝exit code が製品契約。translate は Execute 境界で、が canonical とも整合。

--- a/chezmoi/private_dot_claude/skills/mac-app-dev/SKILL.md
+++ b/chezmoi/private_dot_claude/skills/mac-app-dev/SKILL.md
@@ -42,3 +42,10 @@ description: Use when developing, modifying, or debugging a macOS app in Swift (
 - 科学的デバッグ（観察→仮説→実験）＋`git bisect`。綺麗な commit が bisect を安くする。
 - ホスト影響変更・新規許可フローの検証は **VM**（Tart・APFS-COW clone + suspend snapshot）でクリーン環境実証。
 - 二層ログ: 常時 `Log.line` ＋ env-gate `Log.debug`（off は bool 1回）。temp file へ書き、gate on の時だけ stderr へミラー。
+
+## コメント方針（mandate 2026-07-29）
+- **コメントの読者は Claude Code。人間向けの説明コメントは書かない** — tutorial 調の
+  逐語説明・コードの言い換え・飾りの区切り見出しは書かない。既存コードで見つけたら削る。
+- 書く・残すのは**保守に効くコメントだけ**: コードに表せない制約・不変条件・
+  型/module 冒頭の層契約（役割と禁止事項）・外部仕様への追随点・「なぜこうしないか」。
+- 迷ったら書かない。コードで表せる情報は naming・型・test に載せる。


### PR DESCRIPTION
Adds a comment policy section (mandate 2026-07-29) to the go-dev and mac-app-dev skills: the audience for code comments in Swift/Go repos is Claude Code, not humans. No tutorial-style narration, code paraphrasing, or decorative section-divider comments; keep only comments that carry maintenance value — constraints, invariants, package/type-level layer contracts, upstream-spec references, why-nots. When in doubt, no comment: express it via naming, types, and tests.

## Measurement (claude-md-eval isolated runner, 6 custom cases × 3 trials × 2 arms, claude-opus-5)

The stock 18 cases exercise conversation shape, not in-code comments, and the LLM judge rubric does not cover comment density, so this ran the harness runner with purpose-built cases and an objective metric (comment lines inside code fences), plus manual reading of all guard-case responses per the harness README.

| case | baseline comments | candidate comments | reading |
|---|---|---|---|
| go-refactor-comments | 3 | 0 | narration comments deleted, behavior kept |
| swift-refactor-comments | 1 | 0 | same |
| go-write | 8 | 7 | remaining comments are contract-level |
| swift-write | 0 | 0 | no effect needed |
| go-keep-invariant (guard) | 70 | 37 | deadlock/lock-discipline constraint comments **kept and strengthened** (e.g. "onEvict は cache の lock を握らない状態で呼ばれる") |
| explain-for-humans (guard) | 55 | 16 | not a refusal: names the policy conflict, keeps code comments contract-level, delivers the beginner explanation as prose. In production the precedence rule (user instruction > skill) is always loaded and takes over |

Board: the 18 per-repo retroactive comment-sweep tasks are filed under each repo's `mandate` epic and reference this section as their criteria.

SetStatus-task: https://github.com/akira-toriyama/projects/blob/main/.furrow/bodies/t-3b30.md done

🤖 Generated with [Claude Code](https://claude.com/claude-code)