### PR TITLE
:sparkles:(claude) refuse a deadline-less vncdo call — the overnight-hang guard

### DIFF
--- a/chezmoi/dot_local/bin/executable_claude-vncdo-guard
+++ b/chezmoi/dot_local/bin/executable_claude-vncdo-guard
@@ -55,7 +55,7 @@ cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // empty' 2>/dev/null)
 # the harness env, not the Bash call's), so the marker is honored as literal
 # command text — `CLAUDE_ALLOW_RAW_VNCDO=1 vncdo ...`.
 case $cmd in
-  *CLAUDE_ALLOW_RAW_VNCDO=1*) exit 0 ;;
+*CLAUDE_ALLOW_RAW_VNCDO=1*) exit 0 ;;
 esac
 
 # Command-position match only: vncdo (or .../vncdo) at the start of a shell

--- a/chezmoi/dot_local/bin/executable_claude-vncdo-guard
+++ b/chezmoi/dot_local/bin/executable_claude-vncdo-guard
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# claude-vncdo-guard — PreToolUse guard for vncdo (VNC automation) Bash calls.
+#
+# Refuses a `vncdo` invocation that carries NO explicit deadline, and one that
+# sends an UPPERCASE keysym. Both rules encode one measured incident, not
+# theory (2026-08-11, sill session, facet #448 GUI acceptance in a Tart VM):
+#
+#   - `vncdo ... key Down` (uppercase keysym) hung forever against tart's
+#     experimental VNC server. The same call with `key down` returned in
+#     seconds. Two stuck clients then wedged the single-client server, so
+#     every later call queued behind them.
+#   - none of the calls carried `--timeout`, so the hang had no ceiling: the
+#     session sat blocked OVERNIGHT waiting for a completion notification
+#     that could never arrive, and the agent reported "working" without
+#     verifying — the trust-breaking half of the incident. vncdo has a native
+#     `-t/--timeout SECONDS` ("abort if unable to complete all actions
+#     within TIMEOUT seconds"); with it, the worst case is an N-second abort
+#     instead of an unbounded wait.
+#
+# Scope is deliberately narrow — the literal `vncdo` binary only. The general
+# principle ("every external wait needs a deadline") stays prose in the global
+# CLAUDE.md; a guard that pattern-matches every ssh/curl would cry wolf and
+# get bypassed. This guard covers the one command class that actually burned
+# a night.
+#
+# Fail-open by construction: no jq, unparseable stdin, or a non-Bash tool →
+# allow. Escape hatch for a deliberate raw call (e.g. probing the hang
+# itself): prefix the command text with CLAUDE_ALLOW_RAW_VNCDO=1 — honored as
+# a literal marker because a hook process never sees the Bash call's env
+# (it runs in the harness env; an env-only hatch would be unreachable).
+#
+# Known blind spots (miss a bad call, never block a good one):
+#   - a vncdo invocation assembled from shell variables ("$V" key down) hides
+#     the flag check; the guard only reads the literal command text.
+#   - `--timeout` inside a quoted string that never reaches vncdo satisfies
+#     the pattern.
+#
+# Owned by dotfiles (chezmoi → ~/.local/bin/claude-vncdo-guard); wired from
+# the Claude PreToolUse hook in modify_settings.json.
+
+[ "${CLAUDE_ALLOW_RAW_VNCDO:-}" = "1" ] && exit 0
+command -v jq >/dev/null 2>&1 || exit 0
+
+input=$(cat 2>/dev/null) || exit 0
+[ -n "$input" ] || exit 0
+printf '%s' "$input" | jq -e . >/dev/null 2>&1 || exit 0
+
+tool=$(printf '%s' "$input" | jq -r '.tool_name // empty' 2>/dev/null)
+[ "$tool" = "Bash" ] || exit 0
+
+cmd=$(printf '%s' "$input" | jq -r '.tool_input.command // empty' 2>/dev/null)
+[ -n "$cmd" ] || exit 0
+
+# Per-command escape: the env-var form cannot reach this process (hooks run in
+# the harness env, not the Bash call's), so the marker is honored as literal
+# command text — `CLAUDE_ALLOW_RAW_VNCDO=1 vncdo ...`.
+case $cmd in
+  *CLAUDE_ALLOW_RAW_VNCDO=1*) exit 0 ;;
+esac
+
+# Command-position match only: vncdo (or .../vncdo) at the start of a shell
+# command segment. A command that merely MENTIONS vncdo in a string — editing
+# this very documentation was the measured false positive (2026-08-11) — must
+# not trip the guard, or it cries wolf and gets bypassed.
+if ! printf '%s' "$cmd" | grep -Eq '(^|[|;&`(]|&&|\|\|)[[:space:]]*([A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+)*([^[:space:]]*/)?vncdo([[:space:]]|$)'; then
+  exit 0
+fi
+
+# 1) every vncdo call must carry its own deadline (-t N / --timeout N / =N)
+if ! printf '%s' "$cmd" | grep -Eq -- '(^|[[:space:]])(--timeout(=|[[:space:]]+)[0-9]+|-t[[:space:]]*[0-9]+)'; then
+  {
+    echo "vncdo without an explicit deadline is refused (measured 2026-08-11: an"
+    echo "uppercase-keysym call hung a session overnight). Add \`--timeout <sec>\`"
+    echo "(vncdo-native; aborts the whole call after N seconds), e.g.:"
+    echo "  vncdo --timeout 25 -s HOST::PORT -p PASS capture out.png"
+    echo "Deliberate raw call: re-run with CLAUDE_ALLOW_RAW_VNCDO=1."
+  } >&2
+  exit 2
+fi
+
+# 2) keysyms must be lowercase — `key Down` hangs, `key down` works (measured)
+if printf '%s' "$cmd" | grep -Eq '(^|[[:space:]])key[[:space:]]+[A-Z]'; then
+  {
+    echo "vncdo keysyms must be lowercase: \`key down\`, \`key enter\`, \`key space\`."
+    echo "Uppercase (\`key Down\`) hangs against tart's VNC server (measured 2026-08-11)."
+  } >&2
+  exit 2
+fi
+
+exit 0

