### PR TITLE
:sparkles:(claude) refuse a fan-out that names a sibling worktree of the session repo

### DIFF
--- a/chezmoi/dot_local/bin/executable_claude-fanout-cwd-guard
+++ b/chezmoi/dot_local/bin/executable_claude-fanout-cwd-guard
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# claude-fanout-cwd-guard — PreToolUse guard for Agent/Workflow fan-out.
+#
+# Refuses a fan-out whose input points at ANOTHER WORKTREE OF THE SAME
+# REPOSITORY as the session's cwd, because the subagents will not read it.
+#
+# Why this exists. A subagent's working directory IS the parent session's cwd:
+# there is no cwd parameter on the Agent tool, none in an agent definition, and
+# a path written into the prompt does not steer it. Measured 2026-08-10 on a
+# 17-agent furrow review: the prompt named a worktree checked out at
+# origin/main, and 0 of 17 agents read it while 17 of 17 read the session's own
+# checkout — which was parked 7 commits behind for a schema flag day. Every
+# finding, ~2M output tokens, and 21 tasks written to the shared board were
+# against the wrong tree and had to be discarded. The session had ALREADY
+# detected the staleness and built the worktree as a work-around; the
+# work-around is what silently did nothing. So the check has to refuse the
+# fan-out, not warn about the repo.
+#
+# Scope is deliberately narrow — a sibling worktree of the SAME repo only.
+# That is the confusable case: identical relative paths, identical file names,
+# and findings that look correct at every line. A path in a DIFFERENT
+# repository is an ordinary cross-repo reference and is allowed, because
+# denying those would fire constantly and a guard that cries wolf gets
+# bypassed.
+#
+# Fail-open by construction: no jq, unparseable stdin, cwd outside a work tree,
+# or any git error → allow. A guard that blocks work when it is itself broken
+# would be removed within a day. Escape hatch for a deliberate cross-tree run:
+# CLAUDE_ALLOW_CROSS_TREE_FANOUT=1.
+#
+# Owned by dotfiles (chezmoi → ~/.local/bin/claude-fanout-cwd-guard); wired
+# from the Claude PreToolUse hook in modify_settings.json.
+set -u
+
+command -v jq >/dev/null 2>&1 || exit 0
+[ "${CLAUDE_ALLOW_CROSS_TREE_FANOUT:-}" = "1" ] && exit 0
+
+payload=$(cat) || exit 0
+[ -n "$payload" ] || exit 0
+printf '%s' "$payload" | jq -e . >/dev/null 2>&1 || exit 0
+
+tool=$(printf '%s' "$payload" | jq -r '.tool_name // ""')
+case "$tool" in
+Task | Agent | Workflow) ;;
+*) exit 0 ;;
+esac
+
+cwd=$(printf '%s' "$payload" | jq -r '.cwd // ""')
+[ -n "$cwd" ] || cwd=$PWD
+[ -d "$cwd" ] || exit 0
+
+# The session's own tree, and the repository it belongs to. Linked worktrees of
+# one repository share a common git dir; that is what makes "same repo,
+# different tree" decidable without touching the network.
+here=$(git -C "$cwd" rev-parse --show-toplevel 2>/dev/null) || exit 0
+[ -n "$here" ] || exit 0
+here_common=$(cd "$cwd" 2>/dev/null && git rev-parse --git-common-dir 2>/dev/null) || exit 0
+[ -n "$here_common" ] || exit 0
+here_common=$(cd "$cwd" && cd "$here_common" 2>/dev/null && pwd -P) || exit 0
+
+# Candidate paths named anywhere in the tool input (prompt, script, args).
+candidates=$(printf '%s' "$payload" |
+  jq -r '.tool_input // {} | tostring' 2>/dev/null |
+  grep -oE '/[A-Za-z0-9._@+-]+(/[A-Za-z0-9._@+-]+)*' |
+  sort -u | head -n 40) || exit 0
+[ -n "$candidates" ] || exit 0
+
+offender=''
+while IFS= read -r p; do
+  [ -n "$p" ] || continue
+  [ -d "$p" ] || p=$(dirname "$p")
+  [ -d "$p" ] || continue
+  top=$(git -C "$p" rev-parse --show-toplevel 2>/dev/null) || continue
+  [ -n "$top" ] || continue
+  [ "$top" = "$here" ] && continue
+  common=$(cd "$p" 2>/dev/null && git rev-parse --git-common-dir 2>/dev/null) || continue
+  common=$(cd "$p" && cd "$common" 2>/dev/null && pwd -P) || continue
+  # Same repository, different working tree — the confusable case.
+  if [ "$common" = "$here_common" ]; then
+    offender=$top
+    break
+  fi
+done <<EOF
+$candidates
+EOF
+
+[ -n "$offender" ] || exit 0
+
+here_rev=$(git -C "$here" rev-parse --short HEAD 2>/dev/null || printf '?')
+there_rev=$(git -C "$offender" rev-parse --short HEAD 2>/dev/null || printf '?')
+
+reason=$(printf '%s' "サブエージェントは cwd を継ぐため、この fan-out は指定した木を読みません。
+  session cwd : ${here} (${here_rev})
+  指定された木: ${offender} (${there_rev})
+同一 repo の別 worktree なので、読み違えても出力は正しく見えます（2026-08-10 に実測: 17 体中 0 体しか指定した木を読まず、全結果を破棄）。
+対処: 対象 checkout でセッションを開き直すか /cd で移ってから fan-out する。パスを prompt で渡す方式は効きません。
+意図的に別の木を指している場合のみ CLAUDE_ALLOW_CROSS_TREE_FANOUT=1 を付けて再実行。")
+
+jq -n --arg r "$reason" '{
+  hookSpecificOutput: {
+    hookEventName: "PreToolUse",
+    permissionDecision: "deny",
+    permissionDecisionReason: $r
+  }
+}'
+exit 0

