### PR TITLE
:sparkles:(chord) hold TU_LL_F to drag-scroll, move rift focus next to TU_LL_G

### DIFF
--- a/chezmoi/dot_config/chord/private_config.toml
+++ b/chezmoi/dot_config/chord/private_config.toml
@@ -220,10 +220,21 @@ input = "TU_LL_D"
 action-shell = "rift-cli execute window prev"
 
 # doc: 次のウィンドウへ（rift フォーカス）
+# TU_LL_F は drag-scroll へ譲り、隣の TU_LL_G へ移動（2026-08-12）。
 [[bindings]]
 name = "rift focus next"
-input = "TU_LL_F"
+input = "TU_LL_G"
 action-shell = "rift-cli execute window next"
+
+# doc: ドラッグスクロール（押している間、マウス移動がスクロールになる）
+# 押している間だけカーソルを固定して、移動量をスクロールに変換する。
+# 離せば終わり。取りこぼしても max-ms で自動解除される。
+# invert = スクロールバーを掴んで動かす向き（下へ動かすと下へ進む）。
+[[bindings]]
+name = "drag-scroll"
+input = "TU_LL_F"
+action-drag-scroll = true
+action-drag-scroll-invert = true
 
 # ---- ZMK 単押し専用キー ----
 

--- a/docs/chord.md
+++ b/docs/chord.md
@@ -69,7 +69,8 @@ private_config.toml の `# doc:` 行＋`[[bindings]]` を編集 →
 | `TU_LL_V` | タブを右へ（Chrome: Ctrl+Tab） | com.google.Chrome |
 | `TU_LL_V` | タブを右へ（VS Code: Cmd+Shift+]） | com.microsoft.VSCode |
 | `TU_LL_D` | 前のウィンドウへ（rift フォーカス） | * |
-| `TU_LL_F` | 次のウィンドウへ（rift フォーカス） | * |
+| `TU_LL_G` | 次のウィンドウへ（rift フォーカス） | * |
+| `TU_LL_F` | ドラッグスクロール（押している間、マウス移動がスクロールになる） | * |
 | `VK_X1` | Mission Control（全ワークスペースをグリッド表示） | * |
 | `Ctrl + B` | ← Left | * |
 | `Ctrl + F` | → Right | * |


### PR DESCRIPTION
## What

Binds the held-pointer scroll mode that chord 3.0.0 added (akira-toriyama/chord#208):
hold `TU_LL_F`, the cursor pins, pointer motion becomes scroll, release ends it.
`action-drag-scroll-invert = true` gives scrollbar-grab direction (drag down → go down).

`TU_LL_F` already carried **rift focus next**, so that binding moves one key over to
the free `TU_LL_G` rather than being shadowed.

## Verification

- `chord config --validate --strict` against the applied config at `~/.config/chord/config.toml`:
  `parsed: 21 bindings, 1 fallbacks, 1 action-aliases; dropped: 0, undefined-action-aliases: 0, warnings: 0` — **exit 0**.
  Run with a **chord 3.0.0 release build from source** (`swift build -c release`); chord is not installed on this machine, so the `run_onchange_after_chord-validate.sh` hook is a no-op here and could not have caught anything.
- `python3 scripts/gen-chord-doc.py --check` → **`chord doc は同期済み`** (exit 0). `docs/chord.md` is generated, not hand-edited.
- `nix develop .#lint --command scripts/lint` → all gates pass on this branch.
- `glyph lint --range origin/main..HEAD` → clean.

## Release gating

`action-drag-scroll` / `-invert` are **chord 3.0.0+** keys, so `verify-chord-validate.yml`
(which installs from the brew tap and runs `--validate --strict`) would fail against an older
chord. Checked: `Formula/chord.rb` on the tap's `origin/main` already pins **v3.0.0**, so the
job installs a chord that knows these keys. (A local tap checkout pinned v1.0.0 is simply 51
commits stale.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)