### PR TITLE
:bug: stop a mistyped flag from rewriting docs/chord.md

### DIFF
--- a/scripts/claude-md-eval/README.md
+++ b/scripts/claude-md-eval/README.md
@@ -17,7 +17,8 @@ python3 judge.py
 ```
 
 `run.py` が baseline（節なし）と candidate（節あり）の応答を作り、`judge.py` が盲検で
-判定してリリースゲートを適用する。ゲートが通れば exit 0、落ちれば exit 2。
+判定してリリースゲートを適用する。ゲートが通れば exit 0、落ちれば **exit 3**
+（argparse の usage エラー = exit 2 と区別するため。以前は両方 2 だった）。
 
 既定は 16 ケース × 2 試行 × 2 条件 = 応答 64 本、判定 32 ペア。実測で 10 分・$6 前後。
 中断しても `results/responses.jsonl` を見て再開する（完了済みの行は作り直さない）。

--- a/scripts/claude-md-eval/judge.py
+++ b/scripts/claude-md-eval/judge.py
@@ -13,6 +13,14 @@ Two independent signals, on purpose:
 
 The gate refuses a candidate that wins by deleting substance: a net increase in
 judge-flagged information loss blocks release even when the win count is higher.
+
+Exit codes:
+  0  gate passed
+  2  argparse usage error (bad flags) — argparse owns this code
+  3  gate BLOCKED
+
+BLOCKED is 3 rather than 2 so a caller can tell "the release is blocked" apart
+from "you mistyped a flag". Both used to be 2.
 """
 
 from __future__ import annotations
@@ -159,9 +167,15 @@ def judge_one(
         "",
     ]
     for _ in range(retries + 1):
-        p = subprocess.run(
-            cmd, input=prompt, capture_output=True, text=True, timeout=600
-        )
+        try:
+            p = subprocess.run(
+                cmd, input=prompt, capture_output=True, text=True, timeout=600
+            )
+        except subprocess.TimeoutExpired:
+            # 未捕捉だと 1 本のハングが run 全体を道連れにし、既に judge 済みの
+            # verdict まで失われた（書き出しは全 pair 完了後だったため）。
+            # timeout は他の失敗と同じくリトライ対象として扱う。
+            continue
         if p.returncode != 0:
             continue
         try:
@@ -323,15 +337,18 @@ def main(argv: list[str] | None = None) -> int:
         )
     print(f"judging {len(pairs)} pairs", flush=True)
 
-    with ThreadPoolExecutor(max_workers=args.workers) as ex:
-        verdicts = list(
-            ex.map(
-                lambda p: judge_one(p[0][0], p[0][1], p[1], args.model, args.retries),
-                pairs,
-            )
-        )
+    # verdict は 1 件ごとに書き出す。全 pair 完了後に一括保存していたころは、
+    # 終盤の 1 本が落ちるとそれまでの judge 結果（= API 呼び出し数十回分）が
+    # まるごと消えた。逐次書き出しなら中断しても手元に残る。
     args.out.parent.mkdir(parents=True, exist_ok=True)
-    args.out.write_text(json.dumps(verdicts, ensure_ascii=False, indent=2))
+    verdicts = []
+    with ThreadPoolExecutor(max_workers=args.workers) as ex:
+        for v in ex.map(
+            lambda p: judge_one(p[0][0], p[0][1], p[1], args.model, args.retries),
+            pairs,
+        ):
+            verdicts.append(v)
+            args.out.write_text(json.dumps(verdicts, ensure_ascii=False, indent=2))
 
     agg: dict[Any, Any] = defaultdict(lambda: defaultdict(list))
     for r in rows:
@@ -392,7 +409,7 @@ def main(argv: list[str] | None = None) -> int:
     print(f"release gate: {'PASS' if passed else 'BLOCKED'}")
     for r in reasons:
         print(f"  - {r}")
-    return 0 if passed else 2
+    return 0 if passed else 3
 
 
 if __name__ == "__main__":

--- a/scripts/claude-md-eval/judge.py
+++ b/scripts/claude-md-eval/judge.py
@@ -341,13 +341,13 @@ def main(argv: list[str] | None = None) -> int:
     # 終盤の 1 本が落ちるとそれまでの judge 結果（= API 呼び出し数十回分）が
     # まるごと消えた。逐次書き出しなら中断しても手元に残る。
     args.out.parent.mkdir(parents=True, exist_ok=True)
-    verdicts = []
+    verdicts: list[dict[str, Any]] = []
     with ThreadPoolExecutor(max_workers=args.workers) as ex:
-        for v in ex.map(
+        for verdict in ex.map(
             lambda p: judge_one(p[0][0], p[0][1], p[1], args.model, args.retries),
             pairs,
         ):
-            verdicts.append(v)
+            verdicts.append(verdict)
             args.out.write_text(json.dumps(verdicts, ensure_ascii=False, indent=2))
 
     agg: dict[Any, Any] = defaultdict(lambda: defaultdict(list))

--- a/scripts/claude-md-eval/test_eval.py
+++ b/scripts/claude-md-eval/test_eval.py
@@ -7,6 +7,8 @@ quiet mistake turns into a wrong conclusion rather than a visible error.
 """
 
 import json
+import subprocess
+import sys
 import tempfile
 import unittest
 from pathlib import Path
@@ -341,6 +343,30 @@ class TestCases(unittest.TestCase):
         for c in self.cases:
             if "fire_regex" in c:
                 self.assertNotRegex(c["prompt"], c["fire_regex"], c["id"])
+
+
+class ExitCodes(unittest.TestCase):
+    """A blocked gate and a mistyped flag must not look the same to a caller.
+
+    Both used to exit 2. The gate now exits 3; argparse keeps 2.
+    """
+
+    def test_a_usage_error_still_exits_two(self) -> None:
+        p = subprocess.run(
+            [sys.executable, str(HERE / "judge.py"), "--no-such-flag"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(p.returncode, 2, p.stderr)
+        self.assertIn("unrecognized arguments", p.stderr)
+
+    def test_the_blocked_code_is_documented_as_three(self) -> None:
+        # 実際に BLOCKED を出すには judge の run が要るので、契約の側を固定する:
+        # main() の戻り値と README の記述が 3 で揃っていること。
+        source = (HERE / "judge.py").read_text(encoding="utf-8")
+        self.assertIn("return 0 if passed else 3", source)
+        self.assertIn("exit 3", (HERE / "README.md").read_text(encoding="utf-8"))
 
 
 if __name__ == "__main__":

--- a/scripts/gen-chord-doc.py
+++ b/scripts/gen-chord-doc.py
@@ -21,6 +21,7 @@ stdlib のみ。リポジトリルートからの相対パスで動く。
 
 from __future__ import annotations
 
+import argparse
 import re
 import sys
 from pathlib import Path
@@ -176,5 +177,22 @@ def update_doc(check_only: bool = False) -> int:
     return 0
 
 
+def main(argv: list[str] | None = None) -> int:
+    # argparse を挟むのは、素の `"--check" in sys.argv` が **未知フラグを黙って
+    # 書き込みモードに落とす**ため。`--dry-run` や `--chek` と打った人は読み取り
+    # だけのつもりなのに docs/chord.md が書き換わる。argparse なら未知フラグは
+    # usage を出して exit 2 で止まる。
+    ap = argparse.ArgumentParser(
+        description="chord config から docs/chord.md のショートカット表を生成する。"
+    )
+    ap.add_argument(
+        "--check",
+        action="store_true",
+        help="書き換えず、差分があれば exit 1（CI 用）",
+    )
+    args = ap.parse_args(argv)
+    return update_doc(check_only=args.check)
+
+
 if __name__ == "__main__":
-    sys.exit(update_doc(check_only=("--check" in sys.argv[1:])))
+    sys.exit(main())

--- a/scripts/gen-chord-doc.py
+++ b/scripts/gen-chord-doc.py
@@ -179,7 +179,7 @@ def update_doc(check_only: bool = False) -> int:
 
 def main(argv: list[str] | None = None) -> int:
     # argparse を挟むのは、素の `"--check" in sys.argv` が **未知フラグを黙って
-    # 書き込みモードに落とす**ため。`--dry-run` や `--chek` と打った人は読み取り
+    # 書き込みモードに落とす**ため。`--dry-run` や `--check-only` と打った人は読み取り
     # だけのつもりなのに docs/chord.md が書き換わる。argparse なら未知フラグは
     # usage を出して exit 2 で止まる。
     ap = argparse.ArgumentParser(

--- a/scripts/test_gen_chord_doc.py
+++ b/scripts/test_gen_chord_doc.py
@@ -2,7 +2,7 @@
 
 守っているのは 1 点だけ: **未知フラグで書き込みモードに落ちないこと**。
 以前は `check_only=("--check" in sys.argv[1:])` だったので、`--dry-run` や
-`--chek` と打つと「読むだけのつもり」が docs/chord.md の書き換えになった。
+`--check-only` と打つと「読むだけのつもり」が docs/chord.md の書き換えになった。
 生成ロジック本体は verify-chord-doc.yml が `--check` で回している。
 """
 
@@ -38,9 +38,11 @@ class UnknownFlags(unittest.TestCase):
 
     def test_a_near_miss_of_check_does_not_silently_write(self) -> None:
         before = DOC.read_bytes()
-        p = run("--chek")
+        p = run("--check-only")
         self.assertEqual(p.returncode, 2, p.stderr)
-        self.assertEqual(DOC.read_bytes(), before, "doc was modified by a typo")
+        self.assertEqual(
+            DOC.read_bytes(), before, "doc was modified by a near-miss flag"
+        )
 
 
 class CheckMode(unittest.TestCase):

--- a/scripts/test_gen_chord_doc.py
+++ b/scripts/test_gen_chord_doc.py
@@ -1,0 +1,61 @@
+"""gen-chord-doc.py の引数処理のテスト。
+
+守っているのは 1 点だけ: **未知フラグで書き込みモードに落ちないこと**。
+以前は `check_only=("--check" in sys.argv[1:])` だったので、`--dry-run` や
+`--chek` と打つと「読むだけのつもり」が docs/chord.md の書き換えになった。
+生成ロジック本体は verify-chord-doc.yml が `--check` で回している。
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = ROOT / "scripts" / "gen-chord-doc.py"
+DOC = ROOT / "docs" / "chord.md"
+
+
+def run(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+class UnknownFlags(unittest.TestCase):
+    def test_an_unknown_flag_is_a_usage_error_not_a_write(self) -> None:
+        before = DOC.read_bytes()
+        p = run("--dry-run")
+        self.assertEqual(p.returncode, 2, p.stderr)
+        self.assertIn("unrecognized arguments", p.stderr)
+        self.assertEqual(DOC.read_bytes(), before, "doc was modified by a bad flag")
+
+    def test_a_near_miss_of_check_does_not_silently_write(self) -> None:
+        before = DOC.read_bytes()
+        p = run("--chek")
+        self.assertEqual(p.returncode, 2, p.stderr)
+        self.assertEqual(DOC.read_bytes(), before, "doc was modified by a typo")
+
+
+class CheckMode(unittest.TestCase):
+    def test_check_reports_sync_without_writing(self) -> None:
+        before = DOC.read_bytes()
+        p = run("--check")
+        # 0 = 同期済み / 1 = 差分あり。どちらでも書き込んではいけない。
+        self.assertIn(p.returncode, (0, 1), p.stderr)
+        self.assertEqual(DOC.read_bytes(), before)
+
+    def test_help_exits_zero(self) -> None:
+        p = run("--help")
+        self.assertEqual(p.returncode, 0, p.stderr)
+        self.assertIn("--check", p.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Three robustness items from `t-vk0w`'s remaining checklist. They share a theme: a script reporting two different situations identically.

### `gen-chord-doc.py` — an unknown flag meant "write"

```python
sys.exit(update_doc(check_only=("--check" in sys.argv[1:])))
```

Anything that was not exactly `--check` fell through to the write branch. `--dry-run`, `-c`, `--chek` — all of them rewrote `docs/chord.md` while the person typing them was trying to look without touching. argparse now owns the parsing.

Measured before/after:

| invocation | before | after |
|---|---|---|
| `--dry-run` | exit 0, **write mode** | exit 2, `unrecognized arguments` |
| `--check` | exit 0, read-only | unchanged |
| no args | regenerate | unchanged |

### `judge.py` — BLOCKED and "bad flags" were both exit 2

A caller could not tell a blocked release from a typo. BLOCKED is now **3**; argparse keeps 2. The docstring and `README.md` state the contract.

### `judge.py` — an uncaught timeout discarded the whole run

`subprocess.run(..., timeout=600)` raised `TimeoutExpired` uncaught, and verdicts were written only after every pair completed. One hung judge call therefore threw away dozens of finished API calls. Timeouts are now retried like any other failure, and each verdict is written as it lands, so an interrupted run leaves its work on disk.

## Tests

- New `scripts/test_gen_chord_doc.py` (4 tests) pins the flag contract, including that a bad flag leaves `docs/chord.md` byte-identical.
- `test_eval.py` gains 2 for the exit-code split.
- Suites: 51 and 45, both green.
- **Mutation-checked**: reverting the argparse change fails 3 of the 4 new tests, so they bind the behaviour rather than merely running.

SetStatus-task: https://github.com/akira-toriyama/projects/blob/main/.furrow/bodies/t-vk0w.md in-progress