### PR TITLE
:bug:(claude-maint) emit a gitmoji subject so the monthly PR stops failing commit-lint

### DIFF
--- a/docs/claude-maint-reports/2026-08.md
+++ b/docs/claude-maint-reports/2026-08.md
@@ -1,0 +1,23 @@
+# Claude ドキュメント保守 2026-08
+
+- 実行: 2026-08-01 10:06:34
+- ⚠️ claude による判断が完了しなかった (rc=1)。使用統計のみ記録。
+
+## 使用統計
+```
+観測期間: 2026-07-18 〜 2026-08-01
+
+### skills (明示起動回数)
+- cli-app-dev: 0 回
+- condition-wait: 1 回 / 最終 2026-07-19
+- github-practices: 0 回
+- go-dev: 2 回 / 最終 2026-07-29
+- mac-app-dev: 0 回
+- macos-gui-verify: 3 回 / 最終 2026-07-28
+- software-architecture: 0 回
+
+### commands (起動回数)
+
+### agents (Agent ツール経由の起動回数)
+- fable-architect: 6 回 / 最終 2026-07-28
+```

--- a/system/modules/scripts/claude-maint.sh
+++ b/system/modules/scripts/claude-maint.sh
@@ -293,14 +293,14 @@ if git diff --cached --quiet; then
   exit 0
 fi
 git -c user.email="claude-maint@noreply" -c user.name="claude-maint" \
-  commit -q -m "chore: monthly Claude docs maintenance (${YM})" \
+  commit -q -m ":memo:(claude) monthly docs maintenance (${YM})" \
   -m "archived: ${moved} / report: ${REPORT_REL}"
 git push -q -u origin "$BRANCH"
 
 # worktree は git remote 設定を共有するので gh は origin を自動検出する。
 PR_URL=$(gh pr create \
   --head "$BRANCH" --base main \
-  --title "chore: Claude docs maintenance ${YM}" \
+  --title ":memo:(claude) monthly docs maintenance ${YM}" \
   --body-file "$WT/$REPORT_REL" 2>&1) || {
   log "gh pr create failed: $PR_URL"
   PR_URL=""


### PR DESCRIPTION
Fixes the generator behind the red monthly maintenance PR.

## What was wrong

`system/modules/scripts/claude-maint.sh` hardcoded the retired Conventional form in two places:

| line | string |
|---|---|
| 296 | `chore: monthly Claude docs maintenance (${YM})` (commit subject) |
| 303 | `chore: Claude docs maintenance ${YM}` (PR title) |

So every monthly run opens a PR that `commit-lint / lint` and `version-preview / verdict`
reject with `malformed-subject`. The first run (#301, 2026-08-01) has been red since.

## Measured

`glyph lint --message`, old vs new:

```
"chore: monthly Claude docs maintenance (2026-08)"   -> exit 3  malformed-subject
":memo:(claude) monthly docs maintenance (2026-08)"  -> exit 0
```

`:memo:` is `none` on the bump lattice, so the maintenance run cannot move the version.

## Also here

`docs/claude-maint-reports/2026-08.md` is re-landed from #301 under a conforming
subject, so the August report survives. **#301 is closed as superseded** — no
force-push, no history rewrite.

## Gates

- `nix develop .#lint --command scripts/lint` — 14 gates passed
- `nix flake check --no-build` — green
- `glyph lint --range origin/main..HEAD` — exit 0

## Not in scope

The August report records `⚠️ claude による判断が完了しなかった (rc=1)` — the judgment
step inside `claude-maint.sh` failed and only usage stats were written. That is a
separate defect from the subject format and is not touched here.

SetStatus-task: https://github.com/akira-toriyama/projects/blob/main/.furrow/bodies/t-aap0.md done