### PR TITLE
:bug:(claude) keep the failure output when the monthly maintenance run dies

### DIFF
--- a/system/modules/scripts/claude-maint.sh
+++ b/system/modules/scripts/claude-maint.sh
@@ -238,6 +238,12 @@ RUN_LOG="$WT/.claude-maint-run.log"
   --output-format text \
   "$PROMPT") >"$RUN_LOG" 2>&1 || CLAUDE_RC=$?
 sed "s/^/$LOG_PREFIX claude| /" "$RUN_LOG" 2>/dev/null || true
+# 失敗の証拠はレポート (= PR 本文) に載せる。ここで捨てると診断材料が二重に消える:
+# RUN_LOG は直後に rm され、唯一の写しである launchd の /tmp/claude-maint.log も
+# 再起動で消える。実際 2026-08 の第 1 回は「rc=1」という自己申告だけが残り、
+# 原因を特定できないまま t-8tkm になった。
+CLAUDE_TAIL=""
+[ "$CLAUDE_RC" -eq 0 ] || CLAUDE_TAIL=$(tail -n 20 "$RUN_LOG" 2>/dev/null || true)
 rm -f "$RUN_LOG" # PR に含めない
 [ "$CLAUDE_RC" -eq 0 ] || log "claude exited rc=$CLAUDE_RC (続行: レポート有無で判断)"
 
@@ -249,6 +255,18 @@ if [ ! -s "$WT/$REPORT_REL" ]; then
     echo
     echo "- 実行: $(date '+%F %T')"
     echo "- ⚠️ claude による判断が完了しなかった (rc=$CLAUDE_RC)。使用統計のみ記録。"
+    if [ -n "$CLAUDE_TAIL" ]; then
+      echo
+      echo '## 失敗の記録 (claude の出力・末尾 20 行)'
+      echo
+      echo "rc=$CLAUDE_RC。よくある原因は予算 (\$${MAX_BUDGET_USD}) 到達で、"
+      echo "その場合 claude は Error: Exceeded USD budget を出して rc=1 で終わる"
+      echo "(2026-08-19 実測)。上限は CLAUDE_MAINT_MAX_USD で上げられる。"
+      echo
+      echo '```'
+      echo "$CLAUDE_TAIL"
+      echo '```'
+    fi
     echo
     echo '## 使用統計'
     echo '```'


### PR DESCRIPTION
furrow t-8tkm。

## 症状

`docs/claude-maint-reports/2026-08.md`（月次 run 第 1 回）が自認していた内容:

```
- ⚠️ claude による判断が完了しなかった (rc=1)。使用統計のみ記録。
```

原因が特定できないまま止まっていたのは、**証拠が二重に消えるから**だった:

1. `RUN_LOG` は launchd ログへ sed した直後に `rm -f` される
2. その唯一の写しである `/tmp/claude-maint.log`（`claude-maint.nix` L33-34）も既に存在しない

## 変更

`rm -f` の前に `tail -n 20` を取り、rc≠0 のときだけフォールバックレポートへ「失敗の記録」節として載せる。レポートは PR 本文になるので、揮発しない場所に残る。

## 実測（このセッションで再現した／潰した仮説）

- **予算到達は rc=1 になる**: `claude --print --permission-mode acceptEdits --allowedTools "…" --max-budget-usd 0.0001 --output-format text "…"` → `Error: Exceeded USD budget (0.0001)` / rc=1。`MAX_BUDGET_USD` の既定は 3 なので、症状と形が完全に一致する。**候補であって断定ではない** —— 8 月の実 run の原因は上記のとおり証拠が無く特定不能。
- **反証済みの仮説**: 「`--allowedTools` を空白区切りの 1 文字列で渡しているので tool が 1 つも許可されていない」→ **誤り**。同じ引数形のまま Write が通ってファイルが生成され rc=0 だった。フラグ 5 種はすべて現行 CLI に実在する。

## 検証

- `bash -n` 通過
- `nix develop .#lint --command scripts/lint` 13 ゲート緑（shellcheck / shfmt 含む）
- フォールバックブロックを単体で描画し、Markdown として壊れないことを確認

SetStatus-task: https://github.com/akira-toriyama/projects/blob/main/.furrow/bodies/t-8tkm.md done

🤖 Generated with [Claude Code](https://claude.com/claude-code)