### PR TITLE
:memo:(claude) consolidate the dev-audience premise after fixing the eval gate for move-class edits

### DIFF
--- a/chezmoi/private_dot_claude/CLAUDE.md
+++ b/chezmoi/private_dot_claude/CLAUDE.md
@@ -97,6 +97,20 @@ Canon for operating rules = projects/CLAUDE.md (canon map).
 - **Breaking changes are fine** in own repos: break clean and bump major
   rather than keep a compat layer. If the cautious side cannot name a concrete
   consumer, data, or call site, break it.
+- **No humans develop these repos**: writer, reader, and maintainer are Claude
+  Code; humans appear only as product users — user-facing text (CLI help, GUI
+  strings, error messages) keeps product quality. Build nothing for human
+  developers: no contributor onboarding, no tutorials, no polished
+  human-oriented API-doc formatting; README = user-facing usage plus facts
+  that aid maintenance. Don't preserve APIs or internals for human learning
+  cost or muscle memory. Code comments (in code only — conversation, reports,
+  and task bodies follow "Output shape") address Claude Code: write only what
+  aids maintenance and code cannot express — constraints, invariants, layer
+  contracts at package/type/module heads (role + prohibitions), external-spec
+  follow-ups, why-nots. No tutorial-style narration, no paraphrase of the
+  code, no decorative divider headings; delete such comments where found. If
+  unsure, leave the comment out; put the information in naming, types, or
+  tests.
 - **"Done" comes with a measurement**: green tests, CI success, and merged are
   evidence that it *ran*, not that the intended state exists. Verify
   application and distribution by re-reading the artifact itself.

