### PR TITLE
:bug:(azookey) make claude the bridge's default engine and give launchd a PATH

### DIFF
--- a/chezmoi/dot_local/share/azookey-bridge/executable_azookey-bridge.py
+++ b/chezmoi/dot_local/share/azookey-bridge/executable_azookey-bridge.py
@@ -8,19 +8,30 @@ JSON 文字列 {"predictions": ["…", …]} しか読まない (OpenAIClient.pa
 ローカル推論エンジンへ渡し、azooKey の期待形で返す。
 
 エンジン (BRIDGE_ENGINE 環境変数):
-- "fm" (既定): 同ディレクトリの fm-predict バイナリ = FoundationModels
-  オンデバイスモデル。~1 秒/回。Apple Intelligence 有効が前提。
-- "claude": claude -p (haiku)。warm でも ~5 秒/回のため不採用だが、
-  FM 不調時の比較用に残す。
+- "claude" (既定): claude -p (haiku)。1 回 4.6-9.7 秒 (中央値 7.3、8 サンプル)。
+- "fm": 同ディレクトリの fm-predict バイナリ = FoundationModels オンデバイス
+  モデル。~1 秒/回と速いが、下記のとおり品質が実用に達しない。比較用。
+
+既定を fm から claude へ移した理由 (2026-08-03 実測、azooKeyMac バイナリから
+復元した実 stock プロンプトで A/B):
+
+- 8 ケース中、claude は 8 正解 / fm は 1-2 正解。fm が当たるのは入力が stock の
+  few-shot 例と字面一致した時だけで、「明日の会議を<えんき>」は天気の候補を、
+  「また明日<えいご>」「よろしくお願いします<ちゅうごくご>」は言語名を無視した
+  日本語を返す。「ありがとう<えいご>」は 3/3 でスペイン語 (stock 最終例の丸写し)。
+- 例文の模倣を断つプロンプトを 2 種書いて fm に投げると 0/5 まで悪化する
+  (<ふらんすご> すら日本語になる)。つまり例文の丸写しが唯一の正解経路で、
+  オンデバイス FM はこのタスク自体を実行できていない。
+- 速度で fm を選んでいた元の判断 (#246) は、品質を測る前のものだった。
 
 これは upstream 修正 (azooKey-Desktop のプロンプト改善、projects t-22se) が
-リリースされるまでのつなぎ。恒久対応後は backend を Foundation Models に
-戻してこのブリッジごと退役させる。設計と検証ログは projects t-85fn。
+リリースされるまでのつなぎ。設計と検証ログは projects t-85fn。
 """
 
 import json
 import os
 import re
+import shutil
 import subprocess
 import sys
 import time
@@ -28,7 +39,7 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 HOST = "127.0.0.1"
 PORT = 8787
-ENGINE = os.environ.get("BRIDGE_ENGINE", "fm")
+ENGINE = os.environ.get("BRIDGE_ENGINE", "claude")
 FM_PREDICT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "fm-predict")
 CLAUDE_MODEL = "haiku"
 
@@ -100,8 +111,18 @@ def run_engine(prompt: str) -> list[str]:
     if ENGINE == "fm":
         cmd, timeout = [FM_PREDICT], 15
     else:
+        # launchd の既定 PATH (/usr/bin:/bin:/usr/sbin:/sbin) には claude が
+        # 無い (実体は ~/.local/bin)。PATH は plist の EnvironmentVariables が
+        # 与えるが、欠けたときに FileNotFoundError で終わると原因が読めないので
+        # ここで名指しにする。
+        claude = shutil.which("claude")
+        if claude is None:
+            raise RuntimeError(
+                "claude not found in PATH="
+                f"{os.environ.get('PATH', '')!r} — see the LaunchAgent plist"
+            )
         cmd = [
-            "claude",
+            claude,
             "-p",
             "--model",
             CLAUDE_MODEL,

--- a/chezmoi/private_Library/LaunchAgents/com.akira-toriyama.azookey-bridge.plist.tmpl
+++ b/chezmoi/private_Library/LaunchAgents/com.akira-toriyama.azookey-bridge.plist.tmpl
@@ -9,6 +9,14 @@
 		<string>/usr/bin/python3</string>
 		<string>{{ .chezmoi.homeDir }}/.local/share/azookey-bridge/azookey-bridge.py</string>
 	</array>
+	<key>EnvironmentVariables</key>
+	<dict>
+		<!-- 既定エンジン claude の実体は ~/.local/bin/claude。launchd が渡す
+		     既定 PATH (/usr/bin:/bin:/usr/sbin:/sbin) では見えず、Ctrl+S が
+		     毎回 500 になるため明示する。 -->
+		<key>PATH</key>
+		<string>{{ .chezmoi.homeDir }}/.local/bin:/run/current-system/sw/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+	</dict>
 	<key>RunAtLoad</key>
 	<true/>
 	<key>KeepAlive</key>


### PR DESCRIPTION
## Why

The azooKey MagicConversion bridge shipped with `fm` (on-device FoundationModels) as its default engine. Measured against the real stock prompt — recovered from the `azooKeyMac` binary rather than reconstructed by hand — that engine only answers correctly when the input matches azooKey's own few-shot examples verbatim.

| case | fm (~1.1s) | claude haiku (4.6–9.7s, median 7.3) |
|---|---|---|
| `明日の会議を<えんき>` | weather candidates | 延期 / 先延ばし / … |
| `また明日<えいご>` | Japanese | See you tomorrow / … |
| `よろしくお願いします<ちゅうごくご>` | Japanese | 请多关照 / … |
| `ありがとう<えいご>` | Spanish, 3/3 | Thank you / … |
| 8 cases total | 1–2 correct | **8 correct** |

Two prompt rewrites aimed at breaking the copying make `fm` *worse* (0/5 — even `<ふらんすご>` returns Japanese), so verbatim copying was the only path to a correct answer: the on-device model cannot perform this task. The original speed-based decision (#246) predates any quality measurement.

## What

- `BRIDGE_ENGINE` default `fm` → `claude`. `fm` stays reachable for comparison.
- LaunchAgent plist sets `PATH` explicitly. Without it the switch would have shipped a bridge that 500s on every Ctrl+S: launchd hands the agent `/usr/bin:/bin:/usr/sbin:/sbin` and `claude` lives in `~/.local/bin`.
- The bridge names the missing binary instead of dying on a bare `FileNotFoundError`.
- The docstring records the measurement, so the next reader does not re-litigate the engine choice from latency alone.

## Verification

- Bridge run under the environment the agent actually receives — read off the live pid with `ps eww`, not assumed; `launchctl print` omits `USER`/`HOME`/`LOGNAME`, and an `env -i` test that dropped `USER` made `claude` exit 1 with `Not logged in` — on `/usr/bin/python3` 3.9.6: 4/4 correct.
- After `chezmoi apply`, against the real launchd agent on :8787: 3/3 correct, 6.6–8.4s. Agent `PATH` confirmed on the new pid.
- `nix develop .#lint --command scripts/lint`: 14 gates pass. `chezmoi verify`: clean.

Live `aiBackend` had been switched to `"Off"` by hand on 2026-07-22 and left there; it is back to `"OpenAI API"`. In-IME Ctrl+S verification is the remaining step and is tracked on the task.

SetStatus-task: https://github.com/akira-toriyama/projects/blob/main/.furrow/bodies/t-85fn.md in-progress

🤖 Generated with [Claude Code](https://claude.com/claude-code)