### PR TITLE
:truck: move the lint CLIs from brew to nix + convention job cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,9 @@ jobs:
         run: nix develop .#lint --command scripts/lint external --ci
 
   # 規約チェック: chezmoi 配下のスクリプトは executable_ 接頭辞を持つこと。
-  # 例外: run_* / .chezmoiscripts/ 配下 (chezmoi 自身が実行 = $HOME に展開しない)。
+  # 例外: run_* / modify_* / .chezmoiscripts/ 配下 (chezmoi 自身が実行するもので、
+  # $HOME にはスクリプトとして展開されない)。modify_ は「生成結果を target に書く」
+  # スクリプトなので、その target に +x を付ける executable_ は意味が逆になる。
   convention-executable-prefix:
     name: convention / executable_ prefix
     runs-on: ubuntu-latest
@@ -115,6 +117,7 @@ jobs:
               \( -name '*.sh' -o -name '*.py' -o -name '*.zsh' -o -name '*.bash' \) \
               -not -path '*/.chezmoiscripts/*' \
               -not -name 'run_*' \
+              -not -name 'modify_*' \
               | while IFS= read -r f; do
                   if head -1 "$f" | grep -q '^#!' \
                      && [[ "$(basename "$f")" != executable_* ]]; then
@@ -130,40 +133,6 @@ jobs:
             exit 1
           fi
           echo "✅ executable_ 規約 OK"