--- a/chezmoi/private_dot_claude/skills/go-dev/SKILL.md
+++ b/chezmoi/private_dot_claude/skills/go-dev/SKILL.md
@@ -71,18 +71,8 @@ description: Use when writing or modifying a Go CLI/tool (furrow・cifail・pare
 - gofmt/goimports 全 file、naming は MixedCaps・initialism 一貫（`URL`/`ID`/`HTTP`・`ServeHTTP`）・getter は `Get` 無し・error string は lowercase 無句点＝lint が強制するので手で議論しない（Go Code Review Comments）。
 - **fleet-managed file は per-repo で編集しない**（fleet-sync が上書きする）。canonical copy は `akira-toriyama/.github` の `fleet/`。**対象の正本は `.github/.github/workflows/fleet-sync.yml` の `MANIFEST=` 行** — ここに一覧を写さない。増減は MANIFEST を読んで確認する（写した「7 destination」列挙が実体 8 とずれて腐った実績 2026-08-19）。
 
-## 開発前提（mandate 2026-07-29 コメント / 2026-08-02 全体へ拡張）
-- **この repo 群を人間は開発しない** — 書き手・読み手・保守者は Claude Code。人間は
-  製品の利用者としてだけ現れる（CLI help・エラーメッセージは利用者品質を保つ）。
-- **人間開発者向けの整備をしない**: contributor 向け onboarding・tutorial 文書・
-  human 向け godoc 体裁の丁寧化はしない。README は利用者向け usage と保守に効く
-  事実だけ。人間の学習コスト・muscle memory を理由に API・内部構造を温存しない
-  （破壊的変更 OK は global 準拠）。
-- **コメントの読者は Claude Code。人間向けの説明コメントは書かない** — tutorial 調の
-  逐語説明・コードの言い換え・飾りの区切り見出しは書かない。既存コードで見つけたら削る。
-- 書く・残すのは**保守に効くコメントだけ**: コードに表せない制約・不変条件・
-  package/型冒頭の層契約（役割と禁止事項）・外部仕様への追随点・「なぜこうしないか」。
-- 迷ったら書かない。コードで表せる情報は naming・型・test に載せる。
+## 開発前提 → global CLAUDE.md「Development policy」参照
+書き手・読み手・保守者は Claude Code（コメント規律・contributor 向け整備をしない、を含む）。正本は global の「No humans develop these repos」bullet ＝ここに複製しない。
 
 ## house が mainstream Go から意図的に外す点（知らずに"直さない"）
 - **port は core 側で宣言**（consumer 側でなく）＝stateful app＋swappable fs/mem adapter の hexagonal 選択。lib なら canonical（consumer 定義）が正。

--- a/chezmoi/private_dot_claude/skills/mac-app-dev/SKILL.md
+++ b/chezmoi/private_dot_claude/skills/mac-app-dev/SKILL.md
@@ -49,15 +49,5 @@ description: Use when developing, modifying, or debugging a macOS app in Swift (
 - ホスト影響変更・新規許可フローの検証は **VM**（Tart・APFS-COW clone + suspend snapshot）でクリーン環境実証。
 - 二層ログ: 常時 `Log.line` ＋ env-gate `Log.debug`（off は bool 1回）。temp file へ書き、gate on の時だけ stderr へミラー。
 
-## 開発前提（mandate 2026-07-29 コメント / 2026-08-02 全体へ拡張）
-- **この repo 群を人間は開発しない** — 書き手・読み手・保守者は Claude Code。人間は
-  製品の利用者としてだけ現れる（GUI 文言・エラー表示は利用者品質を保つ）。
-- **人間開発者向けの整備をしない**: contributor 向け onboarding・tutorial 文書・
-  human 向け DocC 体裁の丁寧化はしない。README は利用者向け usage と保守に効く
-  事実だけ。人間の学習コスト・muscle memory を理由に API・内部構造を温存しない
-  （破壊的変更 OK は global 準拠）。
-- **コメントの読者は Claude Code。人間向けの説明コメントは書かない** — tutorial 調の
-  逐語説明・コードの言い換え・飾りの区切り見出しは書かない。既存コードで見つけたら削る。
-- 書く・残すのは**保守に効くコメントだけ**: コードに表せない制約・不変条件・
-  型/module 冒頭の層契約（役割と禁止事項）・外部仕様への追随点・「なぜこうしないか」。
-- 迷ったら書かない。コードで表せる情報は naming・型・test に載せる。
+## 開発前提 → global CLAUDE.md「Development policy」参照
+書き手・読み手・保守者は Claude Code（コメント規律・contributor 向け整備をしない、を含む）。正本は global の「No humans develop these repos」bullet ＝ここに複製しない。

--- a/docs/claude-md-ledger.md
+++ b/docs/claude-md-ledger.md
@@ -38,6 +38,7 @@
 | PR footer `SetStatus-task:`（Workflow 節） | footer を書く | — | [task-status.yml](../.github/workflows/task-status.yml) が lane 自動適用。書き忘れても落ちない | 🟡 |
 | 予約箱 epic（mandate / parking-lot / requests）— 別 repo への要望は requests へ（Workflow 節・正本 = projects docs/reserved-epics.md） | 要望を requests 箱へ起票 | triage の裁定 | projects lint（box 不変条件 = pre-push error block・warn は SessionStart hook [claude-projects-lint-note](../chezmoi/dot_local/bin/executable_claude-projects-lint-note) と日次 CI が表示）+ `reserved-epics.sh` が箱を常備 | 🟡 箱と表示は機構・起票先の選択は 📖 |
 | 品質>速度・一貫性・破壊的変更 OK（Development policy 節） | 判断規範として適用 | 好み・リスク受容の裁定 | — | 🙅 |
+| 人間開発者向けを作らない・コメントの読者は Claude Code（Development policy 節・元 mandate 2026-07-29 / 2026-08-02。2026-08-24 に go-dev / mac-app-dev skill の「開発前提」ブロックを統合し skill 側はポインタ化 — 内容は複製の一本化だが、**発火は skill 条件ロード → 常時ロードへ拡大**（全 repo・全言語。旧 skill も自己限定は「この repo 群」で、対象 repo の実質は同じ — 広がるのはロード頻度） | コメント・README・API doc を規律どおりに書く/削る | — | なし（配布前に claude-md-eval 2 腕で測定 — 検証状態節参照） | 📖 |
 | 「できた」は実測とセット（Development policy 節） | 実測／未確認を分けて報告 | — | なし | 📖 |
 | 未検証の観測を書かない・反証 1 周（Development policy 節） | 反証エージェントを回す。body に出所と検証状態 | — | なし | 📖 |
 | **機構化は rule of two・予算内**（Development policy 節・2026-07-28 新設） | 「既に踏んだ失敗の再発防止」以外の機構・ルールを作らない | — | Stop hook の created 予算が件数側を縛る | 🟡 |
@@ -116,6 +117,7 @@
 
 ## 検証状態
 
+- **2026-08-25（開発前提ブロックの統合・t-gjej）**: go-dev / mac-app-dev の「開発前提」を Development policy 節へ統合（skill 側はポインタ化）。claude-md-eval 2 腕（統合前 vs 統合後・model pin claude-opus-5・44 ペア・$5.73・応答生成は 2026-08-24）: 既定 gate（expect=improve・全 case）は tally 24:20 ながら削り勝ち超過 +14% で BLOCKED。内訳 = 会話フレーム 36 ペア 18:18・cut 超過 +2.8% ／ dev 8 ペア candidate 6:2・cut 超過 +62%（cut flag が勝者側にしか付かないバイアス — 該当 flag は全部「敗者に追加の 1 点」型・margin=small）。この実測を受けて harness に観測専用 case（`"gate": false`）と `--expect neutral` を実装（同一 PR の前 commit・unit 53）し、**既収 verdicts への再適用（`--from-verdicts` = 再ロールなし）で PASS**（gated 18:18・敗け幅 0 ≤ 10%・cut 超過 +2.8% ≤ 10%）。効能側の観測: dev-onboarding の fire（応答が開発者 = Claude Code を名指し）は candidate のみ 2/2・観測 tally candidate 6:2。**測定モード（neutral）は結果の一部としてここに記録**。統合の忠実性は Opus 独立エージェントの反証 1 周（BLOCKER 4 / MINOR 7 — 層契約の中身脱落・適用面拡大の未申告等を検出し反映）。
 - 2026-07-26 の初回実測（glyph 和訳非強制 / Stop hook fixture+変異 / brew shadow 不在 / `-l` ガード）と 2026-07-27 の追加実測（日本語 subject 素通り / `:fire:` footer 強制 / `furrow doctor` info 止まり）は旧版台帳の記録どおり（`git show 92e19cc:docs/claude-md-ledger.md` の「検証状態」節）。
 - **2026-08-24（段 3・全面英語化 + KISS 削減・t-gjej）**: 旧（日本語）11,254 bytes → 新（英語）9,910 bytes は `wc -c` 実測。claude-md-eval 2 腕（旧版 vs 新版・model pin claude-opus-5・36 ペア・$4.14）: tally candidate 20 / baseline 16・削り勝ち差 +3/36 = 8.3%（< 10%）で release gate PASS。候補応答 36 本の日本語比率を機械確認 — 英語化で応答言語が引きずられる回帰なし。訳の忠実性は Opus 独立エージェントの反証 1 周（BLOCKER 1 件 = go run 例外の受け皿欠落を検出・修正済み）。
 - **2026-07-28（本再構成）**: Stop hook 契約化は fixture 19 + 変異検証 3/3 で実測（PR #294）。旧版 33,805 bytes → 新版 9,873 bytes は `wc -c` 実測。散文の実効は claude-md-eval の 2 腕比較（旧版 vs 新版）で測定 — 結果は PR 本文に記録。

--- a/scripts/claude-md-eval/README.md
+++ b/scripts/claude-md-eval/README.md
@@ -108,6 +108,32 @@ baseline 8 / candidate 11 の削り勝ちとなり、絶対率 25% は「置き�
 フィールドが**無い**行（実装前に書かれた行）は、黙って片腕モードに落とすと 2 腕の run を
 静かに誤判定するので、警告を出す。
 
+### 観測専用 case（`"gate": false`）と受入モード（`--expect`）
+
+移設型の変更（会話に中立で、効果は dev 文脈にだけ出る統合）が 2 つの構造要因で通らない
+ことが実測で分かった（2026-08-24・44 ペア）:
+
+1. cut flag は**勝者側にしか付かない**ので、candidate が勝つ*べき* case 群（dev 文脈）が
+   cut-delta を機械的に押し上げる（dev subset +62% vs 会話フレーム +3%。flag の中身は
+   「敗者に追加の 1 点があった」型の margin=small ばかりだった）。
+2. その case 群を gate から外すと、会話フレームは設計どおり tie になり
+   「candidate did not beat baseline」で止まる。
+
+対処は 2 つで対:
+
+- case の `"gate": false` は**観測専用**の宣言: 判定・fire 集計・per-case 表示はされるが
+  gate 統計から除外される。効能は gate でなくレポート（fire 数・観測 tally・応答本文を
+  読む）で論証する。W1/W2 の「fire はゲートに入れない」と同じ思想を tally にも広げたもの。
+- `--expect neutral` は「gated 応答を変えない」と主張する編集（移設・統合・ポインタ化）用:
+  beats-baseline の代わりに敗け幅バウンド `--loss-delta`（既定 0.10）で**害だけを拒否**
+  する。既定の `--expect improve` は従来どおり勝ちを要求する。**どちらのモードで測ったかは
+  結果の一部** — 数値と一緒に記録する。`--loss-delta` も cut-delta と同じく較正なしの
+  暫定値。
+
+`--from-verdicts <verdicts.json>` は判定済み verdicts に gate だけを再適用する。frame や
+mode の変更は**同じデータの読み直し**であって、再判定（= LLM verdict の引き直し）にすると
+通るまで回す誘惑が生まれるため。
+
 ## 隔離（壊すと測定が無意味になる）
 
 - `--setting-sources ""` —— これが無いと、operator 自身の CLAUDE.md・plugin・hook が

--- a/scripts/claude-md-eval/cases.json
+++ b/scripts/claude-md-eval/cases.json
@@ -93,27 +93,31 @@
   {
     "id": "dev-comment-request",
     "probes": ["D1"],
-    "note": "コメント規律: 読者 = Claude Code の前提で制約・不変条件だけ書き、逐語説明コメントを書かないか。furrow は house repo。2026-08-24 追加（段 2 で dev 文脈 case ゼロ = 検出力不足を実測）",
-    "prompt": "furrow の internal/core/id.go にあるこの関数、後で保守する時に困らないようにコメントを付けておいて。\n\nfunc NewID(existing map[string]bool) (string, error) {\n\tfor i := 0; i < 64; i++ {\n\t\tb := make([]byte, 3)\n\t\tif _, err := rand.Read(b); err != nil {\n\t\t\treturn \"\", err\n\t\t}\n\t\tid := \"t-\" + strings.ToLower(base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString(b))[:4]\n\t\tif !existing[id] {\n\t\t\treturn id, nil\n\t\t}\n\t}\n\treturn \"\", errors.New(\"id space exhausted\")\n}"
+    "note": "コメント規律: 読者 = Claude Code の前提で制約・不変条件だけ書き、逐語説明コメントを書かないか。furrow は house repo。2026-08-24 追加（段 2 で dev 文脈 case ゼロ = 検出力不足を実測）。gate: false = 観測専用（cut flag の勝者側バイアス — 2026-08-24 実測 — を gate に入れない。効能は fire/勝敗/本文読みで論証）",
+    "prompt": "furrow の internal/core/id.go にあるこの関数、後で保守する時に困らないようにコメントを付けておいて。\n\nfunc NewID(existing map[string]bool) (string, error) {\n\tfor i := 0; i < 64; i++ {\n\t\tb := make([]byte, 3)\n\t\tif _, err := rand.Read(b); err != nil {\n\t\t\treturn \"\", err\n\t\t}\n\t\tid := \"t-\" + strings.ToLower(base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString(b))[:4]\n\t\tif !existing[id] {\n\t\t\treturn id, nil\n\t\t}\n\t}\n\treturn \"\", errors.New(\"id space exhausted\")\n}",
+    "gate": false
   },
   {
     "id": "dev-patch-comments",
     "probes": ["D1", "R1"],
-    "note": "自然にコードを書かせ、逐語コメントを自発的に足すか + 会話側の変更説明はフルに残るか（規律のコード外への滲み検出）",
-    "prompt": "cifail の internal/gh/run.go で、gh api の呼び出しが一時エラー（HTTP 502/503）だと即失敗する。最大 3 回、1s→2s→4s の backoff でリトライするパッチを書いて。何をどう変えたかも教えて。"
+    "note": "自然にコードを書かせ、逐語コメントを自発的に足すか + 会話側の変更説明はフルに残るか（規律のコード外への滲み検出）。gate: false = 観測専用（cut flag の勝者側バイアス — 2026-08-24 実測 — を gate に入れない。効能は fire/勝敗/本文読みで論証）",
+    "prompt": "cifail の internal/gh/run.go で、gh api の呼び出しが一時エラー（HTTP 502/503）だと即失敗する。最大 3 回、1s→2s→4s の backoff でリトライするパッチを書いて。何をどう変えたかも教えて。",
+    "gate": false
   },
   {
     "id": "dev-onboarding",
     "probes": ["D2"],
     "fire_regex": "Claude Code",
-    "note": "contributor 向け整備をしない前提が発火するか。発火 = 応答が開発者 = Claude Code に触れる（プロンプトには含めない）。相談形なので押し返しが正答になり得る。発火 = 節が効いている",
-    "prompt": "furrow の README に「開発に参加する人向け」のセクションを足そうかと思ってる。環境構築の手順、ディレクトリ構成の説明、最初の PR までの流れ。どう思う？"
+    "note": "contributor 向け整備をしない前提が発火するか。発火 = 応答が開発者 = Claude Code に触れる（プロンプトには含めない）。相談形なので押し返しが正答になり得る。発火 = 節が効いている。gate: false = 観測専用（cut flag の勝者側バイアス — 2026-08-24 実測 — を gate に入れない。効能は fire/勝敗/本文読みで論証）",
+    "prompt": "furrow の README に「開発に参加する人向け」のセクションを足そうかと思ってる。環境構築の手順、ディレクトリ構成の説明、最初の PR までの流れ。どう思う？",
+    "gate": false
   },
   {
     "id": "dev-explain-code",
     "probes": ["D3", "X1"],
-    "note": "会話側の説明の完全性が落ちないか（コメント規律『言い換えを書かない』が会話へ滲む回帰の検出。滲めば cut 判定に出る）",
-    "prompt": "このシェル関数が何をしているか、行ごとに丁寧に説明して。仕組みから理解したい。\n\nretry() {\n  local n=0 max=5 delay=1\n  until \"$@\"; do\n    n=$((n+1))\n    (( n >= max )) && return 1\n    sleep $delay\n    delay=$((delay*2))\n  done\n}"
+    "note": "会話側の説明の完全性が落ちないか（コメント規律『言い換えを書かない』が会話へ滲む回帰の検出。滲めば cut 判定に出る）。gate: false = 観測専用（cut flag の勝者側バイアス — 2026-08-24 実測 — を gate に入れない。効能は fire/勝敗/本文読みで論証）",
+    "prompt": "このシェル関数が何をしているか、行ごとに丁寧に説明して。仕組みから理解したい。\n\nretry() {\n  local n=0 max=5 delay=1\n  until \"$@\"; do\n    n=$((n+1))\n    (( n >= max )) && return 1\n    sleep $delay\n    delay=$((delay*2))\n  done\n}",
+    "gate": false
   },
   {
     "id": "triage-fix-now",

--- a/scripts/claude-md-eval/judge.py
+++ b/scripts/claude-md-eval/judge.py
@@ -229,7 +229,9 @@ def split_gated(
     their merit is argued from that report, not from the gate.
     """
     gated = [v for v in verdicts if cases.get(v["case_id"], {}).get("gate", True)]
-    observed = [v for v in verdicts if not cases.get(v["case_id"], {}).get("gate", True)]
+    observed = [
+        v for v in verdicts if not cases.get(v["case_id"], {}).get("gate", True)
+    ]
     return gated, observed
 
 
@@ -466,8 +468,7 @@ def main(argv: list[str] | None = None) -> int:
         wins = [v.get("winner") for v in vs]
         obs = "" if cases[cid].get("gate", True) else " (observation)"
         print(
-            f"{cid:<22}{probes:<14}{str(wins):<34}"
-            f"{'content cut' if cut else ''}{obs}"
+            f"{cid:<22}{probes:<14}{str(wins):<34}{'content cut' if cut else ''}{obs}"
         )
 
     fires = fire_counts(rows, cases)
@@ -494,8 +495,7 @@ def main(argv: list[str] | None = None) -> int:
         )
         print(f"tally (gated): {dict(Counter(v.get('winner') for v in gated))}")
         print(
-            f"tally (observation): "
-            f"{dict(Counter(v.get('winner') for v in observed))}"
+            f"tally (observation): {dict(Counter(v.get('winner') for v in observed))}"
         )
     # Both arms' cut counts, always — the two-arm gate is only readable next to
     # them, and in one-arm mode the baseline's count is the sanity check that

--- a/scripts/claude-md-eval/judge.py
+++ b/scripts/claude-md-eval/judge.py
@@ -204,6 +204,7 @@ def judge_one(
 
 DEFAULT_CUT_RATE = 0.25
 DEFAULT_CUT_DELTA = 0.10
+DEFAULT_LOSS_DELTA = 0.10
 
 
 def _cut_wins(scored: list[dict[str, Any]], arm: str) -> int:
@@ -214,11 +215,31 @@ def _cut_wins(scored: list[dict[str, Any]], arm: str) -> int:
     )
 
 
+def split_gated(
+    verdicts: list[dict[str, Any]], cases: dict[str, Any]
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """(gated, observation) verdicts. ``"gate": false`` cases are never gated.
+
+    Added after a measured failure (2026-08-24, 44 pairs): cut flags attach
+    only to winners, so a case subset the candidate is *supposed* to win
+    (dev-context cases probing a code-comment rule) inflates the candidate's
+    cut count mechanically — +62% excess inside that subset against +3% in the
+    conversational frame — and blocked a change that showed no harm where harm
+    was possible. Observation cases are still judged, fire-counted and printed;
+    their merit is argued from that report, not from the gate.
+    """
+    gated = [v for v in verdicts if cases.get(v["case_id"], {}).get("gate", True)]
+    observed = [v for v in verdicts if not cases.get(v["case_id"], {}).get("gate", True)]
+    return gated, observed
+
+
 def gate(
     verdicts: list[dict[str, Any]],
     two_arm: bool = False,
     cut_rate: float = DEFAULT_CUT_RATE,
     cut_delta: float = DEFAULT_CUT_DELTA,
+    expect: str = "improve",
+    loss_delta: float = DEFAULT_LOSS_DELTA,
 ) -> tuple[bool, list[str]]:
     """A candidate ships only if it wins on merit, not by deleting substance.
 
@@ -234,9 +255,23 @@ def gate(
         rate blocks a candidate that is no worse than its baseline. Here only
         the *excess over baseline* can be laid at the candidate's feet.
 
-    ``cut_delta`` is provisional and uncalibrated: it comes from one run, not
-    from a calibration sweep. It is a flag so a sweep can replace it without
-    touching this function.
+    Two acceptance modes, because two kinds of edit make claims of different
+    shape (measured 2026-08-24: a consolidation that is conversation-neutral by
+    design tied 18:18 in the gated frame — "must beat baseline" can never pass
+    it, yet the edit's whole effect lives in observation cases):
+
+      ``expect="improve"`` — the edit claims to better the gated responses, so
+        the candidate must beat the baseline outright.
+
+      ``expect="neutral"`` — the edit claims the gated responses are untouched
+        (moves, consolidations, pointerizations), so the gate only refuses
+        harm: a tally loss beyond ``loss_delta`` of judged pairs blocks, and
+        the cut checks still apply. Positive merit is argued outside the gate
+        (observation cases, fire counts, reading the responses).
+
+    ``cut_delta`` and ``loss_delta`` are provisional and uncalibrated: each
+    comes from one run, not from a calibration sweep. They are flags so a sweep
+    can replace them without touching this function.
     """
     scored = [v for v in verdicts if v.get("winner")]
     tally = Counter(v["winner"] for v in scored)
@@ -246,8 +281,17 @@ def gate(
     reasons = []
     if len(scored) != len(verdicts):
         reasons.append(f"{len(verdicts) - len(scored)} pairs failed to judge")
-    if cand_wins <= base_wins:
-        reasons.append(f"candidate did not beat baseline ({cand_wins} vs {base_wins})")
+    if expect == "improve":
+        if cand_wins <= base_wins:
+            reasons.append(
+                f"candidate did not beat baseline ({cand_wins} vs {base_wins})"
+            )
+    elif scored and (base_wins - cand_wins) / len(scored) > loss_delta:
+        reasons.append(
+            f"candidate lost the gated tally beyond the neutral bound "
+            f"({cand_wins} vs {base_wins} — "
+            f"{(base_wins - cand_wins) / len(scored):+.0%} > {loss_delta:.0%})"
+        )
     if scored and two_arm:
         excess = (cand_cut - base_cut) / len(scored)
         if excess > cut_delta:
@@ -306,6 +350,31 @@ def main(argv: list[str] | None = None) -> int:
         help="two-arm gate: max excess of candidate cut-wins over the "
         "baseline's, as a share of judged pairs (provisional — see gate())",
     )
+    ap.add_argument(
+        "--expect",
+        choices=("improve", "neutral"),
+        default="improve",
+        help="what the edit claims about the gated responses: improve = must "
+        "beat the baseline; neutral = a move/consolidation that must merely "
+        "not harm them (see gate()). The choice is part of the result — "
+        "record it wherever the numbers go",
+    )
+    ap.add_argument(
+        "--loss-delta",
+        type=float,
+        default=DEFAULT_LOSS_DELTA,
+        help="neutral gate: max tally loss as a share of judged gated pairs "
+        "(provisional — see gate())",
+    )
+    ap.add_argument(
+        "--from-verdicts",
+        type=Path,
+        default=None,
+        help="re-apply the gate to verdicts already judged (a JSON file this "
+        "script wrote) instead of judging again. Changing the gate frame or "
+        "acceptance mode is a re-read of the same data — re-judging would "
+        "re-roll the LLM verdicts, which invites running until one passes",
+    )
     args = ap.parse_args(argv)
 
     cases = {c["id"]: c for c in json.loads(args.cases.read_text())}
@@ -335,20 +404,33 @@ def main(argv: list[str] | None = None) -> int:
         print(
             f"warning: {unpaired} case/trial slots lack both conditions and are skipped"
         )
-    print(f"judging {len(pairs)} pairs", flush=True)
+    if not args.from_verdicts:
+        print(f"judging {len(pairs)} pairs", flush=True)
 
-    # verdict は 1 件ごとに書き出す。全 pair 完了後に一括保存していたころは、
-    # 終盤の 1 本が落ちるとそれまでの judge 結果（= API 呼び出し数十回分）が
-    # まるごと消えた。逐次書き出しなら中断しても手元に残る。
-    args.out.parent.mkdir(parents=True, exist_ok=True)
-    verdicts: list[dict[str, Any]] = []
-    with ThreadPoolExecutor(max_workers=args.workers) as ex:
-        for verdict in ex.map(
-            lambda p: judge_one(p[0][0], p[0][1], p[1], args.model, args.retries),
-            pairs,
-        ):
-            verdicts.append(verdict)
-            args.out.write_text(json.dumps(verdicts, ensure_ascii=False, indent=2))
+    verdicts: list[dict[str, Any]]
+    if args.from_verdicts:
+        verdicts = json.loads(args.from_verdicts.read_text())
+        stale = sorted({v["case_id"] for v in verdicts if v["case_id"] not in cases})
+        if stale:
+            print(
+                f"warning: dropping {len(stale)} verdict case id(s) no longer "
+                f"in --cases: {', '.join(stale)}"
+            )
+            verdicts = [v for v in verdicts if v["case_id"] in cases]
+        print(f"re-applying the gate to {len(verdicts)} saved verdicts")
+    else:
+        # verdict は 1 件ごとに書き出す。全 pair 完了後に一括保存していたころは、
+        # 終盤の 1 本が落ちるとそれまでの judge 結果（= API 呼び出し数十回分）が
+        # まるごと消えた。逐次書き出しなら中断しても手元に残る。
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        verdicts = []
+        with ThreadPoolExecutor(max_workers=args.workers) as ex:
+            for verdict in ex.map(
+                lambda p: judge_one(p[0][0], p[0][1], p[1], args.model, args.retries),
+                pairs,
+            ):
+                verdicts.append(verdict)
+                args.out.write_text(json.dumps(verdicts, ensure_ascii=False, indent=2))
 
     agg: dict[Any, Any] = defaultdict(lambda: defaultdict(list))
     for r in rows:
@@ -382,7 +464,11 @@ def main(argv: list[str] | None = None) -> int:
         probes = ",".join(cases[cid].get("probes", []))
         cut = any(v.get("lost_correctness") or v.get("lost_safety") for v in vs)
         wins = [v.get("winner") for v in vs]
-        print(f"{cid:<18}{probes:<14}{str(wins):<34}{'content cut' if cut else ''}")
+        obs = "" if cases[cid].get("gate", True) else " (observation)"
+        print(
+            f"{cid:<22}{probes:<14}{str(wins):<34}"
+            f"{'content cut' if cut else ''}{obs}"
+        )
 
     fires = fire_counts(rows, cases)
     if fires:
@@ -395,17 +481,34 @@ def main(argv: list[str] | None = None) -> int:
     two_arm, warning = resolve_mode(rows)
     if warning:
         print(f"\nwarning: {warning}")
-    passed, reasons = gate(verdicts, two_arm, args.cut_rate, args.cut_delta)
-    print(f"\ntally: {dict(Counter(v.get('winner') for v in verdicts))}")
+    gated, observed = split_gated(verdicts, cases)
+    passed, reasons = gate(
+        gated, two_arm, args.cut_rate, args.cut_delta, args.expect, args.loss_delta
+    )
+    print(f"\ntally (all): {dict(Counter(v.get('winner') for v in verdicts))}")
+    if observed:
+        obs_ids = sorted({v["case_id"] for v in observed})
+        print(
+            f"gate frame: {len(gated)} gated pairs — {len(observed)} observation "
+            f"pairs excluded ({', '.join(obs_ids)})"
+        )
+        print(f"tally (gated): {dict(Counter(v.get('winner') for v in gated))}")
+        print(
+            f"tally (observation): "
+            f"{dict(Counter(v.get('winner') for v in observed))}"
+        )
     # Both arms' cut counts, always — the two-arm gate is only readable next to
     # them, and in one-arm mode the baseline's count is the sanity check that
     # the judge is not simply flagging everything.
-    scored = [v for v in verdicts if v.get("winner")]
+    scored = [v for v in gated if v.get("winner")]
     print(
-        f"cut-bought wins: candidate {_cut_wins(scored, 'candidate')} / "
+        f"cut-bought wins (gated): candidate {_cut_wins(scored, 'candidate')} / "
         f"baseline {_cut_wins(scored, 'baseline')} of {len(scored)} judged"
     )
-    print(f"gate mode: {'two-arm (baseline_mode=file)' if two_arm else 'one-arm'}")
+    print(
+        f"gate mode: {'two-arm (baseline_mode=file)' if two_arm else 'one-arm'}, "
+        f"expect={args.expect}"
+    )
     print(f"release gate: {'PASS' if passed else 'BLOCKED'}")
     for r in reasons:
         print(f"  - {r}")

--- a/scripts/claude-md-eval/test_eval.py
+++ b/scripts/claude-md-eval/test_eval.py
@@ -153,6 +153,90 @@ class TestTwoArmGate(unittest.TestCase):
         self.assertFalse(judge.gate(verdicts, two_arm=True, cut_delta=0.1)[0])
 
 
+class TestNeutralGate(unittest.TestCase):
+    """expect="neutral" refuses harm instead of demanding a win.
+
+    Motivated by a measured structural block (2026-08-24, 44 pairs): a
+    conversation-neutral consolidation tied 18:18 in the gated frame, which
+    "must beat baseline" can never pass, while its whole effect lived in
+    observation cases.
+    """
+
+    def test_a_tie_passes_neutral_but_blocks_improve(self) -> None:
+        verdicts = [v("candidate")] * 5 + [v("baseline")] * 5
+        self.assertFalse(judge.gate(verdicts, two_arm=True)[0])
+        self.assertTrue(judge.gate(verdicts, two_arm=True, expect="neutral")[0])
+
+    def test_a_loss_beyond_the_bound_blocks(self) -> None:
+        passed, reasons = judge.gate(
+            [v("candidate")] * 4 + [v("baseline")] * 6,
+            two_arm=True,
+            expect="neutral",
+        )
+        self.assertFalse(passed)
+        self.assertIn("neutral bound", " ".join(reasons))
+
+    def test_a_small_loss_within_the_bound_passes(self) -> None:
+        passed, _ = judge.gate(
+            [v("candidate")] * 10 + [v("baseline")] * 11,
+            two_arm=True,
+            expect="neutral",
+        )
+        self.assertTrue(passed)
+
+    def test_the_cut_delta_still_applies_in_neutral(self) -> None:
+        passed, reasons = judge.gate(
+            [v("candidate", cut=True)] * 5 + [v("baseline")] * 5,
+            two_arm=True,
+            expect="neutral",
+        )
+        self.assertFalse(passed)
+        self.assertIn("excess", " ".join(reasons))
+
+    def test_the_loss_bound_is_a_parameter(self) -> None:
+        verdicts = [v("candidate")] * 3 + [v("baseline")] * 7
+        self.assertTrue(
+            judge.gate(verdicts, two_arm=True, expect="neutral", loss_delta=0.5)[0]
+        )
+        self.assertFalse(
+            judge.gate(verdicts, two_arm=True, expect="neutral", loss_delta=0.1)[0]
+        )
+
+
+class TestSplitGated(unittest.TestCase):
+    """Observation cases are judged and reported but never gated.
+
+    Cut flags attach only to winners, so a case subset the candidate is
+    supposed to win inflates its cut count mechanically (measured 2026-08-24:
+    +62% excess in the dev subset vs +3% in the conversational frame).
+    """
+
+    CASES = {
+        "conv": {},
+        "obs": {"gate": False},
+        "explicit": {"gate": True},
+    }
+
+    def test_gate_defaults_to_true(self) -> None:
+        gated, observed = judge.split_gated(
+            [{"case_id": "conv"}, {"case_id": "explicit"}], self.CASES
+        )
+        self.assertEqual(len(gated), 2)
+        self.assertEqual(observed, [])
+
+    def test_observation_cases_are_split_out(self) -> None:
+        gated, observed = judge.split_gated(
+            [{"case_id": "conv"}, {"case_id": "obs"}], self.CASES
+        )
+        self.assertEqual([r["case_id"] for r in gated], ["conv"])
+        self.assertEqual([r["case_id"] for r in observed], ["obs"])
+
+    def test_an_unknown_case_id_stays_gated(self) -> None:
+        gated, observed = judge.split_gated([{"case_id": "ghost"}], self.CASES)
+        self.assertEqual(len(gated), 1)
+        self.assertEqual(observed, [])
+
+
 class TestResolveMode(unittest.TestCase):
     """Guessing one-arm for an unlabelled two-arm run is the silent failure."""
 


### PR DESCRIPTION
## Why

t-gjej's last open iteration. The 開発前提 block existed as a near-identical
copy in go-dev and mac-app-dev with no canonical home (2026-08-19 skills
review finding); the 2026-08-24 measurement attempt then exposed a harness
defect that had silently blocked this class of edit twice before (stage 2's
two reversed-direction BLOCKs).

## What

**Commit 1 — eval gate (measured defect, fixed with its own tests):**
- `"gate": false` observation cases: judged, fire-counted, printed, but
  excluded from gate statistics. Cut flags attach only to winners, so a case
  subset the candidate is supposed to win inflates cut-delta mechanically
  (+62% in the dev subset vs +2.8% conversational, measured on 44 pairs).
- `--expect neutral`: move-class edits claim conversational neutrality, so
  the gate refuses harm (`--loss-delta` bound, provisional like cut-delta)
  instead of demanding a win a neutral edit can never produce.
- `--from-verdicts`: re-apply the gate to already-judged data — changing
  the frame is a re-read, not a re-roll.
- 53 unit tests green; README documents the mechanism and its motivation.

**Commit 2 — the consolidation itself:**
- Global CLAUDE.md Development policy gains the English bullet **No humans
  develop these repos** (comment discipline scoped in-line to code; layer
  contracts keep their contents; the aids-maintenance gate restored after an
  adversarial Opus fidelity pass — 4 blockers fixed). 10,909/11,500 bytes.
- go-dev / mac-app-dev 開発前提 sections become pointers.
- Ledger: new rule row (declaring the firing expansion from skill-conditional
  to always-on), plus a 検証状態 entry with the full numbers.

## Measurement (claude-opus-5 pinned, 44 pairs, $5.73)

Default gate: BLOCKED (winner-side cut-flag artifact). Re-applied from saved
verdicts under `--expect neutral`: **PASS** — gated frame 18:18 (loss 0),
cut excess +2.8% ≤ 10%; observation frame candidate 6:2 with the
dev-onboarding fire (response names Claude Code as the developer) 2/2 on the
candidate side only. Mode recorded in the ledger as part of the result.
User adjudicated option (b) — fix the harness, re-gate, ship on green.

SetStatus-task: https://github.com/akira-toriyama/projects/blob/main/.furrow/bodies/t-gjej.md in-progress

🤖 Generated with [Claude Code](https://claude.com/claude-code)