### PR TITLE
:bug: let scripts/lint see files that are not added yet

### DIFF
--- a/scripts/lint
+++ b/scripts/lint
@@ -58,9 +58,21 @@ DEFAULT_GROUPS = sorted(set(GROUPS) - OPT_IN_GROUPS)
 
 
 def tracked(*patterns: str) -> list[str]:
-    """git 管理下のファイルを glob で引く（未追跡・生成物を検査対象にしない）。"""
+    """検査対象のファイルを glob で引く。
+
+    追跡済み **＋ まだ add していない新規ファイル**（`--others --exclude-standard`）。
+    gitignore 済みの生成物は入らない。
+
+    `--others` が要るのは CI と対象集合を一致させるため。`git ls-files` だけだと
+    新規ファイルは commit するまでローカルの lint に見えず、CI では（その時点で
+    追跡済みなので）見える —— 「手元は緑・push すると赤」が新規ファイルに限って
+    起きる。この script はまさにその drift を消すために 1 本にまとめたものなので、
+    ここで漏らすと存在理由が薄くなる。実際に踏んだ: 未追跡の
+    docs/scripts-inventory.md が doc-paths を素通りし、PR #312 の CI で初めて落ちた。
+    """
+    args = ["git", "ls-files", "-z", "--cached", "--others", "--exclude-standard"]
     out = subprocess.run(
-        ["git", "ls-files", "-z", *patterns],
+        [*args, *patterns],
         cwd=ROOT,
         capture_output=True,
         text=True,

--- a/scripts/test_lint.py
+++ b/scripts/test_lint.py
@@ -180,5 +180,30 @@ class TestTemplateDiscovery(unittest.TestCase):
         )
 
 
+class NewFilesAreVisible(unittest.TestCase):
+    """まだ add していないファイルも検査対象に入ること。
+
+    ここが漏れると「手元は緑・push すると赤」が新規ファイルに限って起きる。
+    CI はその時点で追跡済みのファイルを見るので、ローカルだけが盲目になる。
+    実際に踏んだ（PR #312 の doc-paths）ので、性質として固定する。
+    """
+
+    def test_an_unadded_file_is_in_the_target_set(self) -> None:
+        new = ROOT / "zz-lint-visibility-probe.md"
+        self.assertFalse(new.exists(), "probe name collided with a real file")
+        new.write_text("probe\n", encoding="utf-8")
+        try:
+            self.assertIn(new.name, lint.tracked())
+        finally:
+            new.unlink()
+
+    def test_a_gitignored_file_is_not(self) -> None:
+        """--exclude-standard が効いていること。生成物まで拾い始めたら別の壊れ方。"""
+        ignored = ROOT / "result"
+        if not ignored.exists():
+            self.skipTest("no build result symlink present to use as a probe")
+        self.assertNotIn("result", lint.tracked())
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## The gap

`scripts/lint` exists for one reason: so "what I ran locally" and "what CI runs" cannot drift apart. Its file discovery used `git ls-files`, which lists **only what is in the index**.

So a file created but not yet `git add`ed was invisible to the local run — while CI, where the same file arrives committed, checked it. Green here, red there, for new files specifically. That is the exact failure mode the script was consolidated to eliminate.

## How it surfaced

An hour ago, on PR #312. `docs/scripts-inventory.md` was written, `scripts/lint` reported **14 gates passed**, and CI then failed:

```
##[error]repo にこのパスが無い: `scripts/test_modify_settings.py`
##[error]doc-paths failed (exit 1)
```

The doc was untracked at the moment I linted, so `doc-paths` never looked at it.

## The fix

`--others --exclude-standard` on the `git ls-files` call. Measured directly:

```
cached-only sees the probe file?  0
with --others?                    1
```

gitignored build output stays excluded, so `result/` and friends do not start getting linted.

## Tests

Two, in the direction each break would take:

- an unadded file **is** in the target set
- a gitignored path **is not** — picking up build output would be the opposite failure

## On the mutation check

The first attempt reported a pass, which was wrong. `git checkout scripts/lint` had reverted the uncommitted fix along with the mutation, so both runs measured the same unfixed code. Redone with a file copy: with the fix 22 pass, mutated 1 fails. Full suite 61 green, `scripts/lint` 14 gates green.

SetStatus-task: https://github.com/akira-toriyama/projects/blob/main/.furrow/bodies/t-vk0w.md in-progress