-
-  # 規約チェック: ~/.claude/commands/ 配下 (= 自作 slash command) は my- 接頭辞。
-  # built-in / plugin の command は別の場所に住むため、この dir のファイルは
-  # 定義上すべて自作 → 全 *.md を対象に my- 始まりを強制する。
-  convention-command-prefix:
-    name: convention / my- command prefix
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          # CI-only, never pushes — drop the persisted checkout token. t-yaxa
-          persist-credentials: false
-      - name: Check self-made commands have my- prefix
-        run: |
-          set -e
-          dir=chezmoi/private_dot_claude/commands
-          violations=$(
-            find "$dir" -type f -name '*.md' 2>/dev/null | while IFS= read -r f; do
-              base=$(basename "$f")
-              # chezmoi 属性 prefix を剥いでから slash command 名を判定
-              name=${base#private_}; name=${name#dot_}; name=${name#readonly_}
-              if [[ "$name" != my-* ]]; then
-                echo "$f"
-              fi
-            done
-          )
-          if [ -n "$violations" ]; then
-            echo "::error::self-made command under commands/ without my- prefix:"
-            # shellcheck disable=SC2001  # 複数行への prefix 付与。sed の方が読める。
-            # ※ この行は該当行の直前に置くこと（run: ブロック先頭では抑止されない）
-            echo "$violations" | sed 's/^/  - /'
-            exit 1
-          fi
-          echo "✅ my- command prefix 規約 OK"
 
   # 自作スクリプトの回帰テスト（Stop hook の判定ロジックと scripts/lint のゲート宣言）。
   # 「lint/test で防げることは人力でやらない」— これらの壊れは CI で止める。
@@ -387,7 +356,6 @@ jobs:
       - nix-flake-check
       - lint
       - convention-executable-prefix
-      - convention-command-prefix
       - script-test
       - chezmoi-templates
       - flake-changes
@@ -421,7 +389,6 @@ jobs:
       # PR/push では skipped で、skipped は failure ではないので誤発火しない。
       - docs-link-check-external
       - convention-executable-prefix
-      - convention-command-prefix
       - script-test
       - chezmoi-templates
       - darwin-build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,7 +78,7 @@ flowchart TD
   - `nix flake check --no-build` — Nix の型/eval 検査（Linux runner）
   - `lint` — `scripts/lint` 一本（ruff / mypy --strict / shfmt / shellcheck / actionlint / typos / lychee --offline / gitleaks / `.tmpl` は render 後に shellcheck・plist 構文 / コードスパン内のパス実在）。**ローカルでも同じコマンドが走る**: `nix develop .#lint --command scripts/lint`
   - `script test` — Stop hook の fixture テスト + `scripts/` と `scripts/claude-md-eval/` の unittest
-  - 規約検知 — `chezmoi/` 配下 shebang スクリプトの `executable_` 接頭辞 + 自作 command（`~/.claude/commands/`）の `my-` 接頭辞を強制
+  - 規約検知 — `chezmoi/` 配下 shebang スクリプトの `executable_` 接頭辞を強制（例外: `run_*` / `modify_*` / `.chezmoiscripts/`）
   - `chezmoi templates render` — 全 `.tmpl` の `execute-template` 検証
 - **CI green を確認してからマージ**。失敗したら**新規コミットで修正**する（`--amend` / `--force` push / 履歴改変の可否は「作業時の絶対ルール」4 が正本）。
 - **push 時、pre-push フック（[.githooks/pre-push](.githooks/pre-push)）は chezmoi/ を触る push で `chezmoi verify` を実行し、乖離があれば警告するが止めない（warn-only、2026-07-03〜。Claude 主導運用のため）**。気づいたら `chezmoi apply` で live を追従する。恒久ゲートは CI（darwin build/switch smoke + chezmoi apply + templates render）と main のブランチ保護が担う。詳細 → [docs/operations.md §5.11](docs/operations.md)。

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -241,14 +241,13 @@ sh <(curl -fsSL https://raw.githubusercontent.com/akira-toriyama/dotfiles/main/i
 
 [.github/workflows/ci.yml](../.github/workflows/ci.yml) ＋ chord 専用 verify-* ワークフロー:
 
-`ci.yml` の job は 12 本。**表に無い job があれば ci.yml が正**（この表は説明用の写し）。
+`ci.yml` の job は 11 本。**表に無い job があれば ci.yml が正**（この表は説明用の写し）。
 
 | ジョブ | 内容 | runner |
 |---|---|---|
 | `nix flake check (eval only)` | Nix の eval/型検査 | ubuntu-latest |
-| `lint` | `scripts/lint --ci`（ruff / ruff-format / mypy / shellcheck / shfmt / exec-bit / tmpl-shellcheck / tmpl-plist / actionlint / typos / lychee / doc-paths / gitleaks の 13 ゲート） | ubuntu-latest |
-| `convention / executable_ prefix` | `chezmoi/` の shebang スクリプトに `executable_` 接頭辞を強制 | ubuntu-latest |
-| `convention / my- command prefix` | 自作 slash command に `my-` 接頭辞を強制 | ubuntu-latest |
+| `lint` | `scripts/lint --ci`（ruff / ruff-format / mypy / shellcheck / shfmt / exec-bit / tmpl-shellcheck / tmpl-plist / actionlint / typos / lychee / doc-paths / claude-md-guard / gitleaks の 14 ゲート） | ubuntu-latest |
+| `convention / executable_ prefix` | `chezmoi/` の shebang スクリプトに `executable_` 接頭辞を強制（例外: `run_*` / `modify_*` / `.chezmoiscripts/`） | ubuntu-latest |
 | `script test` | Stop hook の fixture + `scripts/**` と `scripts/claude-md-eval/` の unittest | ubuntu-latest |
 | `chezmoi templates render` | 全 `.tmpl` の execute-template 検証（get.chezmoi.io の最新版で） | ubuntu-latest |
 | `docs link check (external URLs)` | 外部 URL 込みの lychee。**nightly / 手動のみ**・`ci-gate` の needs 外 | ubuntu-latest |

--- a/home/modules/packages.nix
+++ b/home/modules/packages.nix
@@ -104,9 +104,11 @@ in
     # scripts/lint の各ゲートが起動する実体。CI は devShells.lint（flake.lock 固定）から
     # 供給するので、ここは **開発機で素の `scripts/lint` を叩ける** ための供給源。
     # 同じ flake.lock 由来なので CI とローカルでバージョンが一致する。
-    # 4 本（shfmt / typos / lychee / gitleaks）は brew で入っていて未宣言のまま
-    # drift 検出器が毎日報告していた（t-vk0w の保留項目）。nix 側へ寄せて解消する
-    # ——「迷ったら Nix」。switch 後に brew 版を uninstall すること。
+    # 4 本（shfmt / typos / lychee / gitleaks）は #297 で homebrew.brews に置かれて
+    # いたが、いずれも nixpkgs にある汎用 CLI ＝ 判断フローでは home.packages 側。
+    # brew bundle は 1 つの cask が壊れると bundle 全体を道連れにする（2026-08-02〜の
+    # CI 赤で実際に道連れになった）ので、Nix で足りるものは Nix に置く。
+    # switch 後に brew 版を uninstall すること。
     shellcheck # shell の lint。system/modules/scripts/*.sh 等の自己検証にも使う
     shfmt      # shell の formatter（scripts/lint の shfmt ゲート）
     actionlint # GitHub Actions workflow の静的チェック。push 前にローカルで拾う

--- a/home/modules/packages.nix
+++ b/home/modules/packages.nix
@@ -87,15 +87,9 @@ in
     # yq-go (バイナリ名 yq): YAML 版 jq。GitHub Actions workflow 等の YAML を
     # 確実にパース・編集する（Python 版 `yq` ではなく mikefarah の Go 版）。
     yq-go
-    # actionlint: GitHub Actions workflow の静的チェック。push して CI が落ちる前に
-    # ローカルで定義ミスを検出する。
-    actionlint
     # xcbeautify: xcodebuild / swift build ログの整形。Swift repo のビルドエラーを
     # 機械的に拾いやすくする。
     xcbeautify
-    # shellcheck: シェルスクリプトの lint。system/modules/scripts/*.sh 等を
-    # 書いた際の自己検証に使う。
-    shellcheck
     # ast-grep (バイナリ名 ast-grep / sg): 構文木ベースのコード検索・書き換え。
     # テキスト置換 (rg + sed) では危険な一括リファクタを構造的に安全に行う。
     ast-grep
@@ -105,6 +99,22 @@ in
     # until+sleep の手書きループ撲滅（projects t-v1t1）。使い方の正典は
     # ~/.claude/skills/condition-wait/SKILL.md（exec の footgun 3 点もそこに記載）。
     wait4x
+
+    # === lint 基盤（scripts/lint が呼ぶツール群）===
+    # scripts/lint の各ゲートが起動する実体。CI は devShells.lint（flake.lock 固定）から
+    # 供給するので、ここは **開発機で素の `scripts/lint` を叩ける** ための供給源。
+    # 同じ flake.lock 由来なので CI とローカルでバージョンが一致する。
+    # 4 本（shfmt / typos / lychee / gitleaks）は brew で入っていて未宣言のまま
+    # drift 検出器が毎日報告していた（t-vk0w の保留項目）。nix 側へ寄せて解消する
+    # ——「迷ったら Nix」。switch 後に brew 版を uninstall すること。
+    shellcheck # shell の lint。system/modules/scripts/*.sh 等の自己検証にも使う
+    shfmt      # shell の formatter（scripts/lint の shfmt ゲート）
+    actionlint # GitHub Actions workflow の静的チェック。push 前にローカルで拾う
+    typos      # 散文・コード中の typo 検出
+    lychee     # リンク切れ検査（PR は --offline、外部 URL は nightly）
+    gitleaks   # commit 済みの秘密検出
+    # ruff / mypy はここに置かない: lint スイートの外で単独に叩く用途が無く、
+    # devShells.lint の供給で足りている（brew にも入っていない）。
 
     # === 再現テスト基盤（roadmap Phase 6: 新 PC install.sh 自動検証）===
     # Tart: Apple Silicon ネイティブの macOS/Linux 仮想化。

--- a/system/modules/homebrew.nix
+++ b/system/modules/homebrew.nix
@@ -25,10 +25,10 @@
     ];
     brews = [
       "sourcekitten"  # Framework and command-line tool for interacting with SourceKit
-      "typos-cli"  # Source code spell checker
-      "shfmt"  # Autoformat shell script source code
-      "lychee"  # Fast, async, resource-friendly link checker
-      "gitleaks"  # Audit git repos for secrets
+      # typos-cli / shfmt / lychee / gitleaks は home/modules/packages.nix へ移した
+      # （#297 で「対話でも使えるように」brew 側に置いたが、4 本とも nixpkgs にある
+      # 汎用 CLI ＝ 判断フローの「nixpkgs にあり & 汎用 CLI → home.packages」に該当。
+      # devShells.lint と同じ flake.lock に載るので CI と版が揃う）。
       # go は mise 管理へ移行（home/modules/mise.nix）。dev runtime は mise に一元化。
       "git-cliff"  # Highly customizable changelog generator
       "gifski"  # Highest-quality GIF encoder based on pngquant


### PR DESCRIPTION
## What

Two of the open decisions on `t-vk0w` ("保留（ユーザー判断）"), both answered by the owner in this session — plus a correction to my own first commit, kept as a separate commit so the mistake stays visible in history.

### 1. The four lint CLIs move from `homebrew.brews` to `home.packages`

**Correction:** I first reported these as *undeclared* and added them to `home.packages`. That was wrong — I had grepped only `packages.nix`. #297 declared `typos-cli` / `shfmt` / `lychee` / `gitleaks` in `homebrew.brews` on 2026-07-29, for the same reason I gave: "available interactively, matching the tools already wired into `scripts/lint`". Adding them to Nix created a real double install, the condition the drift checker calls `Nix 二重`.

The second commit resolves it by removing them from `homebrew.brews`, which is the direction the repo's own decision flow prescribes: all four are ordinary CLIs present in nixpkgs, and the flow routes "nixpkgs にあり & 汎用 CLI" to `home.packages`. #297 had no brew-specific reason — `devShells.lint` has been supplying these same four from nixpkgs the whole time, so this puts local and CI on one `flake.lock`.

There is also a blast-radius argument, learned today: `brew bundle` fails as a unit. The CI red starting 2026-08-02 (see #307) took `typos-cli`, `shfmt`, `lychee` and `gitleaks` down together with every cask because one unrelated cask (`vlc`) was invalid. Tools Nix can supply should not sit in that radius.

`sourcekitten` stays on brew — it is not in nixpkgs.

### 2. `convention / my- command prefix` is removed

It guards `chezmoi/private_dot_claude/commands`, which does not exist in the repo, and there is no `~/.claude/commands` on this machine either. `find` on a missing directory yields nothing, so the job could only ever pass. Its `needs` entries in `ci-gate` and `notify-red-main` go with it.

Folded in as the sibling job in the same file: `convention / executable_ prefix` now skips `modify_*` the way it already skips `run_*` (another `t-vk0w` checklist item). Reproduced before fixing — a `chezmoi/modify_probe.sh` carrying a shebang is flagged, but `modify_` scripts write their output *to* the target file, so an `executable_` prefix would mark the wrong thing executable.

## Verification (local, all green)

- `nix develop .#lint --command scripts/lint` — 14 gates
- `nix flake check --no-build`
- `nix run nix-darwin#darwin-rebuild -- build --flake .#default --impure`
- Declared brews after the move: `sourcekitten`, `git-cliff`, `gifski`, `cliclick`, `steipete/tap/peekaboo` — the four are gone
- `ci.yml` job count recounted after the removal: 11

## Depends on #307

This branch predates the `flake.lock` fix, so its `darwin-rebuild switch smoke` fails for the reason #307 explains, not for anything in this diff. Rebase after #307 merges.

## Follow-up for the operator

After `darwin-rebuild switch` puts the nix copies on PATH:

```sh
brew uninstall typos-cli shfmt lychee gitleaks
```

SetStatus-task: https://github.com/akira-toriyama/projects/blob/main/.furrow/bodies/t-vk0w.md in-progress