--- a/chezmoi/private_dot_claude/CLAUDE.md
+++ b/chezmoi/private_dot_claude/CLAUDE.md
@@ -113,6 +113,7 @@
 - 同じコマンドの再実行差分 → `rundiff`（主要 test runner は PreToolUse hook が自動 wrap）
 - findings の PR レビュー投稿 → `revpost`（`--dry-run` あり）
 - 条件待ち → condition-wait skill（wait4x）/ macOS GUI 検証 → macos-gui-verify skill（peekaboo）
+- **外部待ちは deadline 必須**・停滞は即報告・状態質問は実測後に答える
 - **自作 CLI・アプリは source で使う**: CLI は dotfiles `packages.nix` の source-build
   wrapper、GUI アプリは Xcode ビルド。`brew install` しない（brew が wrapper を shadow する）。
 

--- a/chezmoi/private_dot_claude/modify_settings.json
+++ b/chezmoi/private_dot_claude/modify_settings.json
@@ -2,7 +2,7 @@
 # chezmoi modify_ script for ~/.claude/settings.json.
 #
 # chezmoi pipes the CURRENT settings.json on stdin; our stdout becomes the new
-# file. We ensure exactly EIGHT things and pass everything else (the permissions
+# file. We ensure exactly NINE things and pass everything else (the permissions
 # the user accumulates interactively, plugins, env, other hooks) through
 # untouched:
 #   1. a SessionStart hook that runs git-stale-check (so an agent sees a
@@ -79,11 +79,19 @@
 #      silently reads the wrong tree: measured 2026-08-10, 0 of 17 agents read
 #      the worktree named in their prompt and 17 read the session's own
 #      7-commits-behind checkout, costing ~2M tokens and 21 discarded board
-#      tasks. This is the only one of the eight that can BLOCK, because that
+#      tasks. This one and #9 are the only two that can BLOCK, because that
 #      session had already detected the staleness and built the worktree as a
 #      work-around — a warning was not what was missing. Fail-open, and
 #      CLAUDE_ALLOW_CROSS_TREE_FANOUT=1 is the deliberate-run escape; see its
 #      header for why the scope is same-repo-only.
+#   9. a PreToolUse hook that runs claude-vncdo-guard on Bash calls — DENIES a
+#      `vncdo` invocation without an explicit `--timeout`, and one sending an
+#      uppercase keysym (`key Down`). Measured 2026-08-11: an uppercase keysym
+#      hung against tart's experimental VNC server with no deadline, blocking a
+#      session overnight; `key down` + `--timeout N` bounds the worst case at
+#      N seconds. Fail-open, CLAUDE_ALLOW_RAW_VNCDO=1 escape; scope is the
+#      literal vncdo binary only — the general "every external wait needs a
+#      deadline" rule stays prose in the global CLAUDE.md.
 #
 # Idempotent: each hook and each allow entry is added only if absent (the allow
 # merge is a set-union), so re-apply never duplicates and the user's own edits
@@ -105,6 +113,8 @@ cmd_quota='$HOME/.local/bin/claude-quota-note'
 cmd_pjlint='$HOME/.local/bin/claude-projects-lint-note'
 # shellcheck disable=SC2016  # same: literal $HOME, expanded at hook run
 cmd_fanout='$HOME/.local/bin/claude-fanout-cwd-guard'
