### PR TITLE
:memo:(skills) recover the GUI-verify pointer-state notes that only existed in live

### DIFF
--- a/chezmoi/private_dot_claude/skills/macos-gui-verify/SKILL.md
+++ b/chezmoi/private_dot_claude/skills/macos-gui-verify/SKILL.md
@@ -58,8 +58,19 @@ SSH 経由の合成キー CGEvent は VM 内 app に**届かない**（マウス
   が欠落を deny）。timeout 無しの hang で一晩溶かした実績が起点。
 - **keysym は小文字**（`key down` / `key enter` / `key space`）。大文字 `key Down` は
   tart の VNC サーバ相手に無限 hang する（実測）。これも hook が deny。
-- **1 呼び出し 1 操作**に分割する。数珠つなぎの Bash が tool timeout を超えて
-  background 化 → 迷子になった実績。各操作の後に capture で即検証。
+- **Bash 1 回 = vncdo 1 invocation** に分割する。数珠つなぎの Bash が tool timeout を
+  超えて background 化 → 迷子になった実績。各操作の後に capture で即検証。
+- ただし **vncdo は接続（invocation）ごとに pointer/modifier 状態が独立** —
+  invocation を跨いだ `move` は次の `mousedown` に引き継がれず (0,0) クリックに
+  化ける（2026-08-11 実測: ⌘drag のつもりが壁紙 ⌘click → desktop reveal 発動）。
+  **drag・修飾キー付き操作は 1 invocation 内に連鎖必須**:
+  `vncdo --timeout 25 -s … keydown super move X Y mousedown 1 move X2 Y2 mouseup 1 keyup super`。
+  連鎖の途中に `capture out.png` を挟めば mid-drag の視覚も取れる。
+- **修飾キー combo `key super-n` は modifier が落ちて素の `n` になる**（実測）。
+  combo は使わず `keydown super key n keyup super` 連鎖にする — それでも VM 内
+  アプリに cmd+N が届かないことがあり、その場合は SSH 側 `peekaboo menu click
+  --app <App> --item "New"` が確実。マウスも SSH 側 `capsule-click X Y` が
+  pointer 状態問題と無縁で、VNC より信頼できる（キーだけが VNC 必須）。
 - サーバは実質シングルクライアント: hang したクライアントが居座ると後続が全部
   詰まる。詰まったら `pkill -f "vncdo -s"` してから撮り直す。
 - capture はフレームバッファ直取りで TCC 不要。ホイールは SSH 経由 `peekaboo scroll`


### PR DESCRIPTION
## What

`chezmoi status` reported `MM .claude/skills/macos-gui-verify/SKILL.md` — the live file had
been hand-edited after the last apply and never re-added, so **live was ahead of source**.
A whole-tree `chezmoi apply` would have silently deleted 11 lines of measured operating knowledge.

This is `chezmoi re-add` of that file. Source now matches what has actually been distributed
since 2026-08-11; **the live file is byte-identical before and after**, so nothing changes for
the running harness.

## Why this was a real loss, not a stale-source false alarm

```
git log -S "pointer/modifier 状態が独立" -- chezmoi/private_dot_claude/skills/macos-gui-verify/SKILL.md
→ (empty)
```

The text has never existed in any commit. Source mtime `2026-08-11 03:05` (commit ff2a5bf,
#325) predates live mtime `2026-08-11 11:16`. Single hunk, +13/−2.

## Recovered content

Three notes replacing a one-line *"split one call per operation"* bullet:

- pointer/modifier state is **per-invocation** — a `move` in one invocation does not carry into
  the next one's `mousedown`, and degrades to a `(0,0)` click
- drags and modified operations must be **chained inside one invocation**; a mid-chain capture
  still yields the mid-drag frame
- the `key super-n` combo form **drops the modifier**; SSH-side `peekaboo` is the reliable
  fallback for menu and pointer work

## Provenance

Stated rather than implied: these claims are **inherited** from the 2026-08-11 session and carry
its `実測` markers. I did **not** re-measure them — that needs the Tart VM lab, and this is a
drift capture, not a behaviour change. They are recorded as that session measured them.

## Verification

- `nix develop .#lint --command scripts/lint` → **13 gates passed**. `claude-md-guard` is satisfied by the `Glossary-unchanged:` footer (the added text is operating detail for an existing tool, not a new canonical term).
- `glyph lint --range origin/main..HEAD` → clean.
- `chezmoi status` → clean (empty) after the re-add and a subsequent apply.

## Related

t-1px4 tracks the same drift class for `.claude/settings.json` and `.ssh/known_hosts`. Those
files are untouched here and stay open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)