### PR TITLE
chore: Claude docs maintenance 2026-08

### DIFF
--- a/docs/claude-maint-reports/2026-08.md
+++ b/docs/claude-maint-reports/2026-08.md
@@ -1,0 +1,23 @@
+# Claude ドキュメント保守 2026-08
+
+- 実行: 2026-08-01 10:06:34
+- ⚠️ claude による判断が完了しなかった (rc=1)。使用統計のみ記録。
+
+## 使用統計
+```
+観測期間: 2026-07-18 〜 2026-08-01
+
+### skills (明示起動回数)
+- cli-app-dev: 0 回
+- condition-wait: 1 回 / 最終 2026-07-19
+- github-practices: 0 回
+- go-dev: 2 回 / 最終 2026-07-29
+- mac-app-dev: 0 回
+- macos-gui-verify: 3 回 / 最終 2026-07-28
+- software-architecture: 0 回
+
+### commands (起動回数)
+
+### agents (Agent ツール経由の起動回数)
+- fable-architect: 6 回 / 最終 2026-07-28
+```


### PR DESCRIPTION
# Claude ドキュメント保守 2026-08

- 実行: 2026-08-01 10:06:34
- ⚠️ claude による判断が完了しなかった (rc=1)。使用統計のみ記録。

## 使用統計
```
観測期間: 2026-07-18 〜 2026-08-01

### skills (明示起動回数)
- cli-app-dev: 0 回
- condition-wait: 1 回 / 最終 2026-07-19
- github-practices: 0 回
- go-dev: 2 回 / 最終 2026-07-29
- mac-app-dev: 0 回
- macos-gui-verify: 3 回 / 最終 2026-07-28
- software-architecture: 0 回

### commands (起動回数)

### agents (Agent ツール経由の起動回数)
- fable-architect: 6 回 / 最終 2026-07-28
```