+# shellcheck disable=SC2016  # same: literal $HOME, expanded at hook run
+cmd_vnc='$HOME/.local/bin/claude-vncdo-guard'
 
 input=$(cat)
 [ -n "$input" ] || input='{}'
@@ -114,12 +124,13 @@ if ! command -v jq >/dev/null 2>&1 || ! printf '%s' "$input" | jq -e . >/dev/nul
   exit 0
 fi
 
-out=$(printf '%s\n' "$input" | jq --arg cmd "$cmd" --arg stop "$cmd_stop" --arg quota "$cmd_quota" --arg pjlint "$cmd_pjlint" --arg fanout "$cmd_fanout" '
+out=$(printf '%s\n' "$input" | jq --arg cmd "$cmd" --arg stop "$cmd_stop" --arg quota "$cmd_quota" --arg pjlint "$cmd_pjlint" --arg fanout "$cmd_fanout" --arg vnc "$cmd_vnc" '
   def hook_present: [ (.hooks.SessionStart // [])[]?.hooks[]?.command ] | any(. == $cmd);
   def stop_hook_present: [ (.hooks.Stop // [])[]?.hooks[]?.command ] | any(. == $stop);
   def quota_hook_present: [ (.hooks.SessionStart // [])[]?.hooks[]?.command ] | any(. == $quota);
   def pjlint_hook_present: [ (.hooks.SessionStart // [])[]?.hooks[]?.command ] | any(. == $pjlint);
   def fanout_hook_present: [ (.hooks.PreToolUse // [])[]?.hooks[]?.command ] | any(. == $fanout);
+  def vnc_hook_present: [ (.hooks.PreToolUse // [])[]?.hooks[]?.command ] | any(. == $vnc);
 
   ( if hook_present then .
     else
@@ -150,6 +161,12 @@ out=$(printf '%s\n' "$input" | jq --arg cmd "$cmd" --arg stop "$cmd_stop" --arg 
           (.hooks //= {})
         | (.hooks.PreToolUse //= [])
         | (.hooks.PreToolUse += [ { matcher: "Task|Agent|Workflow", hooks: [ { type: "command", command: $fanout } ] } ])
+      end )
+  | ( if vnc_hook_present then .
+      else
+          (.hooks //= {})
+        | (.hooks.PreToolUse //= [])
+        | (.hooks.PreToolUse += [ { matcher: "Bash", hooks: [ { type: "command", command: $vnc, timeout: 10 } ] } ])
       end )
   | (.permissions //= {})
   | (.permissions.allow //= [])

--- a/chezmoi/private_dot_claude/skills/macos-gui-verify/SKILL.md
+++ b/chezmoi/private_dot_claude/skills/macos-gui-verify/SKILL.md
@@ -46,6 +46,25 @@ family 外の app か、その場限りの手元 1 回だけの確認に限る�
   （`make verify`/`make bake` は自分で設定する。素の `tart clone`/`pull` は
   OCI cache を LRU auto-prune し、他 VM を黙って消しうる）。
 
+## VM への合成キーボードは VNC 経由（2026-08-10/11 実測・facet #448 受け入れ）
+
+SSH 経由の合成キー CGEvent は VM 内 app に**届かない**（マウス系は届く — 非対称）。
+キーが要る検証は `tart run --vnc-experimental` + vncdotool で回す。
+
+- 起動: `TART_NO_AUTO_PRUNE=1 tart run <vm> --no-graphics --vnc-experimental`。
+  **stdout をパイプで加工しない**（`| head` は vnc:// URL とパスワードを飲み込む —
+  実績あり）。URL は生出力から読む。パスワードは run ごとに変わる。
+- **全 vncdo 呼び出しに `--timeout <sec>` 必須**（PreToolUse hook `claude-vncdo-guard`
+  が欠落を deny）。timeout 無しの hang で一晩溶かした実績が起点。
+- **keysym は小文字**（`key down` / `key enter` / `key space`）。大文字 `key Down` は
+  tart の VNC サーバ相手に無限 hang する（実測）。これも hook が deny。
+- **1 呼び出し 1 操作**に分割する。数珠つなぎの Bash が tool timeout を超えて
+  background 化 → 迷子になった実績。各操作の後に capture で即検証。
+- サーバは実質シングルクライアント: hang したクライアントが居座ると後続が全部
+  詰まる。詰まったら `pkill -f "vncdo -s"` してから撮り直す。
+- capture はフレームバッファ直取りで TCC 不要。ホイールは SSH 経由 `peekaboo scroll`
+  でも可。座標系は VM のフレームバッファ実寸（Retina 2x）。
+
 ## 前提（TCC）
 
 - Accessibility + Screen Recording の許可は **CLI 本体でなくホストアプリ（Terminal / IDE）に付与**する（TCC の responsible-code）。ローカルで再ビルドしたバイナリでも同じホストから動く限り再付与不要。

--- a/docs/claude-md-ledger.md
+++ b/docs/claude-md-ledger.md
@@ -43,6 +43,7 @@
 | **機構化は rule of two・予算内**（開発ポリシー節・2026-07-28 新設） | 「既に踏んだ失敗の再発防止」以外の機構・ルールを作らない | — | Stop hook の created 予算が件数側を縛る | 🟡 |
 | fleet 変更の段取り（開発ポリシー節） | 段を踏む | カナリア/フリート進行の判断 | 正本 [fleet-change-policy.md](https://github.com/akira-toriyama/.github/blob/main/docs/fleet-change-policy.md) に機械強制の段一覧 | → 別台帳 |
 | 調査 clone・VM 全操作・Packages 配布の許可（開発ポリシー節） | 許可を行使 | ホスト sudo の実行 | — | 🙅 |
+| 外部待ちの deadline 必須・vncdo は timeout+小文字 keysym（道具節・2026-08-11 新設） | timeout を付ける・停滞は kill → 即報告・状態質問には実測後に回答 | — | PreToolUse hook [claude-vncdo-guard](../chezmoi/dot_local/bin/executable_claude-vncdo-guard)（[modify_settings.json](../chezmoi/private_dot_claude/modify_settings.json) #9 配線）が vncdo の timeout 欠落と大文字 keysym を deny（unit 9 ケース実測）。一般則（他コマンドの deadline・状態報告の正直さ）は散文 | 🟡 vncdo は 🔒・一般則は 📖 |
 | 道具を既定で使う（道具節） | pare/cifail/rundiff/revpost/wait4x/peekaboo に先に手を伸ばす | — | rundiff の test 自動 wrap・読み取り git allowlist は modify_settings.json が 🔒。**使う判断**は散文 | 🟡 |
 | 自作 CLI/アプリは source・brew 禁止（道具節） | `brew install` しない | `brew install` しない | brew 版が無ければ shadow は構造的に起きない（実測: wrapper のみ） | 🟡 |
 | gitmoji 規約・push 前 `glyph lint`（Commits 節） | `glyph rules` を引く・push 前に lint | — | PR の commit-lint.yml（fleet 同期）。branch protection 必須は `ci-gate` のみで commit-lint 赤は merge を止めない（実測） | 🟡 push 前 lint は 📖 |


### PR DESCRIPTION
A PreToolUse Bash guard denies a `vncdo` invocation without an explicit `--timeout`, and one sending an uppercase keysym.

**The incident (2026-08-11, measured).** During facet #448 GUI acceptance in a Tart VM, `vncdo … key Down` (uppercase keysym) hung forever against tart's experimental VNC server. No call carried `--timeout`, so nothing bounded the hang: the session sat blocked overnight behind two wedged VNC clients — and reported "working" without verifying, which is the trust-breaking half this guard exists to prevent structurally.

**What the guard enforces** (`~/.local/bin/claude-vncdo-guard`, wired as item 9 of `modify_settings.json`):
- `vncdo` in command position without `-t/--timeout N` → **deny** (vncdo-native flag; worst case becomes an N-second abort)
- `key <Uppercase>` keysym → **deny** (`key down` works, `key Down` hangs — measured)
- mention-only commands (e.g. editing docs that contain the word vncdo) pass — that false positive was measured against the first substring matcher while building this
- fail-open on no jq / bad stdin / non-Bash tools; escape = literal command-text marker `CLAUDE_ALLOW_RAW_VNCDO=1` (a hook process never sees the Bash call's env)

**Verification** — unit suite of 10 fixtures green against both the repo copy and the installed binary; live in-session: a deadline-less call was denied by the running harness and a `--timeout 25` call executed; modifier dry-run + double-apply idempotency measured.

**Prose layer**: one line in the global CLAUDE.md (道具節, kept under the 11500-byte gate), a VNC recipe section in the macos-gui-verify skill (SSH keys don't reach the VM, lowercase keysyms, one call per op, single-client server), and the ledger row recording the split: vncdo mechanized 🔒, the general deadline rule prose 📖.

SetStatus-task: https://github.com/akira-toriyama/projects/blob/main/.furrow/bodies/t-rwrg.md done

🤖 Generated with [Claude Code](https://claude.com/claude-code)