--- a/chezmoi/dot_local/bin/executable_claude-fanout-cwd-guard
+++ b/chezmoi/dot_local/bin/executable_claude-fanout-cwd-guard
@@ -28,6 +28,14 @@
 # would be removed within a day. Escape hatch for a deliberate cross-tree run:
 # CLAUDE_ALLOW_CROSS_TREE_FANOUT=1.
 #
+# Two known blind spots, stated rather than left to be discovered. Both make the
+# guard MISS a bad fan-out; neither makes it stop a good one:
+#   - a worktree path containing a SPACE is not extracted (paths are lifted out
+#     of the tool input by pattern, and the input is prose, so a space cannot be
+#     told from a word break). Measured: such a path is allowed through.
+#   - at most CANDIDATE_LIMIT distinct path-shaped strings are examined, so a
+#     fan-out naming more than that could hide the offender past the cut.
+#
 # Owned by dotfiles (chezmoi → ~/.local/bin/claude-fanout-cwd-guard); wired
 # from the Claude PreToolUse hook in modify_settings.json.
 set -u
@@ -59,16 +67,20 @@ here_common=$(cd "$cwd" 2>/dev/null && git rev-parse --git-common-dir 2>/dev/nul
 here_common=$(cd "$cwd" && cd "$here_common" 2>/dev/null && pwd -P) || exit 0
 
 # Candidate paths named anywhere in the tool input (prompt, script, args).
+# The limit bounds the git calls below; the stat filter in the loop is what
+# keeps the common case (a prose prompt full of non-paths) cheap.
+CANDIDATE_LIMIT=200
 candidates=$(printf '%s' "$payload" |
   jq -r '.tool_input // {} | tostring' 2>/dev/null |
   grep -oE '/[A-Za-z0-9._@+-]+(/[A-Za-z0-9._@+-]+)*' |
-  sort -u | head -n 40) || exit 0
+  sort -u | head -n "$CANDIDATE_LIMIT") || exit 0
 [ -n "$candidates" ] || exit 0
 
 offender=''
 while IFS= read -r p; do
   [ -n "$p" ] || continue
