### PR TITLE
:memo:(claude) point the commit canon at CONTRIBUTING and fix the filing example

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,7 +73,7 @@ flowchart TD
 
 - **`main` は唯一の永続ブランチ**（2026-05-27 に `rebuild` を統合・削除。CI も main へ単発）。作業は短命な feature ブランチを切り、**PR 経由で `main` に squash-merge** する（直 push はしない）。
 - **フロー**: `git checkout -b <type>/<topic>` → 論理単位で commit → `git push -u origin <branch>` → `gh pr create` → CI green → `gh pr merge --squash`（`--auto` 可）。実例は [docs/operations.md](docs/operations.md)。
-- **コミットメッセージは gitmoji-driven**（`<:gitmoji:>[(<scope>)][!] <subject>`。Conventional の `<type>` 語は退役済み）。規約の正本は [docs/commit-convention.md](docs/commit-convention.md)（機械検査 = `glyph lint`）。**push 前に `glyph lint --range origin/main..HEAD`**（履歴には退役形式の commit が残っているので `git log` を手本にしない）。
+- **コミットメッセージは gitmoji-driven**（`<:gitmoji:>[(<scope>)][!] <subject>`。Conventional の `<type>` 語は退役済み）。規約の正本は .github の [CONTRIBUTING.md](https://github.com/akira-toriyama/.github/blob/main/CONTRIBUTING.md)（[docs/commit-convention.md](docs/commit-convention.md) は fleet 配布のポインタ・機械検査 = `glyph lint`）。**push 前に `glyph lint --range origin/main..HEAD`**（履歴には退役形式の commit が残っているので `git log` を手本にしない）。
 - **CI ジョブ（[.github/workflows/ci.yml](.github/workflows/ci.yml)、push と PR でトリガー）**:
   - `nix flake check --no-build` — Nix の型/eval 検査（Linux runner）
   - `lint` — `scripts/lint` 一本（ruff / mypy --strict / shfmt / shellcheck / actionlint / typos / lychee --offline / gitleaks / `.tmpl` は render 後に shellcheck・plist 構文 / コードスパン内のパス実在）。**ローカルでも同じコマンドが走る**: `nix develop .#lint --command scripts/lint`
@@ -155,7 +155,7 @@ op read "op://Vault/Item/field"
 dotfiles の作業タスク（バックログ・設計メモ・引き継ぎ）の**正本は furrow + private repo
 [`akira-toriyama/projects`](https://github.com/akira-toriyama/projects)**。
 この repo での入口は `furrow ls -r dotfiles`（着手候補 = ready / in-progress）/ `furrow show <id>` /
-起票は `furrow add "…" -r dotfiles`。
+起票は `furrow add "…" -r dotfiles -s icebox -e <epic>`（lane と箱は明示 — projects Standing orders 4・5。省略すると `inbox` 落ち + lint error `epic-required`）。
 
 **帰属・ラベル・board 自動導出・sync・PR footer の規約はここに複製しない** —— 全 repo 共通の作法は
 global `~/.claude/CLAUDE.md` の Workflow 節、運用ルールの正典は


### PR DESCRIPTION
Two fact-level fixes to the repo CLAUDE.md found by the t-36zk cross-review of projects/CLAUDE.md, the global CLAUDE.md, and this file.

- **Commit-convention canon**: this file named [docs/commit-convention.md](docs/commit-convention.md) as the canon, while the global canon map names .github's CONTRIBUTING.md — and the local file itself opens with "This file is only a pointer". The two claims now agree: canon = CONTRIBUTING.md, local path = fleet-distributed pointer.
- **Filing example**: `furrow add "…" -r dotfiles` with no `-s`/`-e` drops the task into `inbox` with no box — an `epic-required` lint error under projects Standing orders 4 and 5. The example now carries both flags.

No rule is added, removed, or moved (ledger untouched); no term changes (commit footer `Glossary-unchanged`).

SetStatus-task: https://github.com/akira-toriyama/projects/blob/main/.furrow/bodies/t-36zk.md in-progress

🤖 Generated with [Claude Code](https://claude.com/claude-code)