### PR TITLE
:sparkles:(claude) stop hook cross-checks the closing counts against board actuals

### DIFF
--- a/chezmoi/dot_local/bin/executable_claude-work-report-check
+++ b/chezmoi/dot_local/bin/executable_claude-work-report-check
@@ -8,6 +8,11 @@
 #   2. a counts line `closed N / created M`; when M > N (budget is
 #      created ≤ closed − 1, projects/CLAUDE.md「board を収束させる」), a
 #      reason must sit on the counts line or the line right after it.
+#   3. (furrow t-64tw) the counts must not contradict the BOARD: actuals come
+#      from `furrow stats -r '' --since <session-start> --json`'s window
+#      (session start = the transcript's first timestamp), and only the lying
+#      directions block — closed overstated, created understated. The board
+#      window includes co-writers, so the honest directions pass untouched.
 # Prose alone (「後で task 化します」) cannot be checked with `furrow show`;
 # ids and numbers can. On violation we emit {"decision":"block","reason":…}
 # so Claude gets exactly one repair round.
@@ -109,5 +114,47 @@ if [ "$created_n" -gt "$closed_n" ]; then
     jq -n --arg c "$closed_n" --arg m "$created_n" '{decision: "block", reason: ("生成予算を超えています（closed \($c) / created \($m)）。projects/CLAUDE.md「board を収束させる」— 予算は created ≤ closed − 1 で、超えてよいのは今日の作業が生んだ blocker だけです。新しい task を (a) その場で直す（effort ≤ 2 かつ今触っているコード内）(b) icebox に落とす（`furrow set <id> -s icebox`・復帰可能）のどちらかに振り直して数字を直すか、超過の理由を counts 行かその直後の行に 1 行添えてください。直したらそのまま停止してよい。")}'
     exit 0
   fi
+fi
+
+# ---- board actuals cross-check (furrow t-64tw) ------------------------------
+# The shape checks above prove the declaration is WELL-FORMED; this one proves
+# it is TRUE where the board can testify. Session boundary: the transcript's
+# first entry timestamp (the Stop payload carries transcript_path — no marker
+# files, no SessionStart plumbing). Actuals: `furrow stats -r '' --since <t0>
+# --json`'s `window` section (created/closed ids inside the window, archive
+# unioned — furrow ≥ #224).
+#
+# Concurrency makes the board window a SUPERSET of this session's flow (other
+# sessions/machines write the same board), so the two directions differ:
+#   - closed_declared > closed_actual: the whole board closed fewer than this
+#     one session claims — definitely overstated. Block.
+#   - created_declared < created_actual: likely an undercount; a co-writer's
+#     ids can also land here. Block ONCE, naming the ids — the repair round
+#     either fixes the count or attributes the foreign ids out loud, and
+#     stop_hook_active bounds it to a single round.
+# Fail-open at every step (no furrow, no board in scope, no transcript, no
+# parsable timestamp): a broken probe must not break every session stop.
+command -v furrow >/dev/null 2>&1 || exit 0
+transcript=$(printf '%s' "$input" | jq -r '.transcript_path // empty')
+[ -n "$transcript" ] && [ -r "$transcript" ] || exit 0
+t0=$(head -20 "$transcript" | jq -r '.timestamp // empty' 2>/dev/null | grep -m1 . || true)
+[ -n "$t0" ] || exit 0
+window=$(furrow stats -r '' --since "$t0" --json 2>/dev/null | jq -c '.window // empty' 2>/dev/null) || exit 0
+[ -n "$window" ] || exit 0
+closed_actual=$(printf '%s' "$window" | jq -r '.closed // empty')
+created_actual=$(printf '%s' "$window" | jq -r '.created // empty')
+case "$closed_actual$created_actual" in *[!0-9]* | "") exit 0 ;; esac
+
+if [ "$closed_n" -gt "$closed_actual" ]; then
+  closed_ids=$(printf '%s' "$window" | jq -r '.closed_ids | join(", ")')
+  jq -n --arg d "$closed_n" --arg a "$closed_actual" --arg ids "$closed_ids" --arg t0 "$t0" --arg q "''" \
+    '{decision: "block", reason: ("締めの closed \($d) 件に対し、board の実数はセッション開始（\($t0)）以降 \($a) 件です（実 ID: \(if $ids == "" then "なし" else $ids end)）。閉じたつもりの task が board に反映されていないか（`furrow done` 忘れ・sync 前）、数え間違いです。`furrow stats -r \($q) --since \($t0) --json` の window で確認し、counts 行を実数に直すか、閉じ漏れを `furrow done` してください。直したらそのまま停止してよい。")}'
+  exit 0
+fi
+if [ "$created_n" -lt "$created_actual" ]; then
+  created_ids=$(printf '%s' "$window" | jq -r '.created_ids | join(", ")')
+  jq -n --arg d "$created_n" --arg a "$created_actual" --arg ids "$created_ids" --arg t0 "$t0" \
+    '{decision: "block", reason: ("締めの created \($d) 件に対し、board の実数はセッション開始（\($t0)）以降 \($a) 件です（実 ID: \($ids)）。起票を数え漏らしていないか確認してください（並走セッションの分が混ざっている場合は、その ID と旨を counts 行の直後に 1 行で明記して数字はそのままでよい）。直したらそのまま停止してよい。")}'
+  exit 0
 fi
 exit 0

--- a/scripts/claude-work-report-check-test.sh
+++ b/scripts/claude-work-report-check-test.sh
@@ -130,6 +130,65 @@ run "壊れた JSON → allow (fail-open)" 'not-json{{' allow
 run "last_assistant_message 欠落 → allow (fail-open)" \
   '{"stop_hook_active": false}' allow
 
