### PR TITLE
:memo:(claude) point quota reading at the session hook and fix the Fable-inheritance claim

### DIFF
--- a/chezmoi/private_dot_claude/CLAUDE.md
+++ b/chezmoi/private_dot_claude/CLAUDE.md
@@ -134,13 +134,13 @@
 - **Fable 枠**: 独立バケットではなく全体 Weekly と同一原資（Fable 枠 ≈ 全体の 50%・
   重さ ≈ Opus の 2 倍）。不変条件 `Fable% ≥ Weekly%`、目標は約 4 日で Fable 週枠 100%
   （均等割りしない・前倒し可）。枠が尽きたら Opus で粘る（追加課金しない）— これは
-  「コストは制約ではない」より上。枠の読み方: `~/.claude.json` の
-  `cachedUsageUtilization.utilization.limits[]`（`kind=weekly_all` と Fable scoped の
-  `percent`。鮮度は同オブジェクトの `fetchedAtMs`）。
+  「コストは制約ではない」より上。枠の実数は SessionStart hook が毎セッション冒頭に
+  出す（読み方の正本 = claude-quota-note script）。
 - Opus が難所で失敗したら都度 task body に「Opus で N 回失敗（原因）」と書く
   （会話記憶はセッションを跨がない）。ユーザーの「これ Fable で」は割合判断に優先する。
 - Fable セッションのサブエージェントは既定継承させない（探索 = `sonnet` + low・
-  検証 = `opus` を明示。漏れると黙って全員 Fable になる）。検証・レビューは常に Opus 側。
+  検証 = `opus` を明示。漏れると Plan・general-purpose は黙って Fable を継承する —
+  実測 2026-08-19。Explore 等は継承しない）。検証・レビューは常に Opus 側。
 
 ## Mac アプリ（Swift）
 

--- a/docs/claude-md-ledger.md
+++ b/docs/claude-md-ledger.md
@@ -56,7 +56,7 @@
 | Fable のファンアウト禁止（モデル運用節） | `fable-architect` 経由でのみ | — | [agents/fable-architect.md](../chezmoi/private_dot_claude/agents/fable-architect.md) の `tools:` に Agent 非搭載 → harness が拒否 | 🔒 Agent 経路のみ |
 | Fable%≥Weekly% 不変条件・約 4 日で 100%・尽きたら Opus（モデル運用節・正典に無い） | 開幕 quota 行を見て委譲判断 | 「これ Fable で」の発令・課金判断 | SessionStart hook [claude-quota-note](../chezmoi/dot_local/bin/executable_claude-quota-note) が Weekly% / Fable% と不変条件の充足/割れを毎セッション冒頭に提示（fail-open・fixture テストつき） | 🟡 数字は毎回出るが、委譲判断そのものは散文 |
 | Opus 失敗の body 記録（モデル運用節） | 都度 task body に書く | — | なし | 📖 |
-| 分担・Fable セッションで既定継承させない・検証は Opus 側（モデル運用節） | サブエージェントの model/effort を明示 | `/model fable` への切替 | なし。指定漏れは黙って全員 Fable | 📖 |
+| 分担・Fable セッションで既定継承させない・検証は Opus 側（モデル運用節） | サブエージェントの model/effort を明示 | `/model fable` への切替 | なし。指定漏れの継承は subagent_type 依存（Plan・general-purpose のみ — 2026-08-19 の 4081 transcript 実測。旧文言「全員 Fable」は誇張だった） | 📖 |
 | SwiftUI+Sill・AppKit は essential floor・最新 macOS のみ（Mac アプリ節） | 設計・実装時に適用 | — | なし | 📖 |
 | 他 repo は慣習に従う・自分の規約を持ち込まない（他リポジトリ節） | repo の CLAUDE.md/CONTRIBUTING/履歴を先に読む | — | なし | 📖 |
 
@@ -91,6 +91,7 @@
 | N 宣言・入口フィルタ 4 分類（質問フロー細則） | 縮約 | 一問一答・推奨・委任の核だけ残存 | 質問の質が落ちる実害が出たら |
 | 現在地ワンショットの読み方解説（`# branch.ab` の意味等） | nice-to-have | コマンド自体は残存 | — |
 | pare/cifail/rundiff の詳細解説（フラグ・profile の理由） | 縮約 | トリガー→コマンド 1 行ずつに | ツールの誤用が頻発したら |
+| 枠の読み方の jq 詳細（モデル運用節・2026-08-19） | 移設 | 実数は SessionStart hook が毎セッション出す — 読み方の正本は claude-quota-note script 自身 | hook が退役したら global へ戻す |
 
 ## ユーザーの手番（一覧）
 


### PR DESCRIPTION
## What

The surviving, eval-exempt slice of the t-gjej stage-2 edit (fact fix + pointerization only):

- **Fable-inheritance claim corrected**: "omitting a subagent model silently makes every agent Fable" is measured to be false — inheritance is subagent_type-dependent (only Plan and general-purpose inherit; Explore and claude-code-guide fall to their own defaults; 4,081-transcript measurement, adversarially verified in t-dfyq). Prose and ledger row updated.
- **Quota reading pointerized**: the jq recipe for `~/.claude.json` duplicated what the claude-quota-note SessionStart hook computes and prints at the top of every session. The hook script is now the named canon; the recipe's removal is recorded in the ledger's deletion table as a transfer.

## What was withdrawn, and why

The stage-2 candidate originally also unified the dev-premise block (go-dev / mac-app-dev near-duplicates) into the global 開発ポリシー section. The claude-md-eval release gate blocked it twice on a 2-arm run (run 1: candidate won 23:13 but with +19% excess content-cut wins; run 2 after rewording: candidate lost 15:21). The two runs swung in opposite directions on small margins — the fixed 16-case set is conversation-shaped and has no dev-context cases, so it cannot resolve this diff. The unification is withdrawn until it can be measured properly; the skills keep their existing blocks. Details and verdict data in t-gjej's body.

## Verification

- `scripts/lint` via `nix develop .#lint` — 13 gates green (claude-md-guard: 11,254 bytes ≤ 11,500)
- `glyph lint --range origin/main..HEAD` — clean (borrowed glyph repo config; dotfiles glyph.toml gap = .github t-6bxz)

SetStatus-task: https://github.com/akira-toriyama/projects/blob/main/.furrow/bodies/t-gjej.md in-progress

🤖 Generated with [Claude Code](https://claude.com/claude-code)