### PR TITLE
:memo:(claude) translate the global CLAUDE.md to English and cut duplicated rules

### DIFF
--- a/chezmoi/private_dot_claude/CLAUDE.md
+++ b/chezmoi/private_dot_claude/CLAUDE.md
@@ -1,153 +1,181 @@
-# akira-toriyama のリポジトリに対して
+# For akira-toriyama repositories
 
-## この文書の読み方
+## How to read this document
 
-毎セッション全文ロードされる、全 repo 共通の既定ルール。
+Loaded in full every session, in every repo — the fleet-wide defaults.
 
-- **規範が食い違ったら上が勝つ**: ①ユーザーのその場の指示 ②作業中 repo の CLAUDE.md
-  ③リンク先の正典 ④この文書。
-- **正典に無い事実は、この文書が一次の置き場**（該当箇所に「正典に無い」と明記してある。
-  そこから削ると常時ロードの文脈から消える）。
-- **正典マップ**:
+- **When norms conflict, the higher one wins**: ① the user's in-session
+  instruction ② the working repo's CLAUDE.md ③ the linked canon ④ this document.
+- **Facts that have no canon live here first** (marked "no canon" where they
+  appear — deleting them removes them from the always-loaded context).
+- **Canon map**:
 
-  | topic | 正典 |
+  | topic | canon |
   |---|---|
