### PR TITLE
:arrow_up: unbreak CI — bump nix-homebrew for the command_wrapper cask stanza

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,16 +3,16 @@
     "brew-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1784068757,
-        "narHash": "sha256-7KnV7rTlMpys+2J+TFVxUDDyKPLXFs4wIMtckMC72VM=",
+        "lastModified": 1785146564,
+        "narHash": "sha256-Sa7/HrfB04H32OJ7/ofxXjiZEbkWtCNOriONYYTL1OA=",
         "owner": "Homebrew",
         "repo": "brew",
-        "rev": "6bd951d96e7ebc54787799dba77bfb26ec956c4c",
+        "rev": "b2cfc03346d482f79886de108fee5dc49a6efc10",
         "type": "github"
       },
       "original": {
         "owner": "Homebrew",
-        "ref": "6.0.11",
+        "ref": "6.0.13",
         "repo": "brew",
         "type": "github"
       }
@@ -63,11 +63,11 @@
         "brew-src": "brew-src"
       },
       "locked": {
-        "lastModified": 1784159664,
-        "narHash": "sha256-I/B6YoRLImHEqNWh8bs+tPjEDeteACeFhcLyoSMo1GE=",
+        "lastModified": 1785544760,
+        "narHash": "sha256-qV6OoNuly4ntqpCg7esIeJjUboxSnQNlLPxz+y5h9/o=",
         "owner": "zhaofengli",
         "repo": "nix-homebrew",
-        "rev": "842eeb863ecca0eeb463f7a814cdc51e1d925776",
+        "rev": "937ce52c7d046310571f3a070713804ead496843",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## The red

`main` has failed CI on every run since 2026-08-02 (6 consecutive runs, measured via `gh run list`). `darwin-rebuild switch smoke` is the failing job and `ci-gate` follows it, so **no PR in this repo can merge** until this lands.

```
`brew bundle` failed! Failed to fetch sourcekitten, typos-cli, shfmt, lychee, gitleaks, ...
Error: Cask 'vlc' definition is invalid: undefined method 'command_wrapper' for Cask 'vlc'
```

## Why

Cask *definitions* come from the live `homebrew/cask` tap (and `onActivation.autoUpdate = true` deliberately refreshes them every activation). The `brew` that *reads* those definitions is pinned, via `nix-homebrew` → `brew-src`, in `flake.lock`. The `vlc` cask adopted the `command_wrapper` stanza; the pinned brew predates it, so `brew bundle` aborts for the entire bundle — a single upstream cask edit takes the whole activation down with it.

Measured rather than inferred: `Library/Homebrew/cask/artifact/command_wrapper.rb` is a **404** at the old pin `6bd951d` (2026-07-14) and **present** at the new pin `b2cfc03` (2026-07-27).

| input | before | after |
|---|---|---|
| `nix-homebrew` | `842eeb8` (2026-07-15) | `937ce52` (2026-08-01) |
| `nix-homebrew/brew-src` | `6bd951d` (2026-07-14) | `b2cfc03` (2026-07-27) |

## Verification

- `nix flake check --no-build` — green
- `nix run nix-darwin#darwin-rebuild -- build --flake .#default --impure` — green, rebuilds `brew-6.0.13-patched`
- The real proof is this PR's own `darwin-rebuild switch smoke` job, which is the exact step that has been failing

## Not fixed here

Two known tasks own the wider problem and this PR deliberately does not pull them in:

- **t-1p3s** — periodic `flake.lock` bumps (`update-flake-lock`). A scheduled bump is what keeps a pin from drifting 13 days behind the tap it has to parse.
- **t-qehf** — `homebrew-nonfatal.nix`: stop a `brew bundle` failure from killing the whole home-manager activation. Note the fetch list above — `sourcekitten`, `typos-cli`, `shfmt`, `lychee`, `gitleaks` and every cask were dragged down by one bad cask.

SetStatus-task: https://github.com/akira-toriyama/projects/blob/main/.furrow/bodies/t-j09q.md backlog