### PR TITLE
:memo: record the two mechanisms that enforce the ledger's own rules

### DIFF
--- a/docs/claude-md-ledger.md
+++ b/docs/claude-md-ledger.md
@@ -114,5 +114,6 @@
 
 ## 運用
 
-- global CLAUDE.md にルールを足す・変える・削る PR では、**同一 PR でこの台帳の行（削除なら削除記録）を更新する**。この義務の正本は [dotfiles/CLAUDE.md](../CLAUDE.md) の「global CLAUDE.md / skill の散文を変えるとき」節。
+- global CLAUDE.md にルールを足す・変える・削る PR では、**同一 PR でこの台帳の行（削除なら削除記録）を更新する**。この義務の正本は [dotfiles/CLAUDE.md](../CLAUDE.md) の「global CLAUDE.md / skill の散文を変えるとき」節。強制は `scripts/lint` の `claude-md-guard` ゲート（escape は commit footer `Ledger-unchanged: <理由>`）。
+- global CLAUDE.md が **dotfiles の実ファイル名を裸で参照する箇所**は、リネーム時に同一 PR で追従する。強制は `scripts/lint` の `doc-paths` ゲートの `FLEET_CLAIMS`（`scripts/doc_paths.py`）で、双方向に見る —— 値のパスが実在すること、かつキーが今も文書から言及されていること。**どの名前が対象かはこの台帳に写さない**（`FLEET_CLAIMS` が機械正本）。以前ここに「6 箇所」と件数を書いていたが、0 ベース再構成で参照が減っても数だけ残って嘘になった。
 - 📖 の行の機構化は rule of two を満たすものだけ task 化する。


### PR DESCRIPTION
## What

The last open item on `t-m8fp`: the ledger's 運用 section.

It stated the "update the ledger in the same PR" duty **without saying what enforces it**, and said nothing at all about the second duty the ledger had already taken on — keeping global `CLAUDE.md`'s bare references to dotfiles filenames correct across renames.

Both have gates now, so the section names them:

| duty | gate |
|---|---|
| ledger updated in the same PR as a CLAUDE.md rule change | `claude-md-guard` (escape: `Ledger-unchanged:` footer) |
| filename references followed on rename | `doc-paths` → `FLEET_CLAIMS` in `scripts/doc_paths.py`, checked **both** directions — the path exists, and the key is still mentioned |

## What I deliberately left out, and why

The task asked to write "global CLAUDE.md は dotfiles の実ファイル名を **6 箇所** 参照する（:13/:38/:137/:216/:239/:241）".

That count was already wrong when the task was written — a previous session noted the measured figure was 8 lines and deferred the update. Measuring again today, after the zero-base rewrite, it is **two** lines (`:19` and `:113`), one of which `FLEET_CLAIMS` tracks.

A count in prose sitting next to a machine-readable table is a second source that can only go stale. The section points at `FLEET_CLAIMS` as the authority and records *why* the number was dropped, so nobody re-adds one.

This is the same reasoning as #312's scope note, and the third time today a stale count or checkbox in a task body sent me at a premise that was no longer true.

SetStatus-task: https://github.com/akira-toriyama/projects/blob/main/.furrow/bodies/t-m8fp.md done