+# ---- board 実数照合 (furrow t-64tw) ------------------------------------------
+# 形式が揃った締めは、board が証言できる範囲で数字の真偽も見る。session 境界は
+# transcript 先頭の timestamp、実数は `furrow stats -r '' --since <t0> --json` の
+# window。furrow は PATH shim で偽装し、shape 検査と独立に照合だけを試験する。
+# 並走セッションで実数が膨らむ側（closed の過少申告・created の過大申告）は
+# 通り、嘘の側（closed 過大・created 過少）だけ block になることを両方向で見る。
+
+shimdir=$(mktemp -d)
+transcript=$(mktemp)
+printf '{"timestamp":"2026-08-02T00:00:00Z","type":"summary"}\n' >"$transcript"
+
+mkshim() { # $1=window JSON (or "ERR" to exit 2)
+  if [ "$1" = ERR ]; then
+    printf '#!/bin/sh\nexit 2\n' >"$shimdir/furrow"
+  else
+    printf '#!/bin/sh\nprintf %%s '"'"'{"total":9,"drafts":0,"window":%s}'"'"'\n' "$1" >"$shimdir/furrow"
+  fi
+  chmod +x "$shimdir/furrow"
+}
+
+mkt() { # $1=last_assistant_message → payload carrying the transcript
+  jq -n --arg m "$1" --arg t "$transcript" \
+    '{stop_hook_active: false, last_assistant_message: $m, transcript_path: $t}'
+}
+
+close_msg='やり残し: なし
+closed 2 / created 0'
+
+mkshim '{"created":0,"closed":2,"created_ids":[],"closed_ids":["t-a1","t-b2"]}'
+PATH="$shimdir:$PATH" run "実数一致 → allow" "$(mkt "$close_msg")" allow
+
+mkshim '{"created":0,"closed":1,"created_ids":[],"closed_ids":["t-a1"]}'
+PATH="$shimdir:$PATH" run "closed 過大申告（宣言2/実数1）→ block" "$(mkt "$close_msg")" block
+
+mkshim '{"created":2,"closed":2,"created_ids":["t-x1","t-y2"],"closed_ids":["t-a1","t-b2"]}'
+PATH="$shimdir:$PATH" run "created 過少申告（宣言0/実数2）→ block" "$(mkt "$close_msg")" block
+
+mkshim '{"created":0,"closed":3,"created_ids":[],"closed_ids":["t-a1","t-b2","t-c3"]}'
+PATH="$shimdir:$PATH" run "closed 過少申告（並走分・宣言2/実数3）→ allow" "$(mkt "$close_msg")" allow
+
+mkshim '{"created":1,"closed":2,"created_ids":["t-x1"],"closed_ids":["t-a1","t-b2"]}'
+PATH="$shimdir:$PATH" run "created 過大申告（宣言側が多い）→ allow" \
+  "$(mkt 'やり残し: なし
+closed 2 / created 1
+理由: 今日の作業が生んだ blocker を起票')" allow
+
+mkshim ERR
+PATH="$shimdir:$PATH" run "furrow が exit 2（board 圏外）→ allow (fail-open)" "$(mkt "$close_msg")" allow
+
+mkshim '{"created":0,"closed":1,"created_ids":[],"closed_ids":["t-a1"]}'
+run_no_shim_transcript=$(jq -n --arg m "$close_msg" '{stop_hook_active: false, last_assistant_message: $m, transcript_path: "/nonexistent/transcript"}')
+PATH="$shimdir:$PATH" run "transcript が読めない → allow (fail-open)" "$run_no_shim_transcript" allow
+
+printf 'no timestamps here\n' >"$transcript"
+mkshim '{"created":0,"closed":1,"created_ids":[],"closed_ids":["t-a1"]}'
+PATH="$shimdir:$PATH" run "transcript に timestamp が無い → allow (fail-open)" "$(mkt "$close_msg")" allow
+
+rm -rf "$shimdir" "$transcript"
+
 echo
 if [ "$fail" -eq 0 ]; then
   echo "✅ all $n tests passed"


### PR DESCRIPTION
## What / Why

The closing contract's `closed N / created M` line was enforced as **shape only** — the hook's own header documented that the session boundary was unknowable, so the numbers stayed honest-by-convention. Both halves are now solved (furrow t-64tw):

- **Session boundary**: the Stop payload's `transcript_path` — its first entry timestamp *is* the session start. No marker files, no SessionStart plumbing.
- **Actuals**: `furrow stats -r '' --since <t0> --json` (furrow #224) returns the window's created/closed ids in one call, archive-unioned so a sweep can't deflate `closed`.

The board window includes co-writers (a superset of this session's flow), so only the **lying directions block**:

| direction | verdict |
|---|---|
| closed overstated (declared > board actual) | block — the whole board closed fewer than one session claims |
| created understated (declared < board actual) | block **once**, naming the ids — repair fixes the count or attributes foreign ids out loud; bounded by `stop_hook_active` |
| closed undercounted / created overdeclared | pass — honest under concurrency |

Every probe step fails open (no furrow on PATH, out of board scope, unreadable transcript, no parsable timestamp) — a broken probe must not break every session stop.

## Verify

- `bash scripts/claude-work-report-check-test.sh` → **27/27 green**: 8 new cases drive the cross-check through a PATH `furrow` shim + fake transcript (both blocking directions, both passing directions, three fail-open paths); the 19 existing shape cases run unchanged. CI job `hook-scripts-test` runs it (ci.yml:180).

SetStatus-task: https://github.com/akira-toriyama/projects/blob/main/.furrow/bodies/t-64tw.md done

🤖 Generated with [Claude Code](https://claude.com/claude-code)