-  [ -d "$p" ] || p=$(dirname "$p")
+  [ -d "$p" ] || p=${p%/*} # a file: fall back to its directory (no subshell)
+  [ -n "$p" ] || continue
   [ -d "$p" ] || continue
   top=$(git -C "$p" rev-parse --show-toplevel 2>/dev/null) || continue
   [ -n "$top" ] || continue

--- a/chezmoi/private_dot_claude/modify_settings.json
+++ b/chezmoi/private_dot_claude/modify_settings.json
@@ -2,7 +2,7 @@
 # chezmoi modify_ script for ~/.claude/settings.json.
 #
 # chezmoi pipes the CURRENT settings.json on stdin; our stdout becomes the new
-# file. We ensure exactly SEVEN things and pass everything else (the permissions
+# file. We ensure exactly EIGHT things and pass everything else (the permissions
 # the user accumulates interactively, plugins, env, other hooks) through
 # untouched:
 #   1. a SessionStart hook that runs git-stale-check (so an agent sees a
@@ -72,6 +72,18 @@
 #      opening context. The lint's other firing points (pre-push, post-merge)
 #      only reach sessions inside the projects checkout; this is the surface
 #      that reaches sessions starting in any repo. Fail-open; see its header.
+#   8. a PreToolUse hook that runs claude-fanout-cwd-guard on Agent/Workflow
+#      calls — DENIES a fan-out whose input names another worktree of the SAME
+#      repository as the session cwd. A subagent's working directory is the
+#      parent session's cwd and no parameter changes it, so such a fan-out
+#      silently reads the wrong tree: measured 2026-08-10, 0 of 17 agents read
+#      the worktree named in their prompt and 17 read the session's own
+#      7-commits-behind checkout, costing ~2M tokens and 21 discarded board
+#      tasks. This is the only one of the eight that can BLOCK, because that
+#      session had already detected the staleness and built the worktree as a
+#      work-around — a warning was not what was missing. Fail-open, and
+#      CLAUDE_ALLOW_CROSS_TREE_FANOUT=1 is the deliberate-run escape; see its
+#      header for why the scope is same-repo-only.
 #
 # Idempotent: each hook and each allow entry is added only if absent (the allow
 # merge is a set-union), so re-apply never duplicates and the user's own edits
@@ -91,6 +103,8 @@ cmd_stop='$HOME/.local/bin/claude-work-report-check'
 cmd_quota='$HOME/.local/bin/claude-quota-note'
 # shellcheck disable=SC2016  # same: literal $HOME, expanded at hook run
 cmd_pjlint='$HOME/.local/bin/claude-projects-lint-note'
+# shellcheck disable=SC2016  # same: literal $HOME, expanded at hook run
+cmd_fanout='$HOME/.local/bin/claude-fanout-cwd-guard'
 
 input=$(cat)
 [ -n "$input" ] || input='{}'
@@ -100,11 +114,12 @@ if ! command -v jq >/dev/null 2>&1 || ! printf '%s' "$input" | jq -e . >/dev/nul
   exit 0
 fi
 
-out=$(printf '%s\n' "$input" | jq --arg cmd "$cmd" --arg stop "$cmd_stop" --arg quota "$cmd_quota" --arg pjlint "$cmd_pjlint" '
+out=$(printf '%s\n' "$input" | jq --arg cmd "$cmd" --arg stop "$cmd_stop" --arg quota "$cmd_quota" --arg pjlint "$cmd_pjlint" --arg fanout "$cmd_fanout" '
   def hook_present: [ (.hooks.SessionStart // [])[]?.hooks[]?.command ] | any(. == $cmd);
   def stop_hook_present: [ (.hooks.Stop // [])[]?.hooks[]?.command ] | any(. == $stop);
   def quota_hook_present: [ (.hooks.SessionStart // [])[]?.hooks[]?.command ] | any(. == $quota);
   def pjlint_hook_present: [ (.hooks.SessionStart // [])[]?.hooks[]?.command ] | any(. == $pjlint);
+  def fanout_hook_present: [ (.hooks.PreToolUse // [])[]?.hooks[]?.command ] | any(. == $fanout);
 
   ( if hook_present then .
     else
@@ -129,6 +144,12 @@ out=$(printf '%s\n' "$input" | jq --arg cmd "$cmd" --arg stop "$cmd_stop" --arg 
           (.hooks //= {})
         | (.hooks.SessionStart //= [])
         | (.hooks.SessionStart += [ { hooks: [ { type: "command", command: $pjlint } ] } ])
+      end )
+  | ( if fanout_hook_present then .
+      else
+          (.hooks //= {})
+        | (.hooks.PreToolUse //= [])
+        | (.hooks.PreToolUse += [ { matcher: "Task|Agent|Workflow", hooks: [ { type: "command", command: $fanout } ] } ])
       end )
   | (.permissions //= {})
   | (.permissions.allow //= [])

--- a/scripts/test_claude_fanout_cwd_guard.py
+++ b/scripts/test_claude_fanout_cwd_guard.py
@@ -1,0 +1,209 @@
+"""claude-fanout-cwd-guard の判定テスト。
+
+この guard は 8 つの Claude hook のうち唯一 **作業を止められる**ので、壊れ方が
+非対称になる。誤って止める（うるさい）と外されて終わり、止め損なう（黙る）と
+2026-08-10 の事故がそのまま再発する —— 17 体中 0 体しか指定した木を読まず、
+約 200 万 token と board への 21 件が全部無駄になった件。
+
+なのでここで固定するのは境界そのもの:
+
+  止める  : 同一 repo の別 worktree を指した Agent / Workflow の fan-out
+  止めない: 別 repo のパス / 自分の木のパス / 対象外の tool / git 管理外 /
+            jq や stdin が壊れている / 明示の環境変数による解除
+
+git は fetch 不要なローカル repo だけで組み、ネットワークに依存させない。
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = ROOT / "chezmoi" / "dot_local" / "bin" / "executable_claude-fanout-cwd-guard"
+
+
+def git(cwd: Path, *args: str) -> str:
+    p = subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        check=True,
+        env={
+            **os.environ,
+            "GIT_CONFIG_GLOBAL": "/dev/null",
+            "GIT_CONFIG_SYSTEM": "/dev/null",
+        },
+    )
+    return p.stdout
+
+
+def commit(repo: Path, name: str) -> None:
+    (repo / name).write_text(name, encoding="utf-8")
+    git(repo, "add", name)
+    git(repo, "-c", "user.name=t", "-c", "user.email=t@e", "commit", "-qm", name)
+
+
+class FanoutCwdGuard(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+        self.repo = self.root / "repo"
+        git(self.root, "init", "-q", "-b", "main", str(self.repo))
+        commit(self.repo, "a")
+        # 同一 repo の別 worktree（＝止めたい対象）
+        self.sibling = self.root / "sibling"
+        git(self.repo, "worktree", "add", "-q", "--detach", str(self.sibling), "HEAD")
+        # 無関係な別 repo（＝止めてはいけない対象）
+        self.other = self.root / "other"
+        git(self.root, "init", "-q", "-b", "main", str(self.other))
+        commit(self.other, "b")
+        self.addCleanup(self.tmp.cleanup)
+
+    def decide(
+        self,
+        *,
+        tool: str = "Task",
+        text: str,
+        cwd: Path | None = None,
+        env: dict[str, str] | None = None,
+    ) -> str:
+        payload = json.dumps(
+            {
+                "tool_name": tool,
+                "tool_input": {"prompt": text},
+                "cwd": str(cwd if cwd is not None else self.repo),
+            }
+        )
+        p = subprocess.run(
+            ["bash", str(SCRIPT)],
+            input=payload,
+            capture_output=True,
+            text=True,
+            check=False,
+            env={**os.environ, **(env or {})},
+        )
+        self.assertEqual(p.returncode, 0, f"guard must always exit 0: {p.stderr}")
+        if not p.stdout.strip():
+            return "allow"
+        decision = json.loads(p.stdout)["hookSpecificOutput"]["permissionDecision"]
+        return str(decision)
+
+    # --- 止める側 -------------------------------------------------------
+    def test_denies_a_sibling_worktree_of_the_same_repo(self) -> None:
+        self.assertEqual(self.decide(text=f"review {self.sibling}"), "deny")
+
+    def test_denies_for_the_workflow_tool_too(self) -> None:
+        d = self.decide(tool="Workflow", text=f"review {self.sibling}")
+        self.assertEqual(d, "deny")
+
+    def test_denies_when_the_path_points_at_a_file_inside_the_sibling(self) -> None:
+        d = self.decide(text=f"read {self.sibling}/a for context")
+        self.assertEqual(d, "deny")
+
+    def test_the_reason_names_both_trees_and_the_way_out(self) -> None:
+        """止めるだけの guard は迂回される。次の一手まで出す。"""
+        payload = json.dumps(
+            {
+                "tool_name": "Task",
+                "tool_input": {"prompt": f"review {self.sibling}"},
+                "cwd": str(self.repo),
+            }
+        )
+        out = subprocess.run(
+            ["bash", str(SCRIPT)],
+            input=payload,
+            capture_output=True,
+            text=True,
+            check=False,
+        ).stdout
+        reason = json.loads(out)["hookSpecificOutput"]["permissionDecisionReason"]
+        self.assertIn(str(self.repo), reason)
+        self.assertIn(str(self.sibling), reason)
+        self.assertIn("/cd", reason)
+        self.assertIn("CLAUDE_ALLOW_CROSS_TREE_FANOUT", reason)
+
+    # --- 止めない側 -----------------------------------------------------
+    def test_allows_a_path_in_a_different_repository(self) -> None:
+        """別 repo は正当な相互参照。ここを止めると毎日鳴って外される。"""
+        self.assertEqual(self.decide(text=f"compare with {self.other}"), "allow")
+
+    def test_allows_a_path_inside_the_session_tree(self) -> None:
+        self.assertEqual(self.decide(text=f"review {self.repo}/a"), "allow")
+
+    def test_allows_a_prompt_with_no_paths(self) -> None:
+        self.assertEqual(self.decide(text="find the bug"), "allow")
+
+    def test_allows_tools_other_than_agent_and_workflow(self) -> None:
+        self.assertEqual(self.decide(tool="Bash", text=f"ls {self.sibling}"), "allow")
+
+    def test_allows_when_cwd_is_not_a_git_work_tree(self) -> None:
+        self.assertEqual(
+            self.decide(text=f"review {self.sibling}", cwd=self.root), "allow"
+        )
+
+    def test_the_escape_hatch_allows_a_deliberate_cross_tree_run(self) -> None:
+        d = self.decide(
+            text=f"review {self.sibling}",
+            env={"CLAUDE_ALLOW_CROSS_TREE_FANOUT": "1"},
+        )
+        self.assertEqual(d, "allow")
+
+    # --- fail-open ------------------------------------------------------
+    def test_unparseable_stdin_allows(self) -> None:
+        p = subprocess.run(
+            ["bash", str(SCRIPT)],
+            input="not json",
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(p.returncode, 0)
+        self.assertEqual(p.stdout.strip(), "")
+
+    def test_empty_stdin_allows(self) -> None:
+        p = subprocess.run(
+            ["bash", str(SCRIPT)],
+            input="",
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(p.returncode, 0)
+        self.assertEqual(p.stdout.strip(), "")
+
+    def test_without_jq_it_allows(self) -> None:
+        """jq が無い環境で黙って止めると、原因の分からない全 fan-out 不能になる。"""
+        bare = self.root / "bin"  # bash と git だけ通し jq は通さない PATH
+        bare.mkdir()
+        for tool in ("bash", "git"):
+            found = shutil.which(tool)
+            if found is None:  # pragma: no cover - devShell が供給する
+                self.skipTest(f"{tool} not on PATH")
+            (bare / tool).symlink_to(found)
+        p = subprocess.run(
+            [str(bare / "bash"), str(SCRIPT)],
+            input=json.dumps(
+                {
+                    "tool_name": "Task",
+                    "tool_input": {"prompt": f"review {self.sibling}"},
+                    "cwd": str(self.repo),
+                }
+            ),
+            capture_output=True,
+            text=True,
+            check=False,
+            env={"PATH": str(bare), "HOME": os.environ.get("HOME", "/tmp")},
+        )
+        self.assertEqual(p.returncode, 0)
+        self.assertEqual(p.stdout.strip(), "")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/scripts/test_claude_fanout_cwd_guard.py
+++ b/scripts/test_claude_fanout_cwd_guard.py
@@ -87,7 +87,9 @@ class FanoutCwdGuard(unittest.TestCase):
             capture_output=True,
             text=True,
             check=False,
-            env={**os.environ, **(env or {})},
+            # 解除フラグは明示したテストだけが持つ。周囲から継承すると
+            # 「たまたま export されていた日だけ deny テストが落ちる」になる。
+            env={**os.environ, "CLAUDE_ALLOW_CROSS_TREE_FANOUT": "", **(env or {})},
         )
         self.assertEqual(p.returncode, 0, f"guard must always exit 0: {p.stderr}")
         if not p.stdout.strip():
@@ -122,6 +124,7 @@ class FanoutCwdGuard(unittest.TestCase):
             capture_output=True,
             text=True,
             check=False,
+            env={**os.environ, "CLAUDE_ALLOW_CROSS_TREE_FANOUT": ""},
         ).stdout
         reason = json.loads(out)["hookSpecificOutput"]["permissionDecisionReason"]
         self.assertIn(str(self.repo), reason)
@@ -154,6 +157,14 @@ class FanoutCwdGuard(unittest.TestCase):
             env={"CLAUDE_ALLOW_CROSS_TREE_FANOUT": "1"},
         )
         self.assertEqual(d, "allow")
+
+    def test_a_worktree_path_containing_a_space_is_a_known_blind_spot(self) -> None:
+        """通ってしまうことを固定する。パスは散文から pattern で拾うので、空白は
+        語の切れ目と区別できない。将来ここが deny に変わるなら、それは改善であって
+        退行ではない —— そのときはこのテストを書き換える。"""
+        spaced = self.root / "side dir"
+        git(self.repo, "worktree", "add", "-q", "--detach", str(spaced), "HEAD")
+        self.assertEqual(self.decide(text=f"review {spaced}"), "allow")
 
     # --- fail-open ------------------------------------------------------
     def test_unparseable_stdin_allows(self) -> None:

--- a/scripts/test_modify_settings.py
+++ b/scripts/test_modify_settings.py
@@ -33,6 +33,7 @@ STALE_CHECK = "$HOME/.local/bin/git-stale-check"
 WORK_REPORT = "$HOME/.local/bin/claude-work-report-check"
 QUOTA_NOTE = "$HOME/.local/bin/claude-quota-note"
 PJLINT_NOTE = "$HOME/.local/bin/claude-projects-lint-note"
+FANOUT_GUARD = "$HOME/.local/bin/claude-fanout-cwd-guard"
 
 
 def jq_only_path() -> str:
@@ -118,6 +119,22 @@ class Seeds(unittest.TestCase):
         self.assertIn(PJLINT_NOTE, commands(got, "SessionStart"))
         self.assertIn(WORK_REPORT, commands(got, "Stop"))
 
+    def test_it_adds_the_fanout_guard_as_a_pretooluse_hook(self) -> None:
+        """8 つのうち唯一 deny できる hook。登録が落ちても既存 7 本は動くので、
+        黙って外れたことに気づけない —— ここで固定する。"""
+        got = json.loads(run("{}").stdout)
+        self.assertIn(FANOUT_GUARD, commands(got, "PreToolUse"))
+
+    def test_the_fanout_guard_matches_only_the_fan_out_tools(self) -> None:
+        """matcher が広がると全ツールで git を叩くことになる。"""
+        got = json.loads(run("{}").stdout)
+        matchers = [
+            entry.get("matcher")
+            for entry in got["hooks"]["PreToolUse"]
+            if any(h.get("command") == FANOUT_GUARD for h in entry.get("hooks", []))
+        ]
+        self.assertEqual(matchers, ["Task|Agent|Workflow"])
+
     def test_home_stays_literal(self) -> None:
         """hook の command は Claude が実行時に展開する。生成時に展開すると
         別マシンへ配ったときに他人の $HOME が焼き込まれる。"""
@@ -156,6 +173,7 @@ class Idempotent(unittest.TestCase):
         self.assertEqual(commands(got, "SessionStart").count(QUOTA_NOTE), 1)
         self.assertEqual(commands(got, "SessionStart").count(PJLINT_NOTE), 1)
         self.assertEqual(commands(got, "Stop").count(WORK_REPORT), 1)
+        self.assertEqual(commands(got, "PreToolUse").count(FANOUT_GUARD), 1)
 
     def test_allow_entries_are_not_duplicated(self) -> None:
         allow = json.loads(run(run("{}").stdout).stdout)["permissions"]["allow"]


### PR DESCRIPTION
## What

Adds a PreToolUse hook, `claude-fanout-cwd-guard`, that **denies** an `Agent`/`Workflow`
call whose input names **another worktree of the same repository** as the session's cwd.

## Why

A subagent's working directory *is* the parent session's cwd. There is no cwd parameter
on the Agent tool, none in an agent definition, and a path written into the prompt does
not steer it.

Measured 2026-08-10 on a 17-agent review: the prompt named a worktree checked out at
`origin/main`, and **0 of 17 agents read it while 17 of 17 read the session's own
checkout** — parked 7 commits behind for a schema flag day. Every finding, ~2M output
tokens and 21 tasks written to a shared board were against the wrong tree and had to be
discarded.

That session had **already detected** the staleness and built the worktree as a
work-around. The work-around is what silently did nothing, so a warning is not what was
missing — this is the only one of the eight seeded hooks that can block.

## Scope, deliberately narrow

Same-repo-only. A sibling worktree is the confusable case: identical relative paths,
identical file names, findings that look right at every line. A path in a **different**
repository is an ordinary cross-repo reference and is allowed — a guard that fires daily
gets bypassed.

Fail-open on missing `jq`, unparseable stdin, a cwd outside a work tree, or any git
error. `CLAUDE_ALLOW_CROSS_TREE_FANOUT=1` is the deliberate-run escape.

## Verification

- `scripts/test_claude_fanout_cwd_guard.py` — 13 cases pinning both directions
  (denies sibling worktree / Workflow tool / file inside it and the reason's content;
  allows another repo, own tree, no paths, other tools, non-git cwd, the escape hatch,
  and every fail-open path).
- `scripts/test_modify_settings.py` — 2 added cases: the hook is registered, and its
  matcher stays `Task|Agent|Workflow` (a widened matcher would shell out to git on every
  tool call).
- `nix develop .#lint --command scripts/lint` — 13 gates green.
- 30 unit tests green.

**Not verified:** `glyph lint` could not run locally — the source-build wrapper fails to
compile the current glyph checkout (unrelated, mid-work). The commit message follows
`<:gitmoji:>[(<scope>)][!] <subject>` by inspection only; CI's commit lint is the check.

## Not in this PR

`git-stale-check` goes silent on a detached HEAD — exactly the state of the checkout in
the incident. That silence is pinned as deliberate by an existing test
(`test_silent_on_detached_head`), so overturning it deserves its own change.

SetStatus-task: https://github.com/akira-toriyama/projects/blob/main/.furrow/bodies/t-sx5g.md in-progress

🤖 Generated with [Claude Code](https://claude.com/claude-code)