### PR TITLE
:sparkles: guard glossary sync beside the ledger sync

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,9 @@ global `~/.claude/CLAUDE.md` の source はこの repo（`chezmoi/private_dot_cl
   編集は対象外。全面改稿は `--baseline`（旧版 vs 新版の 2 腕）で測る。
 - ルールを足す・削る・移す PR は [docs/claude-md-ledger.md](docs/claude-md-ledger.md) の
   該当行（削除なら削除記録節）を**同一 PR で**更新する。
+- CLAUDE.md か skills/ に触る PR は [docs/glossary.md](docs/glossary.md) の該当語も**同一
+  PR で**追従させる（不要なら commit footer `Glossary-unchanged: <理由>`）。台帳と対の
+  義務で、どちらも lint ゲート claude-md-guard が強制する。
 - global CLAUDE.md の肥大を再演しない: 追加は「既に踏んだ失敗の再発防止」だけ
   （global の機構化ルールと同じ基準を散文にも適用する）。
 

--- a/docs/claude-md-ledger.md
+++ b/docs/claude-md-ledger.md
@@ -60,7 +60,7 @@
 
 ### この台帳自身の機構（2026-07-28〜）
 
-- **CLAUDE.md サイズ上限（11,500 bytes）・具体 model ID pin 禁止・台帳同期（CLAUDE.md に触る PR は台帳も触る。escape = commit footer `Ledger-unchanged: <理由>`）** は lint ゲート claude-md-guard（[scripts/claude_md_guard.py](../scripts/claude_md_guard.py)・CI の `lint` job で毎 PR 実行）が強制する 🔒。どれも既に踏んだ失敗（21 倍肥大・pin ずれ・PR #274 の台帳更新漏れ）の再発防止で rule of two 適合。
+- **CLAUDE.md サイズ上限（11,500 bytes）・具体 model ID pin 禁止・台帳同期（CLAUDE.md に触る PR は台帳も触る。escape = commit footer `Ledger-unchanged: <理由>`）・glossary 同期（CLAUDE.md か skills/ に触る PR は docs/glossary.md も触る。escape = commit footer `Glossary-unchanged: <理由>`）** は lint ゲート claude-md-guard（[scripts/claude_md_guard.py](../scripts/claude_md_guard.py)・CI の `lint` job で毎 PR 実行）が強制する 🔒。どれも既に踏んだ失敗（21 倍肥大・pin ずれ・PR #274 の台帳更新漏れ・同日の PR #273 の glossary 追従漏れ）の再発防止で rule of two 適合。
 
 ## 削除記録（0 ベース再構成 2026-07-28・旧版 = `92e19cc`）
 

--- a/scripts/claude_md_guard.py
+++ b/scripts/claude_md_guard.py
@@ -12,6 +12,10 @@
    触る（PR #274 が同一 PR 更新を落とした実績）。escape は commit footer
    `Ledger-unchanged: <理由>`。origin/main が引けない環境では skip
    （lint job は fetch-depth: 0 なので CI では常に引ける）。
+4. glossary 同期 — CLAUDE.md か skills/ に触る変更は docs/glossary.md も
+   同一 PR で触る（#274 と同じ日に PR #273 が glossary 追従を落とした実績 —
+   台帳と対の散文ルールで、台帳側だけ機構化されて glossary 側が残っていた）。
+   escape は commit footer `Glossary-unchanged: <理由>`。skip 条件は 3 と同じ。
 """
 
 from __future__ import annotations
@@ -25,6 +29,8 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parent.parent
 CLAUDE_MD = "chezmoi/private_dot_claude/CLAUDE.md"
 LEDGER = "docs/claude-md-ledger.md"
+GLOSSARY = "docs/glossary.md"
+SKILLS_DIR = "chezmoi/private_dot_claude/skills/"
 SETTINGS = "chezmoi/private_dot_claude/modify_settings.json"
 
 # 2026-07-28 の 0 ベース着地 10,180 bytes + 約 13% の余裕。上げる時は「何を足す
@@ -35,6 +41,7 @@ SIZE_LIMIT_BYTES = 11_500
 MODEL_ID_RE = re.compile(r"claude-(?:opus|sonnet|haiku|fable)-[0-9][0-9a-z-]*")
 
 LEDGER_ESCAPE_RE = re.compile(r"^Ledger-unchanged:", re.MULTILINE)
+GLOSSARY_ESCAPE_RE = re.compile(r"^Glossary-unchanged:", re.MULTILINE)
 
 
 def check_size(errors: list[str]) -> None:
@@ -93,6 +100,35 @@ def check_ledger_sync(errors: list[str]) -> str | None:
     return None
 
 
+def touches_glossary_sources(changed: list[str]) -> bool:
+    """glossary 追従義務のある source に触れているか（CLAUDE.md か skills/）。"""
+    return CLAUDE_MD in changed or any(p.startswith(SKILLS_DIR) for p in changed)
+
+
+def check_glossary_sync(errors: list[str]) -> str | None:
+    """CLAUDE.md / skills に触る変更（commit 済み + 作業樹）は glossary も触ること。
+
+    台帳同期（check_ledger_sync）と対のルール。#274 が台帳を落としたのと同じ日に
+    #273 が glossary を落としており、台帳側だけ機構化されて glossary 側が散文の
+    ままだった。skip 契約は台帳側と同一。
+    """
+    base = git_lines("merge-base", "origin/main", "HEAD")
+    if base is None:
+        return "origin/main が引けないため glossary 同期チェックを skip"
+    changed = git_lines("diff", "--name-only", base[0])
+    if changed is None:
+        return "git diff が失敗したため glossary 同期チェックを skip"
+    if touches_glossary_sources(changed) and GLOSSARY not in changed:
+        msgs = git_lines("log", "--format=%B", f"{base[0]}..HEAD") or []
+        if not GLOSSARY_ESCAPE_RE.search("\n".join(msgs)):
+            errors.append(
+                f"CLAUDE.md / skills に触る変更が {GLOSSARY} を更新していない — "
+                "同一 PR で glossary の該当語を追従させるか、footer "
+                "`Glossary-unchanged: <理由>` を commit に書く"
+            )
+    return None
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--ci", action="store_true", help="GitHub annotations で出力")
@@ -101,9 +137,9 @@ def main() -> int:
     errors: list[str] = []
     check_size(errors)
     check_model_pin(errors)
-    skipped = check_ledger_sync(errors)
-    if skipped:
-        print(f"  note: {skipped}")
+    for skipped in (check_ledger_sync(errors), check_glossary_sync(errors)):
+        if skipped:
+            print(f"  note: {skipped}")
 
     for e in errors:
         print(f"::error ::{e}" if args.ci else f"  {e}")

--- a/scripts/test_claude_md_guard.py
+++ b/scripts/test_claude_md_guard.py
@@ -37,6 +37,36 @@ class LedgerEscape(unittest.TestCase):
         )
 
 
+class GlossaryEscape(unittest.TestCase):
+    def test_footer_matches_at_line_start_only(self) -> None:
+        self.assertIsNotNone(
+            guard.GLOSSARY_ESCAPE_RE.search("subject\n\nGlossary-unchanged: typo only")
+        )
+        self.assertIsNone(
+            guard.GLOSSARY_ESCAPE_RE.search("mentions Glossary-unchanged: mid-line")
+        )
+
+
+class GlossarySources(unittest.TestCase):
+    def test_claude_md_and_skills_trigger(self) -> None:
+        self.assertTrue(guard.touches_glossary_sources([guard.CLAUDE_MD]))
+        self.assertTrue(
+            guard.touches_glossary_sources(
+                ["chezmoi/private_dot_claude/skills/go-dev/SKILL.md"]
+            )
+        )
+
+    def test_everything_else_does_not(self) -> None:
+        for changed in (
+            [],
+            ["scripts/claude_md_guard.py"],
+            ["docs/glossary.md"],
+            # prefix であって substring ではない — skills の文字列を含む無関係パス
+            ["docs/skills-note.md"],
+        ):
+            self.assertFalse(guard.touches_glossary_sources(changed), changed)
+
+
 class SizeCheck(unittest.TestCase):
     def test_current_file_is_within_limit(self) -> None:
         # ゲートの本丸: いま管理下にある CLAUDE.md が上限内であること。


### PR DESCRIPTION
## What (t-vk0w の最終残項目)

2026-07-27 に #274 が台帳追従を、同日 #273 が glossary 追従を落とした — 一つの散文ルールの両半分。台帳側は claude-md-guard のゲートになり、glossary 側は散文のまま残っていた。この PR でその片割れを機構化する:

- `chezmoi/private_dot_claude/CLAUDE.md` か `skills/` に触る変更は、同一 PR で `docs/glossary.md` も触る。escape は commit footer `Glossary-unchanged: <理由>`(台帳側の `Ledger-unchanged:` と同一契約・skip 条件も同一)。
- 予告どおり claude-md-guard に第 4 チェックとして同居(scripts/lint の既存 gate、CI 変更なし)。
- CLAUDE.md の義務節と台帳の強制状態行を同 PR で追従。

## Verify

- `nix develop .#lint --command scripts/lint` → 13 gates passed
- A/B 実測: skills を触って glossary 未更新 → rc=1、clean tree → rc=0
- unit 8 件(escape footer の行頭一致・trigger 集合の prefix 判定含む)

SetStatus-task: https://github.com/akira-toriyama/projects/blob/main/.furrow/bodies/t-vk0w.md in-progress

🤖 Generated with [Claude Code](https://claude.com/claude-code)