-  | task 運用ルール | [projects/CLAUDE.md](https://github.com/akira-toriyama/projects/blob/main/CLAUDE.md) |
-  | commit 規約 | [CONTRIBUTING.md](https://github.com/akira-toriyama/.github/blob/main/CONTRIBUTING.md)（機械検査 = `glyph lint`） |
-  | fleet 変更の段取り | [fleet-change-policy.md](https://github.com/akira-toriyama/.github/blob/main/docs/fleet-change-policy.md) |
-  | Sill の library 契約 | [Sill](https://github.com/akira-toriyama/sill) の `Package.swift` |
-  | ルールの強制状態・削除記録 | dotfiles の [claude-md-ledger.md](https://github.com/akira-toriyama/dotfiles/blob/main/docs/claude-md-ledger.md) |
-  | 文書の一貫性・言語（英語のみ・翻訳を持たない） | [doc-consistency-policy.md](https://github.com/akira-toriyama/.github/blob/main/docs/doc-consistency-policy.md) |
+  | task operations | [projects/CLAUDE.md](https://github.com/akira-toriyama/projects/blob/main/CLAUDE.md) |
+  | commit convention | [CONTRIBUTING.md](https://github.com/akira-toriyama/.github/blob/main/CONTRIBUTING.md) (machine check = `glyph lint`) |
+  | fleet-wide change procedure | [fleet-change-policy.md](https://github.com/akira-toriyama/.github/blob/main/docs/fleet-change-policy.md) |
+  | Sill library contract | [Sill](https://github.com/akira-toriyama/sill) `Package.swift` |
+  | rule enforcement status / deletion log | dotfiles [claude-md-ledger.md](https://github.com/akira-toriyama/dotfiles/blob/main/docs/claude-md-ledger.md) |
+  | doc consistency / language (English only, no translations) | [doc-consistency-policy.md](https://github.com/akira-toriyama/.github/blob/main/docs/doc-consistency-policy.md) |
 
-## 出力の形
+## Output shape
 
-**正確さと安全が短さに優先する。**調べる深さは制限しない — 制限するのは会話に出す分量だけ。
+**Accuracy and safety outrank brevity.** Depth of investigation is uncapped —
+only what goes into the conversation is.
 
-- 1 行目は結論・コマンド・パスから。理由は後。
-- 1 回の返答はスクロールなしで読み切れる長さ。ただし、頼まれた列挙・網羅 /
-  リスク・破壊的副作用の指摘 / 実測と未確認を分ける報告は、削らない。
-- 質問は 1 問ずつ。既定値で進められる場面では聞かずに成果物を出し、置いた前提を添える。
-- 複数手順の作業では現在地を毎ターン書く（「5 中 3 完了」）。
-- エラーは淡々と、原因 → 修正の順。
-- 送信前に、予告するだけの最初の一文と「他にありますか」系の最後の一文を削る。
-  本物の不確かさを表すぼかしは残す（消すと確信の捏造になる）。
+- Line 1 is the conclusion, command, or path. Reasons come after.
+- Keep one reply readable without scrolling. Never trim: enumerations or
+  exhaustive coverage the user asked for, warnings about risk or destructive
+  side effects, and reports that separate measured from unverified.
+- Ask one question at a time. Where a default lets you proceed, ship the
+  deliverable without asking and state the assumptions you made.
+- In multi-step work, state your position every turn (「5 中 3 完了」).
+- Errors: matter-of-fact, cause → fix.
+- Before sending, delete a first sentence that only announces what follows and
+  a closing 「他にありますか」-type sentence. Keep hedges that mark real
+  uncertainty — deleting them fabricates confidence.
 
-## 作業の締め（依頼された作業を実行して終えた時だけ）
+## Work closing (only after executing requested work)
 
-- 締めを付けるのは、依頼された作業を実行して終えた時だけ。質問への回答・エラー報告・
-  相談・壁打ち・状況共有は普通の会話 — 締めの 2 要素も counts も付けない
-  （`closed 0 / created 0` と書きたくなったら、まず締めの場面かを疑う）。
-- 締めに必須の 2 要素（文面自由・Stop hook が検査）:
+- Attach a closing only when you executed requested work and finished it.
+  Answers to questions, error reports, consultations, sparring, and status
+  shares are plain conversation — no closing elements, no counts (the urge to
+  write `closed 0 / created 0` is a cue to first doubt whether this is a
+  closing at all).
+- The two required elements (wording free; the Stop hook checks):
 
   ```
   やり残し: t-xxxx, t-yyyy（無ければ「なし」）
   closed N / created M
   ```
 
-  予算は `created ≤ closed − 1`。超えてよいのは今日の作業が生んだ blocker だけで、
-  counts 行かその直後に理由 1 行。超える分は、その場で直す（effort ≤ 2 かつ今触っている
-  コード内）か icebox に落とす。
-- 質問・報告は一問一答・推奨つき（「XXX です。推奨は ZZZ です」）。ユーザーの
-  「残り全部推奨で」で残りを推奨値で確定。終わったら決定事項と自分で決めた事項を開示。
+  Budget: `created ≤ closed − 1`. Only blockers born from today's work may
+  exceed it, with a one-line reason on or right after the counts line.
+  Anything else over budget: fix it on the spot (effort ≤ 2 and inside the
+  code at hand) or drop it to icebox.
+- Questions and reports: one at a time, with a recommendation
+  (「XXX です。推奨は ZZZ です」). The user's 「残り全部推奨で」 settles the
+  rest at the recommended values. When done, disclose what was decided and
+  what you decided on your own.
 
-## Workflow（タスク管理）
+## Workflow (task management)
 
-運用ルールの正典は projects/CLAUDE.md（正典マップ参照）。
+Canon for operating rules = projects/CLAUDE.md (canon map).
 
-- タスク管理は furrow + private repo `projects` に一本化。furrow は PATH の wrapper
-  （常に source 反映）で叩く。furrow 自身を開発する時だけ source dir で
-  `go run ./cmd/furrow`。board の layout が上がった直後は各マシンで furrow の
-  source checkout を `git pull` してから叩く（古い HEAD のままだと `schema-too-new`
-  で board に書けない）。
-- 読む前・書いた後に `furrow sync`。session start は `furrow sync && furrow brief`
-  で orient（active epic・next の先頭・lint 件数が 1 読で出る）。
-- 進捗の正本はその task body 一本（memory・ブランチ上のファイルに複製しない）。
-  中断時は body のチェックを更新し、次セッションへの希望を 1 行残す。
-- 起票の既定 lane は `icebox`（backlog 以上に置くのは「戻る価値」を 1 行で言えるものだけ。
-  迷ったら icebox — 消去ではなく `furrow set <id> -s backlog` で戻せる）。
-  ユーザーが明示的に依頼した起票はこの既定の対象外。
-- 指示が無ければ `furrow brief`（= next の先頭）から着手し、何を選んだか 1 行報告。
-  next は active epic の member + epic 未所属に絞られる（active が無ければ意図的に空）。
-  **active epic の切り替えは申請制 — 勝手に `furrow epic activate` しない**。
-  質問・状況共有・相談への返答を作業開始の合図と読まない。
-- 予約箱 epic が各 repo に常設: `mandate`=人間指示 / `parking-lot`=ゴール外の受け皿 /
-  `requests`=**別 repo への要望はここへ**。正本 = projects の docs/reserved-epics.md
-  （機械検査 = projects lint。SessionStart hook・pre-push・日次 CI が表示）。
-- code repo の PR 本文に footer を 1 行:
+- Task management lives in furrow + the private repo `projects`, nowhere else.
+- `furrow sync` before reading and after writing. Session start:
+  `furrow sync && furrow brief` to orient.
+- The single source of progress is the task body (no copies in memory or in
+  files on a branch). On interruption, update the body's checkboxes and leave
+  one line of what you hope the next session does.
+- Default lane for new tasks is `icebox` (backlog or above only when the
+  reason to return fits one line; if torn, icebox — it is not deletion,
+  `furrow set <id> -s backlog` brings it back). Filings the user explicitly
+  asked for are exempt from this default.
+- Without instructions, start from `furrow brief` (= head of next; it is
+  intentionally empty when no epic is active) and report your pick in one
+  line. **Switching the active epic is by request — never run
+  `furrow epic activate` on your own.** Do not read a reply to a question,
+  status share, or consultation as a GO signal.
+- Reserved box epics exist in every repo: `mandate` = human orders /
+  `parking-lot` = catch-all for anything outside the goal / `requests` =
+  **wishes toward another repo go here**. Canon = projects
+  docs/reserved-epics.md.
+- One footer line in code-repo PR bodies:
   `SetStatus-task: https://github.com/akira-toriyama/projects/blob/main/.furrow/bodies/<id>.md <lane>`
 
-## 開発ポリシー
+## Development policy
 
-- **品質 > 速度**。コストは制約ではない（ユーザー明言:「コストより品質」）。
-- **迷ったら一貫性**: 既存の設計・慣習・過去の決定と揃う側を選ぶ。
-- **成果物は英語のみ**: committed な文書・commit・PR・issue は英語で書き、翻訳ファイル
-  （README.ja 等）を持たない（正本 = doc-consistency-policy）。会話と furrow task は日本語。
-- **破壊的変更 OK**: 自分の repo では互換レイヤーを残すより綺麗に壊して major。
-  保守側の理由が具体的な消費者・データ・利用箇所を指せないなら壊す方を採る。
-- **「できた」は実測とセット**: test 緑・CI success・merged は「実行できた」証拠であって
-  「意図した状態になった」証拠ではない。適用・配布は成果物側を読み直して数える
-  （memory に書いた翌日に同じ罠を踏んだ実績 — 散文の記憶では止まらない）。
-- **未検証の観測を task や報告に書かない**: 自分で再現・実測していないシステム挙動の
-  主張は、独立エージェントに「refute しろ」と明示して反証 1 周してから書く。自己申告
-  confidence でのスキップ禁止（11 件中 6 件否定の実績）。task body には出所と検証状態を書く。
-- **機構化（lint / hook / test / ルール追加）は、①既に踏んだ失敗の再発防止で
-  ②created 予算内のものに限る**。1 回目の失敗はその場で直して終わり。
-  あったら便利そうな機構・ルールは作らない。
-- 全 repo に波及する変更（glyph・fleet canonical 等）は fleet-change-policy.md の段を踏む。
-- 許可: 調査のための clone・ドキュメント DL は自由 / Tart VM の中は sudo 含め全操作 OK
-  （ホストの sudo は対象外・コマンド提示までにする）/ GitHub Packages への配布 OK。
+- **Quality > speed**. Cost is not a constraint (user's words:
+  「コストより品質」).
+- **When torn, pick consistency**: the side that matches existing design,
+  conventions, and past decisions.
+- **Deliverables are English only**: committed docs, commits, PRs, and issues
+  are written in English, with no translation files (README.ja and the like;
+  canon = doc-consistency-policy). Conversation and furrow tasks are Japanese.
+- **Breaking changes are fine** in own repos: break clean and bump major
+  rather than keep a compat layer. If the cautious side cannot name a concrete
+  consumer, data, or call site, break it.
+- **"Done" comes with a measurement**: green tests, CI success, and merged are
+  evidence that it *ran*, not that the intended state exists. Verify
+  application and distribution by re-reading the artifact itself.
+- **No unverified observations in tasks or reports**: a claim about system
+  behavior you did not reproduce or measure yourself gets one refutation pass
+  first, by an independent agent explicitly told to refute it. No skipping on
+  self-declared confidence (6 of 11 such claims fell). Write the source and
+  verification status into the task body.
+- **Mechanization (lint / hook / test / new rule) only when ① it prevents
+  recurrence of an already-hit failure and ② it fits the created budget.** A
+  first-time failure is fixed on the spot, and that is all. Never build
+  might-be-useful mechanisms or rules.
+- Changes that ripple across every repo (glyph, fleet canonicals, …) follow
+  the steps in fleet-change-policy.md.
+- Allowed: cloning repos and downloading docs for research, freely / every
+  operation including sudo inside a Tart VM (host sudo excluded — present the
+  command and stop) / publishing to GitHub Packages.
 
-## 道具（生ログ・手書きループより先に）
+## Tools (before raw logs or hand-written loops)
 
-- repo 現在地ワンショット:
+- Repo one-shot:
 
   ```sh
   git status --porcelain=v2 --branch --show-stash; echo ---; git log --format='%h|%cs|%s' -5; echo ---; git worktree list --porcelain
   ```
 
-- 長い出力 → `<cmd> 2>&1 | pare`（test 実行は `| pare --profile test`）
-- CI 失敗の要点 → `cifail`（`wait` = 終了まで待つ / `delta` = 直近の緑との差分 / `flake` = flaky 判定）
-- 同じコマンドの再実行差分 → `rundiff`（主要 test runner は PreToolUse hook が自動 wrap）
-- findings の PR レビュー投稿 → `revpost`（`--dry-run` あり）
-- 条件待ち → condition-wait skill（wait4x）/ macOS GUI 検証 → macos-gui-verify skill（peekaboo）
-- **外部待ちは deadline 必須**・停滞は即報告・状態質問は実測後に答える
-- **自作 CLI・アプリは source で使う**: CLI は dotfiles `packages.nix` の source-build
-  wrapper、GUI アプリは Xcode ビルド。`brew install` しない（brew が wrapper を shadow する）。
+- Long output → `<cmd> 2>&1 | pare` (test runs: `| pare --profile test`)
+- CI failure digest → `cifail` (`wait` = block until it ends / `delta` = diff
+  against the last green / `flake` = flakiness verdict)
+- Re-run diff of the same command → `rundiff` (major test runners are
+  auto-wrapped by a PreToolUse hook)
+- Posting findings as a PR review → `revpost` (has `--dry-run`)
+- Waiting on a condition → condition-wait skill (wait4x) / macOS GUI
+  verification → macos-gui-verify skill (peekaboo)
+- **External waits require a deadline**; report stalls immediately; answer
+  state questions after measuring, not before.
+- **Run self-built CLIs and apps from source**: CLIs via the source-build
+  wrappers in dotfiles `packages.nix`, GUI apps via Xcode builds. Never
+  `brew install` them — brew shadows the wrapper. Exception: while developing
+  the tool itself, run it from its source dir (furrow:
+  `go run ./cmd/furrow`).
 
 ## Commits
 
-- gitmoji-driven: `<:gitmoji:>[(<scope>)][!] <subject>`。規約は暗記せず CONTRIBUTING.md（正典マップ）を引く。
-- **push 前に `glyph lint --range origin/main..HEAD`**（push 後に CI で落ちるのは
-  1 往復の無駄 — 実際に起きた）。
-- subject も body も英語。和訳は付けない（2026-08-02 廃止）。
+- gitmoji-driven: `<:gitmoji:>[(<scope>)][!] <subject>`. Don't recite the
+  convention from memory — open CONTRIBUTING.md (canon map).
+- **Before pushing: `glyph lint --range origin/main..HEAD`** (failing in CI
+  after the push wastes a round trip — it has happened).
+- Subject and body in English; no Japanese translation attached.
 
-## モデル運用（この節の事実は正典に無い — ここが一次の置き場）
+## Model operations (facts here have no canon — this is their primary home)
 
-既定 = 最新 Opus（`opus[1m]` alias）+ effort xhigh。ultracode は毎セッション手動
-（恒久設定は Claude Code 仕様上不可）。settings にもこの文書にも具体版 ID を書かない
-（pin して実体とずれた実績）。メインループのモデルは Claude からは切り替え不可で、
-難易度を検知して自動で切り替える機構も存在しない。
+Default = latest Opus (`opus[1m]` alias) + effort xhigh. ultracode is manual
+every session (a permanent setting is impossible by Claude Code design). No
+concrete version IDs in settings or in this document (a pin has drifted from
+reality). Claude cannot switch the main-loop model, and no mechanism detects
+difficulty and switches it automatically.
 
-- **分担**: 最新 Opus = メインループ・並列網羅・レビュー・検証 / Sonnet = 機械的
-  サブエージェント（`effort: low`）/ Fable = 単独深考のみ・`fable-architect` 経由
-  （ファンアウト禁止 — Agent 経路は harness が拒否する）。
-- **Fable 枠**: 独立バケットではなく全体 Weekly と同一原資（Fable 枠 ≈ 全体の 50%・
-  重さ ≈ Opus の 2 倍）。不変条件 `Fable% ≥ Weekly%`、目標は約 4 日で Fable 週枠 100%
-  （均等割りしない・前倒し可）。枠が尽きたら Opus で粘る（追加課金しない）— これは
-  「コストは制約ではない」より上。枠の実数は SessionStart hook が毎セッション冒頭に
-  出す（読み方の正本 = claude-quota-note script）。
-- Opus が難所で失敗したら都度 task body に「Opus で N 回失敗（原因）」と書く
-  （会話記憶はセッションを跨がない）。ユーザーの「これ Fable で」は割合判断に優先する。
-- Fable セッションのサブエージェントは既定継承させない（探索 = `sonnet` + low・
-  検証 = `opus` を明示。漏れると Plan・general-purpose は黙って Fable を継承する —
-  実測 2026-08-19。Explore 等は継承しない）。検証・レビューは常に Opus 側。
+- **Division of labor**: latest Opus = main loop, parallel sweeps, review,
+  verification / Sonnet = mechanical subagents (`effort: low`) / Fable = solo
+  deep thinking only, via `fable-architect` (no fan-out — the harness refuses
+  the Agent path).
+- **Fable quota**: not a separate bucket — it draws on the same pool as the
+  overall Weekly. Invariant: `Fable% ≥ Weekly%`. Target: reach 100% of the
+  Fable weekly quota in about 4 days (do not pace it evenly; front-loading is
+  allowed). When it runs dry, persist on Opus — do not buy extra quota; this
+  outranks "cost is not a constraint". The real numbers appear at every
+  session start via the SessionStart hook (canon for reading them = the
+  claude-quota-note script).
+- When Opus fails at a hard spot, write 「Opus で N 回失敗（原因）」 into the
+  task body each time (conversation memory does not cross sessions). The
+  user's 「これ Fable で」 overrides any ratio judgment.
+- In Fable sessions, never let subagents inherit the default model (state it
+  explicitly: exploration = `sonnet` + low / verification = `opus`. Left
+  unstated, Plan and general-purpose silently inherit Fable — measured
+  2026-08-19; Explore and the rest do not). Verification and review always sit
+  on the Opus side.
 
-## Mac アプリ（Swift）
+# For repositories outside akira-toriyama
 
-- UI は SwiftUI + Sill（契約の正本は Sill の `Package.swift`）。AppKit は SwiftUI で
-  届かない essential floor に限る（判断基準は software-architecture skill）。
-- ターゲットは最新 macOS のみ（古い OS 向けの分岐・workaround を書かない）。
-
-# akira-toriyama 以外のリポジトリに対して
-
-- その repo の慣習に従う。自分の規約（gitmoji・furrow・skill）を持ち込まない。
+- Follow that repo's conventions. Leave your own (gitmoji, furrow, skills) at
+  the door.

--- a/chezmoi/private_dot_claude/skills/mac-app-dev/SKILL.md
+++ b/chezmoi/private_dot_claude/skills/mac-app-dev/SKILL.md
@@ -19,7 +19,7 @@ description: Use when developing, modifying, or debugging a macOS app in Swift (
   ② 既存 AppKit コードの **legacy 保守**。下の落とし穴節はこの 2 つに効く実装知識。
 - **足りない部品はアプリ側に one-off で足す前に Sill への PR を検討する**（共通化できるものを
   各アプリに散らさない）。
-- OS サポートは**最新 macOS のみ**。古い OS 向けの availability 分岐は書かない。
+- OS サポートは**最新 macOS のみ**。古い OS 向けの分岐・workaround は書かない。
 
 ## GUI 検証 → `macos-gui-verify` skill 参照
 

--- a/docs/claude-md-ledger.md
+++ b/docs/claude-md-ledger.md
@@ -25,40 +25,38 @@
 
 | ルール（正本 = global CLAUDE.md の節） | Claude の手番 | ユーザーの手番 | 機構 | 印 |
 |---|---|---|---|---|
-| precedence と正典マップ（読み方節） | 食い違いを ①ユーザー指示 ②repo CLAUDE.md ③正典 ④本書 の順で解決 | — | なし | 📖 |
-| 出力の形・全規則（出力の形節） | 会話で適用 | — | claude-md-eval で**測定**は可能（強制ではない。測定義務は dotfiles/CLAUDE.md へ移設済み） | 📖 |
-| 作業の締めの 2 要素契約（作業の締め節） | やり残し ID（or なし）+ `closed N / created M` を書く | — | Stop hook [claude-work-report-check](../chezmoi/dot_local/bin/executable_claude-work-report-check)（PR #270→#294 で契約化）: arming = 旧冒頭文 / やり残し行 / counts トークン。ID・実数・超過理由（counts 行±1）を検査。**同数（created == closed かつ > 0）も超過として block・0/0 のみ免除**。CI に fixture 29 + 変異検証 | 🟡 締め自体の**発火**（完全な書き忘れ）は判定不能で 📖 のまま |
-| 生成予算 created ≤ closed − 1・icebox 既定（作業の締め節・Workflow 節） | 予算内に収める。起票既定は icebox（ユーザー明示依頼は対象外） | — | 同 Stop hook が実数と超過理由を強制。**2026-08-19 まで等号（`closed 3 / created 3`）を素通しさせており、規範を常に 1 件ぶん見逃していた**（PR で `created ≥ closed` かつ `created > 0` に修正。0/0 は board を増やさないので免除）。block メッセージが挙げていた救済策「icebox に落として数字を下げる」は**実行不能**だったので撤去 —— furrow に起票の取り消しは無く、created は lane 非依存に窓内の起票を数えるため。**lane 選択は今も見ていない** | 🟡 |
-| 質問・報告フロー（一問一答・推奨・委任）（作業の締め節） | 一問一答・推奨つき | 裁定・「残り全部推奨で」の委任 | なし | 📖 |
-| furrow 一本化・wrapper 使用（Workflow 節） | PATH の `furrow` を叩く | — | `packages.nix` の source-build wrapper。brew 版未導入なので shadow は構造的に不発 | 🟡 |
+| precedence と正典マップ（How to read this document 節） | 食い違いを ①ユーザー指示 ②repo CLAUDE.md ③正典 ④本書 の順で解決 | — | なし | 📖 |
+| 出力の形・全規則（Output shape 節） | 会話で適用 | — | claude-md-eval で**測定**は可能（強制ではない。測定義務は dotfiles/CLAUDE.md へ移設済み） | 📖 |
+| 作業の締めの 2 要素契約（Work closing 節） | やり残し ID（or なし）+ `closed N / created M` を書く | — | Stop hook [claude-work-report-check](../chezmoi/dot_local/bin/executable_claude-work-report-check)（PR #270→#294 で契約化）: arming = 旧冒頭文 / やり残し行 / counts トークン。ID・実数・超過理由（counts 行±1）を検査。**同数（created == closed かつ > 0）も超過として block・0/0 のみ免除**。CI に fixture 29 + 変異検証 | 🟡 締め自体の**発火**（完全な書き忘れ）は判定不能で 📖 のまま |
+| 生成予算 created ≤ closed − 1・icebox 既定（Work closing 節・Workflow 節） | 予算内に収める。起票既定は icebox（ユーザー明示依頼は対象外） | — | 同 Stop hook が実数と超過理由を強制。**2026-08-19 まで等号（`closed 3 / created 3`）を素通しさせており、規範を常に 1 件ぶん見逃していた**（PR で `created ≥ closed` かつ `created > 0` に修正。0/0 は board を増やさないので免除）。block メッセージが挙げていた救済策「icebox に落として数字を下げる」は**実行不能**だったので撤去 —— furrow に起票の取り消しは無く、created は lane 非依存に窓内の起票を数えるため。**lane 選択は今も見ていない** | 🟡 |
+| 質問・報告フロー（一問一答・推奨・委任）（Work closing 節） | 一問一答・推奨つき | 裁定・「残り全部推奨で」の委任 | なし | 📖 |
+| furrow 一本化（Workflow 節）・wrapper 使用と開発時 `go run` 例外（Tools 節） | PATH の `furrow` を叩く | — | `packages.nix` の source-build wrapper。brew 版未導入なので shadow は構造的に不発 | 🟡 |
 | 着手前後の `furrow sync`・session start は `furrow sync && furrow brief`（Workflow 節） | 読む前・書いた後に sync。session start は sync && brief で orient | — | なし | 📖 |
-| board の layout が上がった直後は source checkout を `git pull`（Workflow 節） | checkout を board と同じ層に合わせてから furrow を叩く | flag day の順序判断（pins-first の窓では checkout を park する側が正解） | SessionStart hook [claude-furrow-board-note](../chezmoi/dot_local/bin/executable_claude-furrow-board-note)（[modify_settings.json](../chezmoi/private_dot_claude/modify_settings.json) #10 配線）が `furrow board` の `writable:false` を 1 行表示。**READ が全部通る**ので他に発火点が無く、書き込むまで誰も気づけない（2026-08-12 に 1 晩で 2 回発生。1 回はセッション自身、1 回は checkout を共有する別セッションが動かした）。unit 9 ケース | 🟡 warn-only・session start 時点のみ（セッション途中で壊れた分は次回まで出ない） |
 | board の shard は furrow が書く（Workflow 節「進捗の正本はその task body 一本」の実装面） | Edit/Write で `.furrow/{tasks,epics,repos}/*.json`・`meta.json` を直接書かない | 例外時（rebase の conflict marker 手直し）の許可 | PreToolUse hook [claude-board-shard-guard](../chezmoi/dot_local/bin/executable_claude-board-shard-guard)（[modify_settings.json](../chezmoi/private_dot_claude/modify_settings.json) #11 配線）が **ask**。deny にしないのは正当な例外が実測 4 回あるため（2026-07-21 perl / 07-28 python / 07-29 sed ×2）。**Bash 経路は意図的に非カバー** —— 実測の事故は全部そちらだが、正しい直し方の `git checkout --ours` まで巻き込む。scope は **furrow の config に載っている board だけ**（パス形だけで判定した初版は board のコピーにも一致し、`~/Library/Caches/.../.furrow/` へ書いた非対話エージェントを ask で停止させた — 非対話には ask に答える相手が居ない。2026-08-19 実害）。unit 13 ケース | 🟡 tripwire。Edit/Write 経路の hit は全 4048 transcript で 0 件 |
 | 進捗の正本は body 一本・中断時 1 行（Workflow 節） | body 更新・複製しない | — | なし | 📖 |
 | 指示なし時は `furrow brief` の先頭から着手／状況共有を GO と読まない／active epic の切り替えは申請制（Workflow 節） | 既定挙動として従う。勝手に `furrow epic activate` しない | 作業開始の GO・epic 切り替えの裁定 | furrow が next/brief を active epic に scope（epic-multi-active は lint error）。申請制そのものは散文 | 🟡 scope は機構・申請制は 📖 |
 | PR footer `SetStatus-task:`（Workflow 節） | footer を書く | — | [task-status.yml](../.github/workflows/task-status.yml) が lane 自動適用。書き忘れても落ちない | 🟡 |
 | 予約箱 epic（mandate / parking-lot / requests）— 別 repo への要望は requests へ（Workflow 節・正本 = projects docs/reserved-epics.md） | 要望を requests 箱へ起票 | triage の裁定 | projects lint（box 不変条件 = pre-push error block・warn は SessionStart hook [claude-projects-lint-note](../chezmoi/dot_local/bin/executable_claude-projects-lint-note) と日次 CI が表示）+ `reserved-epics.sh` が箱を常備 | 🟡 箱と表示は機構・起票先の選択は 📖 |
-| 品質>速度・一貫性・破壊的変更 OK（開発ポリシー節） | 判断規範として適用 | 好み・リスク受容の裁定 | — | 🙅 |
-| 「できた」は実測とセット（開発ポリシー節） | 実測／未確認を分けて報告 | — | なし | 📖 |
-| 未検証の観測を書かない・反証 1 周（開発ポリシー節） | 反証エージェントを回す。body に出所と検証状態 | — | なし | 📖 |
-| **機構化は rule of two・予算内**（開発ポリシー節・2026-07-28 新設） | 「既に踏んだ失敗の再発防止」以外の機構・ルールを作らない | — | Stop hook の created 予算が件数側を縛る | 🟡 |
-| fleet 変更の段取り（開発ポリシー節） | 段を踏む | カナリア/フリート進行の判断 | 正本 [fleet-change-policy.md](https://github.com/akira-toriyama/.github/blob/main/docs/fleet-change-policy.md) に機械強制の段一覧 | → 別台帳 |
-| 調査 clone・VM 全操作・Packages 配布の許可（開発ポリシー節） | 許可を行使 | ホスト sudo の実行 | — | 🙅 |
-| 外部待ちの deadline 必須・vncdo は timeout+小文字 keysym（道具節・2026-08-11 新設） | timeout を付ける・停滞は kill → 即報告・状態質問には実測後に回答 | — | PreToolUse hook [claude-vncdo-guard](../chezmoi/dot_local/bin/executable_claude-vncdo-guard)（[modify_settings.json](../chezmoi/private_dot_claude/modify_settings.json) #9 配線）が vncdo の timeout 欠落と大文字 keysym を deny（unit 12 ケース = [scripts/test_claude_vncdo_guard.py](../scripts/test_claude_vncdo_guard.py)。**2026-08-19 訂正**: それまでここに「9 ケース実測」とあったがテストは実在しなかった — 同日に実体化し、`--help`/`--version` probe を deny していた誤爆も修正）。一般則（他コマンドの deadline・状態報告の正直さ）は散文 | 🟡 vncdo は 🔒・一般則は 📖 |
-| 道具を既定で使う（道具節） | pare/cifail/rundiff/revpost/wait4x/peekaboo に先に手を伸ばす | — | rundiff の test 自動 wrap・読み取り git allowlist は modify_settings.json が 🔒。**使う判断**は散文 | 🟡 |
-| 自作 CLI/アプリは source・brew 禁止（道具節） | `brew install` しない | `brew install` しない | brew 版が無ければ shadow は構造的に起きない（実測: wrapper のみ） | 🟡 |
+| 品質>速度・一貫性・破壊的変更 OK（Development policy 節） | 判断規範として適用 | 好み・リスク受容の裁定 | — | 🙅 |
+| 「できた」は実測とセット（Development policy 節） | 実測／未確認を分けて報告 | — | なし | 📖 |
+| 未検証の観測を書かない・反証 1 周（Development policy 節） | 反証エージェントを回す。body に出所と検証状態 | — | なし | 📖 |
+| **機構化は rule of two・予算内**（Development policy 節・2026-07-28 新設） | 「既に踏んだ失敗の再発防止」以外の機構・ルールを作らない | — | Stop hook の created 予算が件数側を縛る | 🟡 |
+| fleet 変更の段取り（Development policy 節） | 段を踏む | カナリア/フリート進行の判断 | 正本 [fleet-change-policy.md](https://github.com/akira-toriyama/.github/blob/main/docs/fleet-change-policy.md) に機械強制の段一覧 | → 別台帳 |
+| 調査 clone・VM 全操作・Packages 配布の許可（Development policy 節） | 許可を行使 | ホスト sudo の実行 | — | 🙅 |
+| 外部待ちの deadline 必須・vncdo は timeout+小文字 keysym（Tools 節・2026-08-11 新設） | timeout を付ける・停滞は kill → 即報告・状態質問には実測後に回答 | — | PreToolUse hook [claude-vncdo-guard](../chezmoi/dot_local/bin/executable_claude-vncdo-guard)（[modify_settings.json](../chezmoi/private_dot_claude/modify_settings.json) #9 配線）が vncdo の timeout 欠落と大文字 keysym を deny（unit 12 ケース = [scripts/test_claude_vncdo_guard.py](../scripts/test_claude_vncdo_guard.py)。**2026-08-19 訂正**: それまでここに「9 ケース実測」とあったがテストは実在しなかった — 同日に実体化し、`--help`/`--version` probe を deny していた誤爆も修正）。一般則（他コマンドの deadline・状態報告の正直さ）は散文 | 🟡 vncdo は 🔒・一般則は 📖 |
+| 道具を既定で使う（Tools 節） | pare/cifail/rundiff/revpost/wait4x/peekaboo に先に手を伸ばす | — | rundiff の test 自動 wrap・読み取り git allowlist は modify_settings.json が 🔒。**使う判断**は散文 | 🟡 |
+| 自作 CLI/アプリは source・brew 禁止（Tools 節） | `brew install` しない | `brew install` しない | brew 版が無ければ shadow は構造的に起きない（実測: wrapper のみ） | 🟡 |
 | gitmoji 規約・push 前 `glyph lint`（Commits 節） | CONTRIBUTING.md を引く・push 前に lint | — | PR の commit-lint.yml（fleet 同期）。branch protection 必須は `ci-gate` のみで commit-lint 赤は merge を止めない（実測） | 🟡 push 前 lint は 📖 |
 | commit 英語のみ（Commits 節・2026-08-02 和訳廃止） | 英語のみで書く | — | なし（実測: glyph は日本語 subject も exit 0） | 📖 |
-| 成果物は英語のみ・会話/task は日本語（開発ポリシー節・2026-08-02 新設・正本 = fleet [doc-consistency-policy](https://github.com/akira-toriyama/.github/blob/main/docs/doc-consistency-policy.md)） | committed 文書を英語で書く・翻訳ファイルを持たない | — | なし（pare/rundiff の check-docs は version 検査のみ — README.ja 再出現は検知しない・実測） | 📖 |
-| 既定 model/effort（モデル運用節） | — | `/model`・`/effort` の対話変更 | [modify_settings.json](../chezmoi/private_dot_claude/modify_settings.json) が `//=` で seed | 🔒 seed として |
-| ultracode は毎セッション手動（モデル運用節） | — | セッション開始時に `/effort ultracode` | 機構化不能（Claude Code 仕様） | 🙅 |
-| 版番号を pin しない（モデル運用節） | 具体 ID を書かない | — | [scripts/claude_md_guard.py](../scripts/claude_md_guard.py)（lint ゲート claude-md-guard）が CLAUDE.md と modify_settings.json の実値行で版付き ID を fail | 🔒 |
-| Fable のファンアウト禁止（モデル運用節） | `fable-architect` 経由でのみ | — | [agents/fable-architect.md](../chezmoi/private_dot_claude/agents/fable-architect.md) の `tools:` に Agent 非搭載 → harness が拒否 | 🔒 Agent 経路のみ |
-| Fable%≥Weekly% 不変条件・約 4 日で 100%・尽きたら Opus（モデル運用節・正典に無い） | 開幕 quota 行を見て委譲判断 | 「これ Fable で」の発令・課金判断 | SessionStart hook [claude-quota-note](../chezmoi/dot_local/bin/executable_claude-quota-note) が Weekly% / Fable% と不変条件の充足/割れを毎セッション冒頭に提示（fail-open・fixture テストつき） | 🟡 数字は毎回出るが、委譲判断そのものは散文 |
-| Opus 失敗の body 記録（モデル運用節） | 都度 task body に書く | — | なし | 📖 |
-| 分担・Fable セッションで既定継承させない・検証は Opus 側（モデル運用節） | サブエージェントの model/effort を明示 | `/model fable` への切替 | なし。指定漏れの継承は subagent_type 依存（Plan・general-purpose のみ — 2026-08-19 の 4081 transcript 実測。旧文言「全員 Fable」は誇張だった） | 📖 |
-| SwiftUI+Sill・AppKit は essential floor・最新 macOS のみ（Mac アプリ節） | 設計・実装時に適用 | — | なし | 📖 |
-| 他 repo は慣習に従う・自分の規約を持ち込まない（他リポジトリ節） | repo の CLAUDE.md/CONTRIBUTING/履歴を先に読む | — | なし | 📖 |
+| 成果物は英語のみ・会話/task は日本語（Development policy 節・2026-08-02 新設・正本 = fleet [doc-consistency-policy](https://github.com/akira-toriyama/.github/blob/main/docs/doc-consistency-policy.md)） | committed 文書を英語で書く・翻訳ファイルを持たない | — | なし（pare/rundiff の check-docs は version 検査のみ — README.ja 再出現は検知しない・実測） | 📖 |
+| 既定 model/effort（Model operations 節） | — | `/model`・`/effort` の対話変更 | [modify_settings.json](../chezmoi/private_dot_claude/modify_settings.json) が `//=` で seed | 🔒 seed として |
+| ultracode は毎セッション手動（Model operations 節） | — | セッション開始時に `/effort ultracode` | 機構化不能（Claude Code 仕様） | 🙅 |
+| 版番号を pin しない（Model operations 節） | 具体 ID を書かない | — | [scripts/claude_md_guard.py](../scripts/claude_md_guard.py)（lint ゲート claude-md-guard）が CLAUDE.md と modify_settings.json の実値行で版付き ID を fail | 🔒 |
+| Fable のファンアウト禁止（Model operations 節） | `fable-architect` 経由でのみ | — | [agents/fable-architect.md](../chezmoi/private_dot_claude/agents/fable-architect.md) の `tools:` に Agent 非搭載 → harness が拒否 | 🔒 Agent 経路のみ |
+| Fable%≥Weekly% 不変条件・約 4 日で 100%・尽きたら Opus（Model operations 節・正典に無い） | 開幕 quota 行を見て委譲判断 | 「これ Fable で」の発令・課金判断 | SessionStart hook [claude-quota-note](../chezmoi/dot_local/bin/executable_claude-quota-note) が Weekly% / Fable% と不変条件の充足/割れを毎セッション冒頭に提示（fail-open・fixture テストつき） | 🟡 数字は毎回出るが、委譲判断そのものは散文 |
+| Opus 失敗の body 記録（Model operations 節） | 都度 task body に書く | — | なし | 📖 |
+| 分担・Fable セッションで既定継承させない・検証は Opus 側（Model operations 節） | サブエージェントの model/effort を明示 | `/model fable` への切替 | なし。指定漏れの継承は subagent_type 依存（Plan・general-purpose のみ — 2026-08-19 の 4081 transcript 実測。旧文言「全員 Fable」は誇張だった） | 📖 |
+| 他 repo は慣習に従う・自分の規約を持ち込まない（For repositories outside akira-toriyama 節） | repo の CLAUDE.md/CONTRIBUTING/履歴を先に読む | — | なし | 📖 |
 
 ### この台帳自身の機構（2026-07-28〜）
 
@@ -91,7 +89,11 @@
 | N 宣言・入口フィルタ 4 分類（質問フロー細則） | 縮約 | 一問一答・推奨・委任の核だけ残存 | 質問の質が落ちる実害が出たら |
 | 現在地ワンショットの読み方解説（`# branch.ab` の意味等） | nice-to-have | コマンド自体は残存 | — |
 | pare/cifail/rundiff の詳細解説（フラグ・profile の理由） | 縮約 | トリガー→コマンド 1 行ずつに | ツールの誤用が頻発したら |
-| 枠の読み方の jq 詳細（モデル運用節・2026-08-19） | 移設 | 実数は SessionStart hook が毎セッション出す — 読み方の正本は claude-quota-note script 自身 | hook が退役したら global へ戻す |
+| 枠の読み方の jq 詳細（Model operations 節・2026-08-19） | 移設 | 実数は SessionStart hook が毎セッション出す — 読み方の正本は claude-quota-note script 自身 | hook が退役したら global へ戻す |
+| Mac アプリ節ごと（SwiftUI+Sill / AppKit は essential floor / 最新 macOS のみ）（2026-08-24） | skill 重複 | mac-app-dev skill に 3 事実とも既載（発火場面 = mac アプリ開発時 — ロード頻度と使用場面を一致させる。「分岐・workaround」の文言は同 PR で skill 側へ補完） | skill が発火せず旧 OS 分岐や AppKit 直行が混入したら global へ戻す |
+| board layout 直後の furrow source checkout `git pull`（schema-too-new）（2026-08-24） | 機構委譲 | SessionStart hook claude-furrow-board-note が writable:false を毎セッション表示・エラー名が自己記述的 | schema-too-new を board 障害と誤診する事故が再発したら |
+| Fable 枠の実数（枠 ≈ 全体 Weekly の 50%・重さ ≈ Opus の 2 倍）（2026-08-24） | 縮約 | 委譲判断は不変条件 `Fable% ≥ Weekly%` と 4 日目標で足りる。実数は claude-quota-note が毎セッション表示 | 枠の解釈違いによる委譲ミスが再発したら |
+| furrow の挙動解説（brief の出力内容・next の絞り込み。「active が無ければ意図的に空」だけ英訳版に残存）（2026-08-24） | 正典重複/縮約 | furrow の挙動は projects 正典と runtime 出力が自己記述 | brief 誤読による誤着手が再発したら |
 
 ## ユーザーの手番（一覧）
 
@@ -115,6 +117,7 @@
 ## 検証状態
 
 - 2026-07-26 の初回実測（glyph 和訳非強制 / Stop hook fixture+変異 / brew shadow 不在 / `-l` ガード）と 2026-07-27 の追加実測（日本語 subject 素通り / `:fire:` footer 強制 / `furrow doctor` info 止まり）は旧版台帳の記録どおり（`git show 92e19cc:docs/claude-md-ledger.md` の「検証状態」節）。
+- **2026-08-24（段 3・全面英語化 + KISS 削減・t-gjej）**: 旧（日本語）11,254 bytes → 新（英語）9,910 bytes は `wc -c` 実測。claude-md-eval 2 腕（旧版 vs 新版・model pin claude-opus-5・36 ペア・$4.14）: tally candidate 20 / baseline 16・削り勝ち差 +3/36 = 8.3%（< 10%）で release gate PASS。候補応答 36 本の日本語比率を機械確認 — 英語化で応答言語が引きずられる回帰なし。訳の忠実性は Opus 独立エージェントの反証 1 周（BLOCKER 1 件 = go run 例外の受け皿欠落を検出・修正済み）。
 - **2026-07-28（本再構成）**: Stop hook 契約化は fixture 19 + 変異検証 3/3 で実測（PR #294）。旧版 33,805 bytes → 新版 9,873 bytes は `wc -c` 実測。散文の実効は claude-md-eval の 2 腕比較（旧版 vs 新版）で測定 — 結果は PR 本文に記録。
 
 ## 運用

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -354,7 +354,7 @@ dotfiles が **config だけを持つ**自作 macOS アプリ 3 本（アプリ�
 いずれも akira-toriyama 製で、[`home/modules/packages.nix`](../home/modules/packages.nix) の
 `sourceBuiltCLI`（呼ぶたび clone を incremental build する wrapper）で PATH に載る。
 **brew 版は入れない**（`/opt/homebrew/bin` が nix profile より前なので wrapper を shadow する）。
-使いどころの正典は global CLAUDE.md の「自作 CLI」節 — ここは呼び名の定義だけ。
+使いどころの正典は global CLAUDE.md の Tools 節 — ここは呼び名の定義だけ。
 
 ### `furrow`
 **タスク管理 CLI**。この repo のタスクの正本は furrow + private tracker repo `projects`。


### PR DESCRIPTION
Stage 3 of the global CLAUDE.md quality pass (t-gjej): convert the whole document to English (canon = [doc-consistency-policy](https://github.com/akira-toriyama/.github/blob/main/docs/doc-consistency-policy.md)) and apply delete-when-in-doubt cuts, per the user's standing instruction this session (「迷ったら削除 KISS の原則で」).

## Cuts (all recorded in the ledger deletion log)

- **Mac apps section deleted whole** — all three facts (SwiftUI+Sill default, AppKit essential-floor-only, latest-macOS-only) already live in the `mac-app-dev` skill, which fires exactly when they are needed. The skill's latest-macOS line gains the missing branch/**workaround** wording in this PR so coverage is complete.
- **schema-too-new checkout bullet deleted** — the `claude-furrow-board-note` SessionStart hook surfaces `writable:false` every session and the error names itself.
- **Fable-quota numbers (≈50% pool / ≈2× weight) deleted** — the delegation norm needs only the invariant `Fable% ≥ Weekly%` + the 4-day target; real numbers come from `claude-quota-note` each session.
- **furrow behavior descriptions deleted** (what `brief` prints, how `next` filters) — canon is projects / the runtime output itself. Kept: "intentionally empty when no epic is active".
- **furrow wrapper rule folded into the Tools source-build rule**, keeping the develop-time exception (`go run ./cmd/furrow`) as a literal.

## Measurement (claude-md-eval, two-arm)

- Arms: old Japanese full text vs new English full text. Model pin `claude-opus-5`, 18 cases × 2 trials = 36 judged pairs, $4.14.
- **tally: candidate 20 / baseline 16**; cut-bought wins candidate 13 vs baseline 10 → delta +3/36 = **8.3% < 10%** → **release gate PASS**.
- All 36 candidate responses machine-checked to have stayed Japanese (the main regression risk of an English instruction file).
- Faithfulness: one adversarial refutation pass by an independent Opus agent before measuring — 1 BLOCKER (the go-run exception had no landing spot after the cut) plus modality drifts, all fixed in the measured candidate.

## Same-PR obligations

- ledger: deletion-log rows for every cut + section pointers renamed to the English headings + measurement recorded under 検証状態.
- glossary: the one reference to a global CLAUDE.md section name now points at the Tools section.

The `*.ja.md` review copy is intentionally **not** committed — the translation-file policy exception is pending (.github t-dbcg); the review copy will sit untracked in the working tree per the t-0btf procedure.

SetStatus-task: https://github.com/akira-toriyama/projects/blob/main/.furrow/bodies/t-gjej.md in-progress

🤖 Generated with [Claude Code](https://claude.com/claude-code)