### PR TITLE
:arrow_up:(ci) pin glyph v2.0.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,9 +51,9 @@ jobs:
           persist-credentials: false
 
       - name: install glyph
-        uses: akira-toriyama/glyph/.github/actions/install@v1.0.0
+        uses: akira-toriyama/glyph/.github/actions/install@v2.0.0
         with:
-          version: v1.0.0
+          version: v2.0.0
           token: ${{ github.token }}
 
       - name: Compose the verdict and upsert the rolling DRAFT


### PR DESCRIPTION
Moves every glyph pin in this repo to **v2.0.0**, the version `fleet/commit-lint.yml` distributes.

These sites are NOT fleet-managed: they live in files this repo owns, so `fleet-sync` cannot byte-copy them and until now they moved only by hand — one pull request per repo, per glyph release.

Files:
- .github/workflows/release.yml

Only lines carrying a glyph pin were changed; the rewriter refuses and writes nothing if any other line moves. See `akira-toriyama/.github`: `scripts/glyph-pin-rewrite.sh`, `docs/glyph-rollout-runbook.md`.