### PR TITLE
:memo: correct the ultracode note — the settings key does exist

### DIFF
--- a/chezmoi/private_dot_claude/modify_settings.json
+++ b/chezmoi/private_dot_claude/modify_settings.json
@@ -33,12 +33,24 @@
 #      as "claude-opus-4-8[1m]" here; the seed would then quietly ship a stale
 #      generation on every new Mac.
 #      NOTE: effortLevel is seeded as "xhigh", NOT "ultracode". "ultracode"
-#      (= xhigh + automatic workflow orchestration) is session-only by design and
-#      is NOT a persistable effortLevel value: Claude Code accepts only
-#      low/medium/high/xhigh here and normalizes "ultracode" to "xhigh" at
-#      startup, so seeding it never produced a persistent ultracode default. Enter
-#      it per session with /effort ultracode — there is no settings key, env var,
-#      or --effort launch flag that persists it (--effort tops out at max).
+#      (= xhigh + standing dynamic-workflow orchestration) is session-scoped by
+#      design and is not a persistable effortLevel value, so seeding it here
+#      never produced a persistent ultracode default.
+#      There IS a separate boolean settings key named "ultracode" — an earlier
+#      version of this note denied that, wrongly. Measured against the 2.1.214
+#      binary, its own schema says: "Enable ultracode for the session: xhigh
+#      effort plus standing dynamic-workflow orchestration. Session-scoped —
+#      typically provided via --settings or the apply_flag_settings control
+#      request; interactive toggles never persist it. Requires workflows to be
+#      enabled and an xhigh-capable model." So it can be supplied per launch
+#      (claude --settings '{"ultracode":true}'), but nothing seeded into this
+#      file makes it stick — which is why it is not seeded here.
+#      --effort advertises low/medium/high/xhigh/max (measured: an unknown value
+#      warns and lists exactly those five) and additionally accepts "ultracode"
+#      with no warning. Whether that alias also turns on the orchestration half
+#      or merely maps to xhigh is UNMEASURED — a probe was attempted and its
+#      control returned the same answer, so it proved nothing.
+#      Day to day: enter it per session with /effort ultracode.
 #      Seeded ONLY IF ABSENT (jq //=): /model and /effort change the live values
 #      interactively and re-apply must never fight that — this exists so a new
 #      Mac starts on the intended model+effort instead of whatever the installer


### PR DESCRIPTION
## What

The last open item on `t-m8fp` ("ultracode の settings キー周り — 観測方法から設計が要る"). The observation method turned out to be simple: the installed Claude Code binary carries its own settings schema, descriptions included, so the keys can be read directly instead of inferred.

`chezmoi/private_dot_claude/modify_settings.json` is the canonical home for this prose — the ledger's removal record routed it there when the long explanation left the global `CLAUDE.md`. The note there asserted:

> Enter it per session with `/effort ultracode` — **there is no settings key**, env var, or `--effort` launch flag that persists it

That is wrong. Measured against 2.1.214, a boolean settings key named `ultracode` is declared in the same schema as `effortLevel`, described as:

> Enable ultracode for the session: xhigh effort plus standing dynamic-workflow orchestration. Session-scoped — typically provided via `--settings` or the `apply_flag_settings` control request; interactive toggles never persist it. Requires workflows to be enabled and an xhigh-capable model.

The note's *conclusion* held up — nothing seeded into this file makes ultracode stick, so it is still correct not to seed it — but its stated reason was false, and it hid a usable option: a launch can ask for ultracode directly with `claude --settings '{"ultracode":true}'`.

Two more corrections from the same pass:

- **`--effort` advertises five values, not four.** An unknown value warns and lists `low/medium/high/xhigh/max`; the note omitted `max`.
- **`--effort ultracode` is accepted with no warning**, which the note did not mention. Measured A/B: `--effort bogus-level` warns and lists the five valid values, `--effort ultracode` says nothing.

## What is written down as unmeasured

Whether `--effort ultracode` also switches on the orchestration half or merely maps to `xhigh` is recorded as **UNMEASURED**. I probed it by asking headless sessions whether they saw an ultracode system-reminder; the control (a plain session with no ultracode flag) answered the same as the test arms, so the probe discriminated nothing. It is written up as proving nothing rather than as a result.

## Not changed

The global `CLAUDE.md` model section says ultracode is 毎セッション手動 and that a permanent setting is not possible. Measurement agrees with both halves — session-scoped, interactive toggles never persist it — so it is left alone. The byte budget and the ledger-sync gate both stay untouched as a result.

Also measured but not written into the file, since the task body carries it: the keyword path's real settings key is `workflowKeywordTriggerEnabled`. `ultracodeKeywordTrigger` sits beside the display label "Ultracode keyword trigger" and is written to a different store — it is not a settings key.

## Verification

- Ran the script against the live settings before and after the edit — generated output **byte-identical** (it is a comment-only change to a file that generates `~/.claude/settings.json`)
- `nix develop .#lint --command scripts/lint` — 14 gates passed

SetStatus-task: https://github.com/akira-toriyama/projects/blob/main/.furrow/bodies/t-m8fp.md in-progress