### PR TITLE
:sparkles:(claude) a SessionStart hook says when the furrow board is read-only for this machine

### DIFF
--- a/chezmoi/dot_local/bin/executable_claude-furrow-board-note
+++ b/chezmoi/dot_local/bin/executable_claude-furrow-board-note
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# claude-furrow-board-note — Claude Code SessionStart hook: say so when the
+# furrow board is READ-ONLY for this machine's binary.
+#
+# WHY: furrow gates WRITES on the board's layout version, and the failure is
+# ASYMMETRIC — every READ keeps working. `furrow sync`, `show`, `brief`, `ls`
+# all answer normally while `add`/`set`/`note`/`done` exit 2, so nothing looks
+# wrong until the moment progress is recorded. Measured on 2026-08-12: a session
+# moved the furrow SOURCE checkout (the PATH wrapper builds the binary from it)
+# off the v8 commit it had been deliberately parked at, and the shared board went
+# read-only for the rest of that session with no visible symptom at all.
+#
+# The mismatch is normal, not exotic: during a pins-first flag day the board is
+# deliberately one version BEHIND while the fleet's pins move first, so the
+# source checkout is parked and any `git checkout`/`git pull` in it breaks
+# writing. It recurs at every schema bump.
+#
+# `furrow board` is the right probe precisely because it is the one command that
+# REPORTS a version mismatch instead of failing on it — the check cannot be
+# blinded by the condition it checks for.
+#
+# Output: one line when the board cannot be written, naming both versions and
+# both remedies (which one applies is a judgement — a flag day's order is the
+# human's, so this never prescribes `furrow upgrade`). Silent when writable.
+# Fail-open: no furrow / no jq / no board in scope / unparseable → print nothing,
+# exit 0 (breaking session start is never worth a warning — same asymmetry as
+# claude-projects-lint-note).
+#
+# Owned by dotfiles (chezmoi → ~/.local/bin/claude-furrow-board-note). Wired from
+# ~/.claude/settings.json hooks.SessionStart by modify_settings.json (step 9).
+# Tests: scripts/test_claude_furrow_board_note.py (unittest, CI).
+set -u
+
+command -v jq >/dev/null 2>&1 || exit 0
+# FURROW_BOARD_CMD lets the test substitute a stub; the wrapper is the default.
+cmd="${FURROW_BOARD_CMD:-furrow}"
+command -v "$cmd" >/dev/null 2>&1 || exit 0
+
+# `board` never fails on a version mismatch, so a non-zero exit here means
+# something else entirely (no board in scope, unreadable store) — fail open.
+out=$("$cmd" board --json 2>/dev/null) || exit 0
+[ -n "$out" ] || exit 0
+
+line=$(printf '%s\n' "$out" | jq -r '
+  if (.writable == false) then
+    "⚠ furrow board は書き込み不可: board schema v\(.schema_version) / binary schema v\(.binary_schema_version) (\(.schema_state))"
+    + "  — READ は通るので気づけない。"
+    + (if .schema_state == "too-new"
+       then "binary が古い: furrow の source checkout を git pull"
+       else "binary が board より新しい: source checkout を board と同じ版に戻す（flag day 中の park なら戻すのが正解）か、board を furrow upgrade する（順序は人間の判断）"
+       end)
+  else empty end
+' 2>/dev/null) || exit 0
+
+[ -n "$line" ] && printf '%s\n' "$line"
+exit 0

--- a/chezmoi/private_dot_claude/modify_settings.json
+++ b/chezmoi/private_dot_claude/modify_settings.json
@@ -2,7 +2,7 @@
 # chezmoi modify_ script for ~/.claude/settings.json.
 #
 # chezmoi pipes the CURRENT settings.json on stdin; our stdout becomes the new
-# file. We ensure exactly NINE things and pass everything else (the permissions
+# file. We ensure exactly TEN things and pass everything else (the permissions
 # the user accumulates interactively, plugins, env, other hooks) through
 # untouched:
 #   1. a SessionStart hook that runs git-stale-check (so an agent sees a
@@ -92,6 +92,17 @@
 #      N seconds. Fail-open, CLAUDE_ALLOW_RAW_VNCDO=1 escape; scope is the
 #      literal vncdo binary only — the general "every external wait needs a
 #      deadline" rule stays prose in the global CLAUDE.md.
+#  10. a SessionStart hook that runs claude-furrow-board-note — warns when the
+#      furrow board is READ-ONLY for this machine's binary. The failure is
+#      ASYMMETRIC: every READ keeps working (`sync`, `brief`, `ls`, `show` all
+#      answer) while every WRITE exits 2, so nothing looks wrong until progress
+#      is recorded. Measured 2026-08-12, twice in one evening: the furrow source
+#      checkout — which the PATH wrapper builds the binary from — was moved off
+#      the version the board was parked at, once by the session itself and once
+#      by a CONCURRENT session sharing that checkout, and the board went
+#      read-only both times with no visible symptom. Warn-only: a mismatch is
+#      normal mid-flag-day and the order to fix it in is the human's.
+#      Fail-open; see its header.
 #
 # Idempotent: each hook and each allow entry is added only if absent (the allow
 # merge is a set-union), so re-apply never duplicates and the user's own edits
@@ -112,6 +123,8 @@ cmd_quota='$HOME/.local/bin/claude-quota-note'
 # shellcheck disable=SC2016  # same: literal $HOME, expanded at hook run
 cmd_pjlint='$HOME/.local/bin/claude-projects-lint-note'
 # shellcheck disable=SC2016  # same: literal $HOME, expanded at hook run
+cmd_board='$HOME/.local/bin/claude-furrow-board-note'
+# shellcheck disable=SC2016  # same: literal $HOME, expanded at hook run
 cmd_fanout='$HOME/.local/bin/claude-fanout-cwd-guard'
 # shellcheck disable=SC2016  # same: literal $HOME, expanded at hook run
 cmd_vnc='$HOME/.local/bin/claude-vncdo-guard'
@@ -124,11 +137,12 @@ if ! command -v jq >/dev/null 2>&1 || ! printf '%s' "$input" | jq -e . >/dev/nul
   exit 0
 fi
 
-out=$(printf '%s\n' "$input" | jq --arg cmd "$cmd" --arg stop "$cmd_stop" --arg quota "$cmd_quota" --arg pjlint "$cmd_pjlint" --arg fanout "$cmd_fanout" --arg vnc "$cmd_vnc" '
+out=$(printf '%s\n' "$input" | jq --arg cmd "$cmd" --arg stop "$cmd_stop" --arg quota "$cmd_quota" --arg pjlint "$cmd_pjlint" --arg board "$cmd_board" --arg fanout "$cmd_fanout" --arg vnc "$cmd_vnc" '
   def hook_present: [ (.hooks.SessionStart // [])[]?.hooks[]?.command ] | any(. == $cmd);
   def stop_hook_present: [ (.hooks.Stop // [])[]?.hooks[]?.command ] | any(. == $stop);
   def quota_hook_present: [ (.hooks.SessionStart // [])[]?.hooks[]?.command ] | any(. == $quota);
   def pjlint_hook_present: [ (.hooks.SessionStart // [])[]?.hooks[]?.command ] | any(. == $pjlint);
+  def board_hook_present: [ (.hooks.SessionStart // [])[]?.hooks[]?.command ] | any(. == $board);
   def fanout_hook_present: [ (.hooks.PreToolUse // [])[]?.hooks[]?.command ] | any(. == $fanout);
   def vnc_hook_present: [ (.hooks.PreToolUse // [])[]?.hooks[]?.command ] | any(. == $vnc);
 
@@ -155,6 +169,12 @@ out=$(printf '%s\n' "$input" | jq --arg cmd "$cmd" --arg stop "$cmd_stop" --arg 
           (.hooks //= {})
         | (.hooks.SessionStart //= [])
         | (.hooks.SessionStart += [ { hooks: [ { type: "command", command: $pjlint } ] } ])
+      end )
+  | ( if board_hook_present then .
+      else
+          (.hooks //= {})
+        | (.hooks.SessionStart //= [])
+        | (.hooks.SessionStart += [ { hooks: [ { type: "command", command: $board } ] } ])
       end )
   | ( if fanout_hook_present then .
       else

--- a/docs/claude-md-ledger.md
+++ b/docs/claude-md-ledger.md
@@ -32,6 +32,7 @@
 | 質問・報告フロー（一問一答・推奨・委任）（作業の締め節） | 一問一答・推奨つき | 裁定・「残り全部推奨で」の委任 | なし | 📖 |
 | furrow 一本化・wrapper 使用（Workflow 節） | PATH の `furrow` を叩く | — | `packages.nix` の source-build wrapper。brew 版未導入なので shadow は構造的に不発 | 🟡 |
 | 着手前後の `furrow sync`・session start は `furrow sync && furrow brief`（Workflow 節） | 読む前・書いた後に sync。session start は sync && brief で orient | — | なし | 📖 |
+| board の layout が上がった直後は source checkout を `git pull`（Workflow 節） | checkout を board と同じ層に合わせてから furrow を叩く | flag day の順序判断（pins-first の窓では checkout を park する側が正解） | SessionStart hook [claude-furrow-board-note](../chezmoi/dot_local/bin/executable_claude-furrow-board-note)（[modify_settings.json](../chezmoi/private_dot_claude/modify_settings.json) #10 配線）が `furrow board` の `writable:false` を 1 行表示。**READ が全部通る**ので他に発火点が無く、書き込むまで誰も気づけない（2026-08-12 に 1 晩で 2 回発生。1 回はセッション自身、1 回は checkout を共有する別セッションが動かした）。unit 9 ケース | 🟡 warn-only・session start 時点のみ（セッション途中で壊れた分は次回まで出ない） |
 | 進捗の正本は body 一本・中断時 1 行（Workflow 節） | body 更新・複製しない | — | なし | 📖 |
 | projects checkout では明示 `-r projects`（Workflow 節・正典に無い） | 明示する | — | `furrow doctor` が `scope-shadowed` を info 報告するだけで止めない | 📖 |
 | 指示なし時は `furrow brief` の先頭から着手／状況共有を GO と読まない／active epic の切り替えは申請制（Workflow 節） | 既定挙動として従う。勝手に `furrow epic activate` しない | 作業開始の GO・epic 切り替えの裁定 | furrow が next/brief を active epic に scope（epic-multi-active は lint error）。申請制そのものは散文 | 🟡 scope は機構・申請制は 📖 |

--- a/scripts/test_claude_furrow_board_note.py
+++ b/scripts/test_claude_furrow_board_note.py
@@ -1,0 +1,135 @@
+"""claude-furrow-board-note の fixture テスト。
+
+SessionStart hook は fail-open が契約（壊れた hook はセッション開始ごとに
+ノイズを吐く）。ここで固定するのは:
+
+  1. fail-open: furrow 不在 / board が非 0 終了 / 空出力 / 壊れた JSON
+     → 無出力・exit 0
+  2. writable=true → 完全に無音（健全な board で毎回喋る hook は読まれなくなる）
+  3. writable=false → 1 行出る。両方の version を数字で名指しし、
+     「READ は通る」という非対称性に触れる（これが気づけない理由そのもの）
+  4. schema_state で remedy が分岐する: too-new は binary を上げる /
+     outdated は checkout を戻すか board を upgrade するかを人間が選ぶ
+     （hook は flag day の順序を勝手に決めない）
+
+`furrow board` 本体は furrow 側でテスト済みなので、ここでは stub を
+FURROW_BOARD_CMD に差して配管だけを見る。
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = ROOT / "chezmoi" / "dot_local" / "bin" / "executable_claude-furrow-board-note"
+
+
+def run_with(stub_body: str | None) -> subprocess.CompletedProcess[str]:
+    """Run the hook with `furrow board --json` stubbed by a shell script."""
+    env = dict(os.environ)
+    with tempfile.TemporaryDirectory() as tmp:
+        if stub_body is None:
+            env["FURROW_BOARD_CMD"] = str(Path(tmp) / "nonexistent-furrow")
+        else:
+            stub = Path(tmp) / "furrow-stub"
+            stub.write_text(stub_body)
+            stub.chmod(0o755)
+            env["FURROW_BOARD_CMD"] = str(stub)
+        return subprocess.run(
+            ["bash", str(SCRIPT)],
+            capture_output=True,
+            text=True,
+            check=False,
+            env=env,
+        )
+
+
+def emitting(json_line: str) -> str:
+    return f"#!/bin/sh\ncat <<'EOF'\n{json_line}\nEOF\n"
+
+
+READ_ONLY = (
+    '{"schema_version":8,"binary_schema_version":9,'
+    '"schema_state":"outdated","writable":false}'
+)
+TOO_NEW = (
+    '{"schema_version":10,"binary_schema_version":9,'
+    '"schema_state":"too-new","writable":false}'
+)
+HEALTHY = (
+    '{"schema_version":9,"binary_schema_version":9,'
+    '"schema_state":"current","writable":true}'
+)
+
+
+class TestFailOpen(unittest.TestCase):
+    """A hook that breaks the session is worse than a missed warning."""
+
+    def test_missing_furrow_is_silent(self) -> None:
+        r = run_with(None)
+        self.assertEqual(r.returncode, 0)
+        self.assertEqual(r.stdout, "")
+
+    def test_nonzero_exit_is_silent(self) -> None:
+        # `board` never fails on a version mismatch, so a non-zero exit means
+        # something else (no board in scope) — not a condition to warn about.
+        r = run_with("#!/bin/sh\nexit 2\n")
+        self.assertEqual(r.returncode, 0)
+        self.assertEqual(r.stdout, "")
+
+    def test_empty_output_is_silent(self) -> None:
+        r = run_with("#!/bin/sh\n:\n")
+        self.assertEqual(r.returncode, 0)
+        self.assertEqual(r.stdout, "")
+
+    def test_unparseable_json_is_silent(self) -> None:
+        r = run_with(emitting("not json at all"))
+        self.assertEqual(r.returncode, 0)
+        self.assertEqual(r.stdout, "")
+
+
+class TestHealthyBoardIsSilent(unittest.TestCase):
+    def test_writable_board_says_nothing(self) -> None:
+        r = run_with(emitting(HEALTHY))
+        self.assertEqual(r.returncode, 0)
+        self.assertEqual(
+            r.stdout,
+            "",
+            "a hook that speaks on every healthy session start stops being read",
+        )
+
+
+class TestReadOnlyBoardWarns(unittest.TestCase):
+    def test_one_line_naming_both_versions(self) -> None:
+        r = run_with(emitting(READ_ONLY))
+        self.assertEqual(r.returncode, 0)
+        self.assertEqual(len(r.stdout.strip().splitlines()), 1, r.stdout)
+        self.assertIn("v8", r.stdout)
+        self.assertIn("v9", r.stdout)
+
+    def test_names_the_asymmetry_that_hides_it(self) -> None:
+        # The whole reason this hook exists: reads keep working, so nothing
+        # looks wrong until a write. If the line does not say that, a reader
+        # will "verify" with `furrow ls`, see it answer, and dismiss the warning.
+        r = run_with(emitting(READ_ONLY))
+        self.assertIn("READ", r.stdout)
+
+    def test_outdated_offers_both_remedies_without_choosing(self) -> None:
+        # A flag day's ordering is the human's call, so the hook must not tell
+        # anyone to run `furrow upgrade` as if it were the obvious fix.
+        r = run_with(emitting(READ_ONLY))
+        self.assertIn("checkout", r.stdout)
+        self.assertIn("upgrade", r.stdout)
+
+    def test_too_new_points_at_the_binary_instead(self) -> None:
+        r = run_with(emitting(TOO_NEW))
+        self.assertIn("pull", r.stdout)
+        self.assertNotIn("upgrade", r.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
furrow gates **writes** on the board's layout version, and the failure is **asymmetric**: every **read** keeps working. `furrow sync`, `brief`, `ls` and `show` all answer normally while `add`/`set`/`note`/`done` exit 2 — so nothing looks wrong until the moment progress is recorded, and by then the session has usually been running for a while.

## Measured — twice in one evening (2026-08-12)

The PATH wrapper builds the furrow binary **from a source checkout**, and that checkout was deliberately parked one schema version behind because the board is mid-flag-day (pins move first, board last). It was moved off that commit:

1. by the session itself, cleaning up after a worktree — board read-only for ~20 min;
2. by a **concurrent session sharing that checkout** (`git checkout main` + `pull`, confirmed in the reflog) — board read-only again ~19 min later.

Both times the shared board became unwritable with **no visible symptom**, and both times it was caught only by running `furrow board` on a hunch. The mismatch is not exotic — it is the *normal* state during a pins-first rollout, and it recurs at every schema bump.

## Why `furrow board` is the probe

It is the one command that **reports** a version mismatch instead of failing on it. The check therefore cannot be blinded by the condition it is checking for.

## Behavior

| board state | output |
|---|---|
| `writable: true` | **silent** — a hook that speaks every session stops being read |
| `outdated` (binary ahead of board) | one line: both versions, the read/write asymmetry, **both** remedies |
| `too-new` (binary behind board) | one line pointing at the binary (`git pull` the source checkout) |
| no furrow / no jq / no board / bad JSON | silent, exit 0 |

**Warn-only, and it does not choose the remedy.** A flag day's ordering is the human's call, so the hook must not present `furrow upgrade` as the obvious fix — during the parked window, moving the *checkout* back is the correct answer instead.

It also names the read/write asymmetry explicitly, because without that a reader will "verify" with `furrow ls`, see it answer normally, and dismiss the warning.

## Verification

- `scripts/test_claude_furrow_board_note.py` — 9 cases: all four fail-open paths, the silence on a healthy board, the one-line shape naming both versions, the asymmetry mention, and the two remedy branches.
- Full dotfiles suite: **109 tests OK**. `shellcheck`, `shfmt -d`, `ruff`, `mypy` clean.
- `modify_settings.json` wiring verified end-to-end: `echo '{}' | bash modify_settings.json` emits the hook, and feeding its own output back produces a **byte-identical** file (idempotent).
- Ledger row added — the global CLAUDE.md rule *"board の layout が上がった直後は source checkout を git pull"* had **no** mechanism until now (📖 → 🟡).

🤖 Generated with [Claude Code](https://claude.com/claude-code)