### PR TITLE
:memo:(docs) add the Japanese review copies for the three operations docs

### DIFF
--- a/docs/claude-md-ledger.ja.md
+++ b/docs/claude-md-ledger.ja.md
@@ -1,0 +1,135 @@
+<!--
+この文書は claude-md-ledger.md（英語・正本）の和訳です。人間向け。
+最新とは限りません — 基準: 英語版 @ 13d20e6。
+同時更新はしない — 人間の指示があった時に、基準 commit からの差分を訳して基準を進める。
+-->
+
+# CLAUDE.md ルール台帳（global）
+
+対象 = **global CLAUDE.md**（source: [`chezmoi/private_dot_claude/CLAUDE.md`](../chezmoi/private_dot_claude/CLAUDE.md) → 配布先 `~/.claude/CLAUDE.md`）。
+各 repo の CLAUDE.md（dotfiles 自身の [`CLAUDE.md`](../CLAUDE.md) 含む）は対象外 — 必要になったら各 repo の docs/ に同形式で作る。
+
+目的（furrow t-gqd5・2026-07-26 壁打ち合意）:
+
+1. **散文頼みのルールと機構で強制済みのルールを見分ける** — 📖 の行がそのまま機構化候補（ただし機構化は rule of two — 既に踏んだ失敗の再発防止に限る）。
+2. **各ルールで誰が動くかを 1 表にする** — Claude の手番 / ユーザーの手番 / 機構。
+3. **ユーザーの手番の一覧化**。
+4. **削除されたルールの記録**（2026-07-28 の 0 ベース再構成以降）— 何を・なぜ削ったかと復活条件。
+
+**ルール本文はここに転記しない** — 正本は global CLAUDE.md の各節（転記は剥離の元）。この表は「誰が・どう強制されるか」だけを持つ。削除記録だけは例外（正本が消えたので、ここが唯一の記録になる）。
+
+## 印の凡例
+
+| 印 | 意味 |
+|---|---|
+| 🔒 | **機構が強制** — 違反が機械的に止まる / 正しい状態が自動で作られる |
+| 🟡 | **半機構** — 機構はあるが warn-only・事後（push 後）・部分カバー |
+| 📖 | **散文頼み** — 発火は Claude の読解と記憶次第 |
+| 🙅 | **強制対象外** — 許可・裁量・判断規範で、機械で止める「違反」が定義できない |
+
+## 台帳
+
+| ルール（正本 = global CLAUDE.md の節） | Claude の手番 | ユーザーの手番 | 機構 | 印 |
+|---|---|---|---|---|
+| precedence と正典マップ（How to read this document 節） | 食い違いを ①ユーザー指示 ②repo CLAUDE.md ③正典 ④本書 の順で解決 | — | なし | 📖 |
+| 出力の形・全規則（Output shape 節） | 会話で適用 | — | claude-md-eval で**測定**は可能（強制ではない。測定義務は dotfiles/CLAUDE.md へ移設済み） | 📖 |
+| 作業の締めの 2 要素契約（Work closing 節） | やり残し ID（or なし）+ `closed N / created M` を書く | — | Stop hook [claude-work-report-check](../chezmoi/dot_local/bin/executable_claude-work-report-check)（PR #270→#294 で契約化）: arming = 旧冒頭文 / やり残し行 / counts トークン。ID・実数・超過理由（counts 行±1）を検査。**同数（created == closed かつ > 0）も超過として block・0/0 のみ免除**。CI に fixture 29 + 変異検証 | 🟡 締め自体の**発火**（完全な書き忘れ）は判定不能で 📖 のまま |
+| 生成予算 created ≤ closed − 1・icebox 既定（Work closing 節・Workflow 節） | 予算内に収める。起票既定は icebox（ユーザー明示依頼は対象外） | — | 同 Stop hook が実数と超過理由を強制。**2026-08-19 まで等号（`closed 3 / created 3`）を素通しさせており、規範を常に 1 件ぶん見逃していた**（PR で `created ≥ closed` かつ `created > 0` に修正。0/0 は board を増やさないので免除）。block メッセージが挙げていた救済策「icebox に落として数字を下げる」は**実行不能**だったので撤去 —— furrow に起票の取り消しは無く、created は lane 非依存に窓内の起票を数えるため。**lane 選択は今も見ていない** | 🟡 |
+| 質問・報告フロー（一問一答・推奨・委任）（Work closing 節） | 一問一答・推奨つき | 裁定・「残り全部推奨で」の委任 | なし | 📖 |
+| furrow 一本化（Workflow 節）・wrapper 使用と開発時 `go run` 例外（Tools 節） | PATH の `furrow` を叩く | — | `packages.nix` の source-build wrapper。brew 版未導入なので shadow は構造的に不発 | 🟡 |
+| 着手前後の `furrow sync`・session start は `furrow sync && furrow brief`（Workflow 節） | 読む前・書いた後に sync。session start は sync && brief で orient | — | なし | 📖 |
+| board の shard は furrow が書く（Workflow 節「進捗の正本はその task body 一本」の実装面） | Edit/Write で `.furrow/{tasks,epics,repos}/*.json`・`meta.json` を直接書かない | 例外時（rebase の conflict marker 手直し）の許可 | PreToolUse hook [claude-board-shard-guard](../chezmoi/dot_local/bin/executable_claude-board-shard-guard)（[modify_settings.json](../chezmoi/private_dot_claude/modify_settings.json) #11 配線）が **ask**。deny にしないのは正当な例外が実測 4 回あるため（2026-07-21 perl / 07-28 python / 07-29 sed ×2）。**Bash 経路は意図的に非カバー** —— 実測の事故は全部そちらだが、正しい直し方の `git checkout --ours` まで巻き込む。scope は **furrow の config に載っている board だけ**（パス形だけで判定した初版は board のコピーにも一致し、`~/Library/Caches/.../.furrow/` へ書いた非対話エージェントを ask で停止させた — 非対話には ask に答える相手が居ない。2026-08-19 実害）。unit 13 ケース | 🟡 tripwire。Edit/Write 経路の hit は全 4048 transcript で 0 件 |
+| 進捗の正本は body 一本・中断時 1 行（Workflow 節） | body 更新・複製しない | — | なし | 📖 |
+| 指示なし時は `furrow brief` の先頭から着手／状況共有を GO と読まない／active epic の切り替えは申請制（Workflow 節） | 既定挙動として従う。勝手に `furrow epic activate` しない | 作業開始の GO・epic 切り替えの裁定 | furrow が next/brief を active epic に scope（epic-multi-active は lint error）。申請制そのものは散文 | 🟡 scope は機構・申請制は 📖 |
+| PR footer `SetStatus-task:`（Workflow 節） | footer を書く | — | [task-status.yml](../.github/workflows/task-status.yml) が lane 自動適用。書き忘れても落ちない | 🟡 |
+| 予約箱 epic（mandate / parking-lot / requests）— 別 repo への要望は requests へ（Workflow 節・正本 = projects docs/reserved-epics.md） | 要望を requests 箱へ起票 | triage の裁定 | projects lint（box 不変条件 = pre-push error block・warn は SessionStart hook [claude-projects-lint-note](../chezmoi/dot_local/bin/executable_claude-projects-lint-note) と日次 CI が表示）+ `reserved-epics.sh` が箱を常備 | 🟡 箱と表示は機構・起票先の選択は 📖 |
+| 品質>速度・一貫性・破壊的変更 OK（Development policy 節） | 判断規範として適用 | 好み・リスク受容の裁定 | — | 🙅 |
+| 人間開発者向けを作らない・コメントの読者は Claude Code（Development policy 節・元 mandate 2026-07-29 / 2026-08-02。2026-08-24 に go-dev / mac-app-dev skill の「開発前提」ブロックを統合し skill 側はポインタ化 — 内容は複製の一本化だが、**発火は skill 条件ロード → 常時ロードへ拡大**（全 repo・全言語。旧 skill も自己限定は「この repo 群」で、対象 repo の実質は同じ — 広がるのはロード頻度） | コメント・README・API doc を規律どおりに書く/削る | — | なし（配布前に claude-md-eval 2 腕で測定 — 検証状態節参照） | 📖 |
+| 「できた」は実測とセット（Development policy 節） | 実測／未確認を分けて報告 | — | なし | 📖 |
+| 未検証の観測を書かない・反証 1 周（Development policy 節） | 反証エージェントを回す。body に出所と検証状態 | — | なし | 📖 |
+| **機構化は rule of two・予算内**（Development policy 節・2026-07-28 新設） | 「既に踏んだ失敗の再発防止」以外の機構・ルールを作らない | — | Stop hook の created 予算が件数側を縛る | 🟡 |
+| fleet 変更の段取り（Development policy 節） | 段を踏む | カナリア/フリート進行の判断 | 正本 [fleet-change-policy.md](https://github.com/akira-toriyama/.github/blob/main/docs/fleet-change-policy.md) に機械強制の段一覧 | → 別台帳 |
+| 調査 clone・VM 全操作・Packages 配布の許可（Development policy 節） | 許可を行使 | ホスト sudo の実行 | — | 🙅 |
+| 外部待ちの deadline 必須・vncdo は timeout+小文字 keysym（Tools 節・2026-08-11 新設） | timeout を付ける・停滞は kill → 即報告・状態質問には実測後に回答 | — | PreToolUse hook [claude-vncdo-guard](../chezmoi/dot_local/bin/executable_claude-vncdo-guard)（[modify_settings.json](../chezmoi/private_dot_claude/modify_settings.json) #9 配線）が vncdo の timeout 欠落と大文字 keysym を deny（unit 12 ケース = [scripts/test_claude_vncdo_guard.py](../scripts/test_claude_vncdo_guard.py)。**2026-08-19 訂正**: それまでここに「9 ケース実測」とあったがテストは実在しなかった — 同日に実体化し、`--help`/`--version` probe を deny していた誤爆も修正）。一般則（他コマンドの deadline・状態報告の正直さ）は散文 | 🟡 vncdo は 🔒・一般則は 📖 |
+| 道具を既定で使う（Tools 節） | pare/cifail/rundiff/revpost/wait4x/peekaboo に先に手を伸ばす | — | rundiff の test 自動 wrap・読み取り git allowlist は modify_settings.json が 🔒。**使う判断**は散文 | 🟡 |
+| 自作 CLI/アプリは source・brew 禁止（Tools 節） | `brew install` しない | `brew install` しない | brew 版が無ければ shadow は構造的に起きない（実測: wrapper のみ） | 🟡 |
+| gitmoji 規約・push 前 `glyph lint`（Commits 節） | CONTRIBUTING.md を引く・push 前に lint | — | PR の commit-lint.yml（fleet 同期）。branch protection 必須は `ci-gate` のみで commit-lint 赤は merge を止めない（実測） | 🟡 push 前 lint は 📖 |
+| commit 英語のみ（Commits 節・2026-08-02 和訳廃止） | 英語のみで書く | — | なし（実測: glyph は日本語 subject も exit 0） | 📖 |
+| 成果物は英語のみ・会話/task は日本語（Development policy 節・2026-08-02 新設・正本 = fleet [doc-consistency-policy](https://github.com/akira-toriyama/.github/blob/main/docs/doc-consistency-policy.md)） | committed 文書を英語で書く・翻訳ファイルを持たない | — | なし（pare/rundiff の check-docs は version 検査のみ — README.ja 再出現は検知しない・実測） | 📖 |
+| 既定 model/effort（Model operations 節） | — | `/model`・`/effort` の対話変更 | [modify_settings.json](../chezmoi/private_dot_claude/modify_settings.json) が `//=` で seed | 🔒 seed として |
+| ultracode は毎セッション手動（Model operations 節） | — | セッション開始時に `/effort ultracode` | 機構化不能（Claude Code 仕様） | 🙅 |
+| 版番号を pin しない（Model operations 節） | 具体 ID を書かない | — | [scripts/claude_md_guard.py](../scripts/claude_md_guard.py)（lint ゲート claude-md-guard）が CLAUDE.md と modify_settings.json の実値行で版付き ID を fail | 🔒 |
+| Fable のファンアウト禁止（Model operations 節） | `fable-architect` 経由でのみ | — | [agents/fable-architect.md](../chezmoi/private_dot_claude/agents/fable-architect.md) の `tools:` に Agent 非搭載 → harness が拒否 | 🔒 Agent 経路のみ |
+| Fable%≥Weekly% 不変条件・約 4 日で 100%・尽きたら Opus（Model operations 節・正典に無い） | 開幕 quota 行を見て委譲判断 | 「これ Fable で」の発令・課金判断 | SessionStart hook [claude-quota-note](../chezmoi/dot_local/bin/executable_claude-quota-note) が Weekly% / Fable% と不変条件の充足/割れを毎セッション冒頭に提示（fail-open・fixture テストつき） | 🟡 数字は毎回出るが、委譲判断そのものは散文 |
+| Opus 失敗の body 記録（Model operations 節） | 都度 task body に書く | — | なし | 📖 |
+| 分担・Fable セッションで既定継承させない・検証は Opus 側（Model operations 節） | サブエージェントの model/effort を明示 | `/model fable` への切替 | なし。指定漏れの継承は subagent_type 依存（Plan・general-purpose のみ — 2026-08-19 の 4081 transcript 実測。旧文言「全員 Fable」は誇張だった） | 📖 |
+| 他 repo は慣習に従う・自分の規約を持ち込まない（For repositories outside akira-toriyama 節） | repo の CLAUDE.md/CONTRIBUTING/履歴を先に読む | — | なし | 📖 |
+
+### この台帳自身の機構（2026-07-28〜）
+
+- **CLAUDE.md サイズ上限（11,500 bytes）・具体 model ID pin 禁止・台帳同期（CLAUDE.md に触る PR は台帳も触る。escape = commit footer `Ledger-unchanged: <理由>`）・glossary 同期（CLAUDE.md か skills/ に触る PR は docs/glossary.md も触る。escape = commit footer `Glossary-unchanged: <理由>`）** は lint ゲート claude-md-guard（[scripts/claude_md_guard.py](../scripts/claude_md_guard.py)・CI の `lint` job で毎 PR 実行）が強制する 🔒。どれも既に踏んだ失敗（21 倍肥大・pin ずれ・PR #274 の台帳更新漏れ・同日の PR #273 の glossary 追従漏れ）の再発防止で rule of two 適合。
+
+## 削除記録（0 ベース再構成 2026-07-28・旧版 = `92e19cc`）
+
+**運用ルール: 下表のインシデントと同型の事故が再発したら、そのルールは議論なしで復活する**（旧版 SHA から引用ごと戻す: `git show 92e19cc:chezmoi/private_dot_claude/CLAUDE.md`）。
+背景: 5 週で 1.6KB→33.8KB の肥大、open task の 64% が meta-tooling、W29/W30 の created 暴騰（+103/+79）。「あったら便利そう」なルール・解説・裁量規範を削り 9.9KB に再構成した。
+
+| 削除したルール/記述 | 種別 | 削除理由 | 元インシデント / 復活条件 |
+|---|---|---|---|
+| commit body の `---（和訳）` footer 義務（2026-08-02） | 置換 | ユーザー mandate: 成果物は英語のみ（README.ja も全 repo 撤去・t-xs91） | なし（方針転換）/ ユーザーが和訳を再要求したら |
+| 節の並びは発火頻度順 | 編集時メタ規則 | 実践すれば足り、宣言不要 | なし（予防的規則だった）/ 節順起因の読解事故が起きたら |
+| 正常終了の逐語定型（冒頭文・末尾文） | 置換 | 2 要素契約へ（PR #294。実態と矛盾する締めを生んだ — t-xx7g） | 締めの検証可能性が落ちたら（hook が守る） |
+| 「機構づくりは機能修正より先でよい」 | 置換 | rule of two へ。メタ作業量産の主因 | meta 偏重が解消しないなら見直し。同じ失敗の 3 回目が頻発するなら緩和を検討 |
+| claude-md-eval 測定義務（global 掲載） | 移設 | 発火場所は global CLAUDE.md 編集時 = 常に dotfiles repo 内 → [dotfiles/CLAUDE.md](../CLAUDE.md) へ | 移設先が発火しなかった（未測定の挙動散文が配られた）ら global に戻す |
+| semver 対応表（`:boom:`/`:sparkles:`/patch/bump なし/undeclared-removal） | 正典重複 | `glyph rules` が機械正本・`glyph lint` exit 3 が強制（2026-08-19 訂正: `glyph rules` は実在しないコマンドだった — 正本は CONTRIBUTING.md、強制は `glyph lint` のみ） | type 選択ミスや undeclared-removal が頻発したら |
+| projects checkout の明示 `-r projects` 註記（Workflow 節・2026-08-19） | 正典移管 | 「正典に無い」の但し書きが事実誤り — projects/CLAUDE.md の Standing order 2 に正典が実在（e-wh04 棚卸しで検出）。発火場所も projects checkout 内のみ = その場で projects/CLAUDE.md がロードされる | projects 側の正典が消えたら global に戻す |
+| furrow auto 導出の解説（union・worktree-aware・`auto_filter` 既定・`-l` ガード exit 2+candidates・`.furrow-pointer.toml` 近い方優先） | runtime 自己記述/低頻度 | エラーが自己記述的（exit 2 + candidates）。scope-shadow だけ残した | auto の誤解で draft 混入・板汚染が再発したら（正典側 README にも既載） |
+| 拾うトリガー列挙（不満・仕様曖昧・罠・ツール案…） | 縮約 | icebox 既定 1 行に | 取りこぼしが実害を出したら |
+| セッション粒度の長説明（詰め込まない・分割…） | 縮約 | 中断時 1 行だけ残存 | 品質劣化を伴う詰め込みが再発したら |
+| fleet の段の列挙（local→POC→glyph-test→カナリア→フリート） | 正典重複 | fleet-change-policy.md が正典・機械強制一覧もそちら | — （ポインタは残存） |
+| glossary.md 全 repo 義務 | 移管 | repo 固有義務は各 repo CLAUDE.md 持ち（dotfiles は既載） | 用語ズレ起因の手戻りが再発したら |
+| headless 検証優先・verbose ログの設計原則 | skill 重複 | cli-app-dev / mac-app-dev skill が持つ | — |
+| 「不足パーツは Sill へ PR を検討」 | 裁量 | 「検討する」系 nice-to-have | — |
+| モデル seed の解説・ultracode 非恒久の長説明・`opus[1m]` alias 解説 | 正本重複 | modify_settings.json のコメントに逐語で存在 | — （pin 禁止ルール自体は残存） |
+| GUI/CLI 起動者論・source 主義の哲学（3 段の重複記述） | 縮約 | 要点 2 行に | — |
+| fable-architect の「Bash 迂回できるかも（未実測）」注記 | 自己矛盾 | 「未検証の観測を書かない」に自文書が違反 | 迂回を実測確認したら事実として復活 |
+| N 宣言・入口フィルタ 4 分類（質問フロー細則） | 縮約 | 一問一答・推奨・委任の核だけ残存 | 質問の質が落ちる実害が出たら |
+| 現在地ワンショットの読み方解説（`# branch.ab` の意味等） | nice-to-have | コマンド自体は残存 | — |
+| pare/cifail/rundiff の詳細解説（フラグ・profile の理由） | 縮約 | トリガー→コマンド 1 行ずつに | ツールの誤用が頻発したら |
+| 枠の読み方の jq 詳細（Model operations 節・2026-08-19） | 移設 | 実数は SessionStart hook が毎セッション出す — 読み方の正本は claude-quota-note script 自身 | hook が退役したら global へ戻す |
+| Mac アプリ節ごと（SwiftUI+Sill / AppKit は essential floor / 最新 macOS のみ）（2026-08-24） | skill 重複 | mac-app-dev skill に 3 事実とも既載（発火場面 = mac アプリ開発時 — ロード頻度と使用場面を一致させる。「分岐・workaround」の文言は同 PR で skill 側へ補完） | skill が発火せず旧 OS 分岐や AppKit 直行が混入したら global へ戻す |
+| board layout 直後の furrow source checkout `git pull`（schema-too-new）（2026-08-24） | 機構委譲 | SessionStart hook claude-furrow-board-note が writable:false を毎セッション表示・エラー名が自己記述的 | schema-too-new を board 障害と誤診する事故が再発したら |
+| Fable 枠の実数（枠 ≈ 全体 Weekly の 50%・重さ ≈ Opus の 2 倍）（2026-08-24） | 縮約 | 委譲判断は不変条件 `Fable% ≥ Weekly%` と 4 日目標で足りる。実数は claude-quota-note が毎セッション表示 | 枠の解釈違いによる委譲ミスが再発したら |
+| furrow の挙動解説（brief の出力内容・next の絞り込み。「active が無ければ意図的に空」だけ英訳版に残存）（2026-08-24） | 正典重複/縮約 | furrow の挙動は projects 正典と runtime 出力が自己記述 | brief 誤読による誤着手が再発したら |
+
+## ユーザーの手番（一覧）
+
+機構化できない・Claude からは起こせない操作。
+
+### global CLAUDE.md 由来（全 repo 共通）
+
+- **セッション開始時の `/effort ultracode`** — 恒久化不能。ファンアウトさせたいセッションで 1 回。
+- **`/model` 切替と「これ Fable で」の発令** — メインループのモデルは Claude からは変えられない。
+- **VM 外（ホスト）の sudo 実行** — Claude はコマンド提示まで。
+- **好み・リスク受容・product 判断の裁定** — 一問一答への回答、「残り全部推奨で」の委任。
+- **作業開始の GO** — 質問・状況共有・相談への返答は GO ではない。
+- **カナリア／フリート進行の判断** — 段の正本は fleet-change-policy.md。
+
+### dotfiles の repo CLAUDE.md 由来（この repo だけの手番）
+
+- **`darwin-rebuild switch` / `--rollback` の実行** — sudo が要るのでコマンド提示までが Claude（ルール 2）。
+- **破壊的 git の明示指示** — force push・履歴改変・push 済みへの amend はユーザー明示時のみ（ルール 4）。
+- **PR merge の判断（Claude 主導運用を明示していない repo）** — dotfiles はルール 5 で Claude が merge してよい。
+
+## 検証状態
+
+- **2026-08-25（開発前提ブロックの統合・t-gjej）**: go-dev / mac-app-dev の「開発前提」を Development policy 節へ統合（skill 側はポインタ化）。claude-md-eval 2 腕（統合前 vs 統合後・model pin claude-opus-5・44 ペア・$5.73・応答生成は 2026-08-24）: 既定 gate（expect=improve・全 case）は tally 24:20 ながら削り勝ち超過 +14% で BLOCKED。内訳 = 会話フレーム 36 ペア 18:18・cut 超過 +2.8% ／ dev 8 ペア candidate 6:2・cut 超過 +62%（cut flag が勝者側にしか付かないバイアス — 該当 flag は全部「敗者に追加の 1 点」型・margin=small）。この実測を受けて harness に観測専用 case（`"gate": false`）と `--expect neutral` を実装（同一 PR の前 commit・unit 53）し、**既収 verdicts への再適用（`--from-verdicts` = 再ロールなし）で PASS**（gated 18:18・敗け幅 0 ≤ 10%・cut 超過 +2.8% ≤ 10%）。効能側の観測: dev-onboarding の fire（応答が開発者 = Claude Code を名指し）は candidate のみ 2/2・観測 tally candidate 6:2。**測定モード（neutral）は結果の一部としてここに記録**。統合の忠実性は Opus 独立エージェントの反証 1 周（BLOCKER 4 / MINOR 7 — 層契約の中身脱落・適用面拡大の未申告等を検出し反映）。
+- 2026-07-26 の初回実測（glyph 和訳非強制 / Stop hook fixture+変異 / brew shadow 不在 / `-l` ガード）と 2026-07-27 の追加実測（日本語 subject 素通り / `:fire:` footer 強制 / `furrow doctor` info 止まり）は旧版台帳の記録どおり（`git show 92e19cc:docs/claude-md-ledger.md` の「検証状態」節）。
+- **2026-08-24（段 3・全面英語化 + KISS 削減・t-gjej）**: 旧（日本語）11,254 bytes → 新（英語）9,910 bytes は `wc -c` 実測。claude-md-eval 2 腕（旧版 vs 新版・model pin claude-opus-5・36 ペア・$4.14）: tally candidate 20 / baseline 16・削り勝ち差 +3/36 = 8.3%（< 10%）で release gate PASS。候補応答 36 本の日本語比率を機械確認 — 英語化で応答言語が引きずられる回帰なし。訳の忠実性は Opus 独立エージェントの反証 1 周（BLOCKER 1 件 = go run 例外の受け皿欠落を検出・修正済み）。
+- **2026-07-28（本再構成）**: Stop hook 契約化は fixture 19 + 変異検証 3/3 で実測（PR #294）。旧版 33,805 bytes → 新版 9,873 bytes は `wc -c` 実測。散文の実効は claude-md-eval の 2 腕比較（旧版 vs 新版）で測定 — 結果は PR 本文に記録。
+
+## 運用
+
+- global CLAUDE.md にルールを足す・変える・削る PR では、**同一 PR でこの台帳の行（削除なら削除記録）を更新する**。この義務の正本は [dotfiles/CLAUDE.md](../CLAUDE.md) の「global CLAUDE.md / skill の散文を変えるとき」節。強制は `scripts/lint` の `claude-md-guard` ゲート（escape は commit footer `Ledger-unchanged: <理由>`）。
+- global CLAUDE.md が **dotfiles の実ファイル名を裸で参照する箇所**は、リネーム時に同一 PR で追従する。強制は `scripts/lint` の `doc-paths` ゲートの `FLEET_CLAIMS`（`scripts/doc_paths.py`）で、双方向に見る —— 値のパスが実在すること、かつキーが今も文書から言及されていること。**どの名前が対象かはこの台帳に写さない**（`FLEET_CLAIMS` が機械正本）。以前ここに「6 箇所」と件数を書いていたが、0 ベース再構成で参照が減っても数だけ残って嘘になった。
+- 📖 の行の機構化は rule of two を満たすものだけ task 化する。

--- a/docs/glossary.ja.md
+++ b/docs/glossary.ja.md
@@ -1,0 +1,461 @@
+<!--
+この文書は glossary.md（英語・正本）の和訳です。人間向け。
+最新とは限りません — 基準: 英語版 @ 13d20e6。
+同時更新はしない — 人間の指示があった時に、基準 commit からの差分を訳して基準を進める。
+-->
+
+---
+title: dotfiles 用語集
+tags: [glossary, macos, nix, chezmoi]
+repo: dotfiles
+aliases: []
+---
+
+# 用語集 — dotfiles のユビキタス言語
+
+dotfiles を構成する各パーツの **正規の呼び名** をまとめた規範ドキュメント。
+**コード・ドキュメント・コミットメッセージ・PR タイトル・Claude Code への
+プロンプト、すべてここに載っている名前のみを使う**。同義語は揺らぎを生む。
+1 つに決めて、それで通す。
+
+なお **正規名は英語のまま** 保持する。コード識別子・設定キー・コマンド
+（`home-manager`, `chezmoi`, `nix-darwin`, `homebrew.casks`, `op` など）
+と一対一に対応させるため。日本語化するのは説明文だけ。
+
+用語が足りなければ、その用語を導入する PR で同時にこのファイルへ追記する。
+用語名を変える場合は、コード・ドキュメント・このファイルを **同一 PR で**
+書き換える。
+
+> 各エントリの形式: **正規名**, 1〜2 行の定義, 設定 / コードでの所在,
+> そして `Don't call it:` 行 — このエントリが置き換える誤った呼び名のリスト。
+
+**`Don't call it:` の効き方（誤読しやすいので明記）**: 禁じているのは
+「**そのエントリの概念を、その名前で呼ぶこと**」であって、その語の一般使用ではない。
+たとえば `darwin-rebuild switch` の `Don't call it: apply` は「switch を apply と呼ぶな」の意味で、
+`chezmoi apply`（それ自体が正規名）を禁じない。同様に `適用` `取り込み` `ビルド確認` のような
+一般語も、**別の正規名を持つ操作を指す時にだけ**違反になる。
+この非対称性のため、**単純な grep では強制できない**（台帳の印は 📖）。
+
+---
+
+## 全体像
+
+dotfiles は **4 つの所有レイヤー**（nix-darwin / home-manager / chezmoi /
+1Password）+ ブートストラップ（`install.sh`）で構成される。**1 ファイル
+1 所有** が鉄則
+（[docs/reproduction-architecture.md](reproduction-architecture.md)）。
+
+```mermaid
+flowchart TB
+  USER["新規 macOS"]
+  INSTALL["install.sh<br/>(bootstrap)"]
+  subgraph NIX["Nix flake (リポジトリ直下)"]
+    FLAKE["flake.nix / flake.lock"]
+    DARWIN["nix-darwin<br/>(system + homebrew + defaults)"]
+    HM["home-manager<br/>(home.packages + programs.*)"]
+  end
+  subgraph CHEZMOI["chezmoi/ (.chezmoiroot)"]
+    DOTS["dot_config / dot_local / private_*"]
+    TMPL[".tmpl + onepasswordRead"]
+  end
+  subgraph SECRETS["1Password"]
+    OP["op CLI (op read)"]
+  end
+  USER --> INSTALL
+  INSTALL --> NIX
+  INSTALL --> CHEZMOI
+  FLAKE --> DARWIN
+  FLAKE --> HM
+  TMPL -->|"apply 時に注入"| OP
+  DARWIN -.macOS 環境.-> USER
+  HM -.dotfiles + パッケージ.-> USER
+  CHEZMOI -.dotfiles 実体.-> USER
+```
+
+下の図は **インストール先の判定フロー**（既存図を正規語彙で書き直したもの。
+CLAUDE.md にも同等の図あり）。
+
+```mermaid
+flowchart TD
+  Start([追加したい]) --> Q1{種類は?}
+  Q1 -->|GUI アプリ| Q2{cask 経路}
+  Q1 -->|CLI ツール| Q3{nixpkgs に<br/>あるか?}
+  Q1 -->|ランタイム| M["programs.mise.globalConfig.tools"]
+  Q2 -->|普通の cask| C1["homebrew.casks"]
+  Q2 -->|カスタム tap 経由| C2["homebrew.taps + casks"]
+  Q2 -->|MAS のみ| C3["homebrew.masApps"]
+  Q3 -->|あり & 汎用 CLI| N1["home.packages"]
+  Q3 -->|macOS 専用 / nixpkgs 古い| C4["homebrew.brews"]
+```
+
+---
+
+## 所有レイヤー（鉄則: 1 ファイル 1 所有）
+
+### nix-darwin
+**macOS システム / homebrew / defaults を宣言的に所有**するレイヤー。
+- 場所: [`system/modules/`](../system/modules/)
+- 含むもの: `system.defaults`, `homebrew.{casks,brews,taps,masApps}`,
+  LaunchAgent 等
+- **Don't call it:** darwin nix, macos nix, システム Nix
+
+### home-manager
+**ユーザー領域（パッケージ / DSL ある dotfile）を所有**するレイヤー。
+- 場所: [`home/modules/`](../home/modules/)
+- 含むもの: `home.packages`, `programs.zsh` / `git` / `starship` / `mise` 等
+- **Don't call it:** hm, user nix, ユーザー Nix
+
+### chezmoi
+**生 dotfile / バイナリ資産 / シークレット参照テンプレ**を所有するレイヤー。
+- 場所: [`chezmoi/`](../chezmoi/)（`.chezmoiroot` でルート指定）
+- **Don't call it:** dotfile manager, ドットファイル管理（一般語は可）
+
+### 1Password (`op`)
+**シークレットの唯一の格納先**。リポジトリにはリテラル値を置かず、
+**参照**（`op read "op://Vault/Item/field"`）で apply 時に注入。
+- CLI: `_1password-cli` (Nix 経由) + `1password` GUI (Brew cask)
+- **Don't call it:** 1pass, op cli（cli 単体を指す時のみ可）, シークレット
+  ストア
+
+### Service Account (`op-sa`)
+**無人・agent 用の 1Password 機械アカウント**（`claude-automation`）。
+[[Automation vault]] のみ read-only。wrapper
+[`op-sa`](../chezmoi/dot_local/bin/executable_op-sa) が token を注入して
+biometric なしで `op read` を通す。token はグローバル export しない
+（使う瞬間だけ注入）。人間の対話は従来の `op`（app 統合 + Touch ID）。
+- **Don't call it:** bot account, automation token, SA トークン（token
+  自体を指す時のみ可）
+
+### Automation vault
+**[[Service Account (`op-sa`)]] が読める唯一の vault**。Claude の無人作業に
+要る secret だけを選んで入れる（Personal vault は仕様上 SA に付与不可）。
+中身の追加・削除は自由（SA の vault アクセス自体は immutable）。
+- **Don't call it:** bot vault, claude vault, 自動化保管庫
+
+---
+
+## ビルド / 適用
+
+### `flake.nix`
+リポジトリ直下の Nix flake エントリ。[[nix-darwin]] / [[home-manager]] / nix-homebrew
+を組合せる。
+- **Don't call it:** nix entry, ニックスエントリ
+
+### `darwin-rebuild build`
+**非破壊ビルド**。`switch` の前段で必ず通す検証ゲート。
+- **Don't call it:** dry-run, test build, ビルド確認
+
+### `darwin-rebuild switch`
+**実適用**。sudo 必要（ユーザーがパスワード入力。AI は直接呼ばない）。
+PATH 継承の問題で **フルパス** `sudo /run/current-system/sw/bin/darwin-rebuild
+switch ...` で呼ぶ。
+- **Don't call it:** apply, deploy, system update, 切替
+
+### `chezmoi diff`
+**ソース ⇔ 実体の差分**。`apply` 前に必ず通す検証ゲート。
+- **Don't call it:** preview, dry-run, プレビュー
+
+### `chezmoi apply`
+[[chezmoi]] 管理ファイルを `$HOME` に書き出す **実適用**。
+- **Don't call it:** sync, deploy, 適用
+
+### `chezmoi re-add`
+**実体 → ソース** 方向の取込（`~/.config/<app>/...` を編集した後の正規手順）。
+順序を守らない（先に `apply` する）と古い source が実体を上書きして編集が
+消える。
+- **Don't call it:** import, take, 取り込み
+
+---
+
+## chezmoi 規約
+
+### `executable_` prefix
+**[[chezmoi]] 配下のスクリプトに +x を再現するための prefix**。CI が強制
+（[`.github/workflows/ci.yml`](../.github/workflows/ci.yml)）。`run_*` と
+`.chezmoiscripts/` 配下は例外（chezmoi 自身が実行するので prefix 不要）。
+- **Don't call it:** exec prefix, x prefix, 実行プレフィックス
+
+### `private_` prefix
+**[[chezmoi]] で権限 600 を再現する prefix**。secret ファイルに必須。
+- **Don't call it:** secret prefix, restricted prefix, 機密プレフィックス
+
+### `encrypted_` prefix
+**age / gpg で暗号化された秘密ファイル**の prefix。`private_` の代替。
+- **この repo に実インスタンスは無い**（2026-07-27 実測 0 件）。secret ファイルを
+  置く必要が出たときの規範として残している。
+- **Don't call it:** crypt prefix, secure prefix
+
+### `modify_` prefix
+**既存の live ファイルを stdin で受け取り、stdout で書き戻す** [[chezmoi]] の
+差分マージ script。全置換しないので、ユーザー / AI が live 側に足した設定を
+保ったまま特定のキーだけを保証できる。
+- 適用例: [`chezmoi/private_dot_claude/modify_settings.json`](../chezmoi/private_dot_claude/modify_settings.json)
+  （`~/.claude/settings.json` に 5 項目を保証し、他は pass-through）
+- **Don't call it:** merge script, patch script, マージスクリプト
+
+### `create_` prefix
+**存在しないときだけ生成する** [[chezmoi]] の prefix。以後 live 側の変更を上書きしない。
+- 適用例: `chezmoi/private_dot_ssh/create_private_known_hosts`
+- **Don't call it:** init file, seed file, 初期生成
+
+### `.tmpl` + `onepasswordRead`
+[[chezmoi]] テンプレに secret を **参照** として埋め込む正規パターン。
+リテラル値は書かない。前提: `op signin` 済み。
+- **この repo に実インスタンスは無い**（2026-07-27 実測: `chezmoi/` 配下 0 件）。
+  無人 / agent 読み取りの実経路は [[Service Account (`op-sa`)]]。
+- **Don't call it:** secret template, op template, シークレットテンプレ
+
+### `run_once_` / `run_onchange_` / `run_onchange_after_`
+[[chezmoi]] の **scripts 発火ポリシー**。`run_onchange_` が既定（idempotent）。
+`run_once_` は本当に一度きりの bootstrap でのみ使う。`_after_` は同一 apply 内での
+実行順序を後ろに寄せるサフィックス。
+- **Don't call it:** init script, setup hook, 初期化スクリプト
+
+### `mkOutOfStoreSymlink`
+nix store 外のファイルへ symlink を張る [[home-manager]] イディオム。
+- **この repo では使っていない**（2026-07-27 実測: `*.nix` に 0 件）。AI / ユーザーが
+  編集する共有ファイル（`~/.claude/settings.json`）の実機構は上の [[`modify_` prefix]]。
+  将来 home-manager 側で逃がしたくなったときの選択肢として名前だけ残す。
+- **Don't call it:** writable symlink, out-of-store link, 書き換え可能リンク
+
+---
+
+## ブートストラップ / 配布
+
+### `install.sh`
+**新規 macOS の最終目標**: このスクリプト 1 つで同等環境を再現できる
+状態を維持する。**単一ステージ・無人一気通貫**（CLT → workspace volume → Nix(.pkg)
+→ clone → switch → chezmoi → SSH gate → ghq-get-mine → claude-memory link →
+事後条件検証）。GUI 操作（FDA 付与・1Password サインイン/agent ON/鍵承認・
+自動ロックタイマー OFF）は**事前準備に front-load** する。`✓ 完了` は全 phase +
+検証を通過した時だけ出る。
+- **Don't call it:** setup, bootstrap script, セットアップ
+
+### `--phase2`
+install.sh の**リカバリ入口**。SSH gate（1Password）起因の失敗を直した後、
+導入系 phase（CLT/Nix/switch）を再評価せず、sudoers drop-in の self-heal →
+事後条件検証（システム層）→ clone 以降（SSH gate → ghq-get-mine → link →
+clone 検証）を実行する。通常経路ではない（通常はワンライナー再実行 = 冪等）。
+- **Don't call it:** stage 2, 後半モード, 対話モード
+
+### `summary.txt`
+install.sh の各 run が `~/.dotfiles-install/<run-id>/` に残す機械可読サマリ
+（result / failed / last_phase / log 位置）。LLM・人間はまずこれを読む。
+`latest` symlink が最新 run を指す。
+- **Don't call it:** report, result.txt, ログ本体
+
+### `ghq-get-mine`
+**自リポジトリ一括 clone コマンド**。GitHub 上の akira-toriyama の active
+（非 archived）repo を `GHQ_ROOT`（`/Volumes/workspace`）へ ghq レイアウトで
+SSH clone する。冪等（clone 済みは no-op）。install.sh §6.5 と日常の新 repo
+追従で使う。
+- 所在: [`home/modules/packages.nix`](../home/modules/packages.nix)
+  （`writeShellScriptBin`）/ 運用手順は
+  [operations.md §5.12](operations.md)
+- **Don't call it:** clone-all, repo 一括取得スクリプト, ghq sync
+
+### `aarch64-darwin`
+唯一のサポート arch。flake はこの platform をターゲットする。
+- **Don't call it:** apple silicon, m1/m2, arm mac
+
+---
+
+## GitHub / CI / 運用
+
+### `main` (唯一の永続ブランチ)
+**2026-05-27 に `rebuild` 統合・削除**。作業は短命な feature ブランチを切り、
+PR 経由で `main` に squash-merge する（直 push なし）。
+- **Don't call it:** master, develop, default branch（git の用語としては可）
+
+### feature branch
+**短命**ブランチ。命名は `<type>/<topic>` で `type` は `docs` / `feat` /
+`fix` / `refactor` / `chore` 等。PR → CI green → `gh pr merge --squash`。
+- 散文中の **「feature ブランチ」は同じものの日本語表記として可**（正規名を英語で保つ
+  規則 :21-23 に沿う混在表記）。`feature branch` と揺れていても違反ではない。
+- **Don't call it:** topic branch, work branch, 作業ブランチ
+
+### pre-push hook
+[`.githooks/pre-push`](../.githooks/pre-push) が chezmoi/ を触る push で
+`chezmoi verify` を実行し、乖離（`chezmoi status` の `R` 含む）を**警告する**
+（**warn-only、2026-07-03〜。push は止めない** — Claude 主導運用のため）。
+気づいたら `chezmoi apply` で live を追従。恒久ゲートは CI と main の
+ブランチ保護が担う。詳細 → [operations.md §5.11](operations.md)。
+- **Don't call it:** pre-push check, verify hook, プッシュ前検証
+
+### `chezmoi templates render` (CI)
+全 `.tmpl` の `execute-template` 検証 CI ジョブ。
+- **Don't call it:** template lint, tmpl check, テンプレ検証
+
+### ルール台帳 (claude-md-ledger)
+[`docs/claude-md-ledger.md`](claude-md-ledger.md)。global CLAUDE.md の各ルールに
+「Claude の手番 / ユーザーの手番 / 機構」の 3 列と強制状態の印（🔒/🟡/📖/🙅）を
+付けた索引。ルール本文は転記しない（正本は CLAUDE.md の節）。📖 の行 =
+機構化バックログ。ルールの追加・変更と**同一 PR** でこの台帳も更新する。
+- **Don't call it:** rule list, ルール一覧, enforcement matrix
+
+---
+
+## グレーゾーン判定の正規語彙
+
+### `homebrew.casks` vs `home.packages`
+**casks** = GUI / cask 経路 / macOS 統合（SSH agent / Spotlight / pkg-installer）。
+**home.packages** = nixpkgs にあり Linux 互換が要る CLI。迷ったら **Nix**
+（reproducibility / Linux 互換 / hash pin）。
+- 例: `_1password-cli` (Nix), `1password` GUI (Brew cask),
+  `font-*-nerd-font` (Brew cask, `~/Library/Fonts` Spotlight 連携のため)
+
+### `programs.mise.globalConfig.tools`
+**ランタイム**（node / python / deno 等）の所有先。`home-manager` `programs.mise`
+を `enable = true` にすると zsh init まで自動 wire される。
+- **Don't call it:** asdf, version manager（一般名としては可）
+
+---
+
+## 連携先（外部リポ）の参照
+
+### `chord` (in dotfiles context)
+**macOS host bridge for canon (ZMK)**。`chezmoi/dot_config/chord/private_config.toml`
+が本体、`.tmpl` の `{{ include }}` で組み立てる。リネーム時は
+[`docs/operations.md`](operations.md) §5.7 の **4 箇所同時更新** を厳守。
+config 文法を released chord より先行させると `verify-chord-validate.yml`
+（tap の chord で strict 検証）が落ちる。
+- 参照: [`docs/chord.md`](chord.md)
+- **`chord config` は禁止語ではない** — chord CLI の実サブコマンド名
+  （`chord config --validate`）であり、設定ファイルそのものを指す語としても正しい。
+  禁じるのは **bridge 本体**を「chord config」と呼ぶこと。
+- **Don't call it:**（bridge 本体の呼び名として）hotkey config, ホットキー設定
+
+### `halo` / `facet` / `wand` (in dotfiles context)
+
+dotfiles が **config だけを持つ**自作 macOS アプリ 3 本（アプリ本体は各 repo）。
+`chord` と同じく `chezmoi/dot_config/<name>/config.toml` が chezmoi 管理下にあり、
+**アプリ側は読むだけ**（dotfiles からアプリを起動・ビルドしない）。
+
+| 名前 | 何をするか | config |
+|---|---|---|
+| `halo` | アクティブウィンドウの枠（border ring）を描く | [`chezmoi/dot_config/halo/config.toml`](../chezmoi/dot_config/halo/config.toml) — 未知キーは既定値に落ちるので typo で壊れない |
+| `facet` | デスクトップ演出（focus ring / pets 等）。`#:schema` 行で taplo 補完が効く | [`chezmoi/dot_config/facet/config.toml`](../chezmoi/dot_config/facet/config.toml) — schema sidecar は `facet --emit-schema` 由来 |
+| `wand` | パネル / カード UI。GUI 設定を持たず config が唯一の正本 | [`chezmoi/dot_config/wand/config.toml`](../chezmoi/dot_config/wand/config.toml) |
+
+- **Don't call it:** WM スタック（旧 borders/rift/focusfx は drop 済みで別物）、
+  ランチャー、オーバーレイ設定
+
+---
+
+## 既知の落とし穴の正規語彙
+
+- `__NIX_DARWIN_SET_ENVIRONMENT_DONE` — switch 直後の親シェルで PATH 異常
+  に見える false positive のフラグ。**検証は新ターミナル** か
+  `env -i HOME=$HOME /bin/zsh -l -c '...'`。
+- `nix.enable = false` — Determinate Nix と二重管理しない既定。
+  `/etc/nix/nix.custom.conf` には触らない。
+- ByHost ドメイン（`-currentHost`） — `system.defaults` から **書けない**。
+  Display 配置や一部 Finder 詳細は `activationScripts` で
+  `defaults -currentHost write` を使う以外手がない。
+
+---
+
+## Claude Code を助ける自作 CLI
+
+いずれも akira-toriyama 製で、[`home/modules/packages.nix`](../home/modules/packages.nix) の
+`sourceBuiltCLI`（呼ぶたび clone を incremental build する wrapper）で PATH に載る。
+**brew 版は入れない**（`/opt/homebrew/bin` が nix profile より前なので wrapper を shadow する）。
+使いどころの正典は global CLAUDE.md の Tools 節 — ここは呼び名の定義だけ。
+
+### `furrow`
+**タスク管理 CLI**。この repo のタスクの正本は furrow + private tracker repo `projects`。
+- **Don't call it:** todo CLI, task tracker, タスクツール／install 版・brew 版
+
+### `glyph`
+**commit 規約のエンジン**（gitmoji → semver → release notes）。lint も semver も notes も glyph。
+- **Don't call it:** commitlint, conventional-commits ツール, git-cliff
+
+### `pare`
+**1 回のコマンド出力を予算内に切り詰める**（head + error-match + tail）。`| tail` の代わり。
+- **Don't call it:** truncate, output clipper, ログ切り詰め
+
+### `cifail`
+**CI 失敗の要点抽出**。生 run ログを漁らずに失敗 step のエラー行だけを取る。
+- **Don't call it:** ci log viewer, gh run view のラッパ
+
+### `rundiff`
+**同一コマンドの前回実行との差分**だけを出す（pare が 1 回の出力を切るのに対し、実行間を切る）。
+- **Don't call it:** output diff, テスト差分
+
+### `revpost`
+**findings JSON を PR レビュー 1 本に束ねて投稿**する。アンカーを diff の commentable 行に照合する。
+- **Don't call it:** review bot, コメント投稿ツール
+
+### `peekaboo` / `wait4x`
+自作ではなく **adopt 済の外部 CLI**。peekaboo = macOS の AX ツリー取得と操作（GUI 検証）、
+wait4x = 条件待ち（ログ行 / port / HTTP / プロセス）。手書きの `until` + `sleep` は書かない。
+- 所在: peekaboo = [`system/modules/homebrew.nix`](../system/modules/homebrew.nix)（`steipete/tap/peekaboo`）、
+  wait4x = [`home/modules/packages.nix`](../home/modules/packages.nix)
+- **Don't call it:** AX ダンプツール, ポーリングループ
+
+---
+
+## Claude asset（`chezmoi/private_dot_claude/`）
+
+Claude Code 自身の設定・知識を [[chezmoi]] で再現するレイヤー。
+**所有は chezmoi**（Nix ではない — 1 ファイル 1 所有の鉄則）。
+
+### global CLAUDE.md
+**全 repo に効く Claude への常時ロード指示書**。source =
+[`chezmoi/private_dot_claude/CLAUDE.md`](../chezmoi/private_dot_claude/CLAUDE.md) →
+配布先 `~/.claude/CLAUDE.md`。**live を直接編集しない**（次の apply で剥がれる）。
+- **Don't call it:** システムプロンプト, グローバル設定, AI ルール
+
+### skill（`SKILL.md`）
+**特定の作業で読み込ませる知識パック**。`chezmoi/private_dot_claude/skills/<name>/SKILL.md`。
+frontmatter の `description` が「いつ発火するか」を決める。
+- **Don't call it:** プラグイン, ナレッジベース, プロンプトテンプレ
+
+### agent（`fable-architect`）
+**サブエージェントの定義**。`chezmoi/private_dot_claude/agents/<name>.md`。
+`tools:` に載せないツールは harness が拒否する（＝許可を構造で担保する場所）。
+- **Don't call it:** サブエージェント設定, ペルソナ
+
+### Stop hook（`claude-work-report-check`）
+**セッション終了時に走る判定スクリプト**。作業報告に task ID（か「なし」）と増減の実数が
+無ければ停止をブロックする。実体 =
+[`chezmoi/dot_local/bin/executable_claude-work-report-check`](../chezmoi/dot_local/bin/executable_claude-work-report-check)、
+回帰テストは CI の `hook scripts test`。
+- **Don't call it:** 終了フック, 報告チェッカー
+
+### PreToolUse guard（`claude-*-guard`）
+**ツール呼び出しの直前に走り、通す / 訊く / 拒む を決めるスクリプト**。
+現在 3 本 —— [`claude-fanout-cwd-guard`](../chezmoi/dot_local/bin/executable_claude-fanout-cwd-guard)（別 worktree へのファンアウトを拒む）/
+[`claude-vncdo-guard`](../chezmoi/dot_local/bin/executable_claude-vncdo-guard)（deadline の無い vncdo を拒む）/
+[`claude-board-shard-guard`](../chezmoi/dot_local/bin/executable_claude-board-shard-guard)（furrow の board shard 直編集を訊く）。
+どれも **fail-open**（自身が壊れたら通す）で **narrow scope**（誤検知した guard は
+guard 全体を無視させる）。配線は `modify_settings.json`。
+- **Don't call it:** 事前フック, パーミッションフィルタ, ツールガード
+
+### `claude-md-eval`
+**CLAUDE.md の散文変更を配る前に測るハーネス**。baseline（節なし）と candidate（節あり）の
+応答を作り、盲検で判定してリリースゲートを掛ける。実体 =
+[`scripts/claude-md-eval/`](../scripts/claude-md-eval/README.md)。
+- **Don't call it:** プロンプト評価, A/B テスト基盤
+
+### 台帳（`docs/claude-md-ledger.md`）
+**global CLAUDE.md の各ルールが「機構で強制されているか / 散文頼みか」を 1 表にしたもの**。
+ルール本文は転記しない（正本は CLAUDE.md）。ルールを足す・変える PR では同一 PR で更新する。
+- **Don't call it:** ルール一覧, ポリシー表
+
+---
+
+## エントリ追加時のルール
+
+- 1 つの概念につき正規名は 1 つ。複数の呼び方が流通しているなら、
+  このファイルで勝者を選び、敗者は `Don't call it:` 行に並べる。
+- 正規名は **英語のまま** 書く。chezmoi prefix（`executable_`, `private_`,
+  `encrypted_`, `run_once_`, `run_onchange_`）や Nix module キー
+  （`home.packages`, `homebrew.casks`）はその表記を維持する。
+- 定義は **1〜2 文** に収める。動作の詳細は
+  [`docs/operations.md`](operations.md) /
+  [`docs/reproduction-architecture.md`](reproduction-architecture.md) /
+  ソースファイルへリンクし、ここで説明し直さない。
+- 連携先リポ（canon / chord / wand / glance / eventfx / perch / facet）の
+  用語と衝突しないか確認する。衝突する場合は `Don't call it:` に並べて
+  棲み分けを明記する（例: dotfiles の **chord** ≠ canon の **combo**）。

--- a/docs/operations.ja.md
+++ b/docs/operations.ja.md
@@ -1,0 +1,484 @@
+<!--
+この文書は operations.md（英語・正本）の和訳です。人間向け。
+最新とは限りません — 基準: 英語版 @ 13d20e6。
+同時更新はしない — 人間の指示があった時に、基準 commit からの差分を訳して基準を進める。
+-->
+
+# dotfiles 運用ガイド
+
+> 鉄則・責務分担・判定フローは [CLAUDE.md](../CLAUDE.md) を参照。本書は「実際にどう操作するか」のレシピ集。
+> いずれの作業も **main 一本運用 + PR フロー**（[CLAUDE.md の GitHub / CI 節](../CLAUDE.md)）。
+
+---
+
+<details>
+<summary><b>1. <code>~/.config/&lt;app&gt;/...</code> を編集した場合（chezmoi）</b></summary>
+
+### シナリオ
+`~/.config/chord/config.toml` や `~/.config/wand/config.toml` を直接編集した、または上流（chord / wand 等）の最新挙動に合わせて手で変えた状態を、dotfiles リポへ流す。
+
+dot_config 配下の管理ファイルは **全て plain（`.tmpl` なし）** に統一済み。チェック内容に template 変数が登場しないので、`chezmoi re-add` で安全に取り込める。
+
+### 手順
+
+```sh
+# ── ① ~/.config を編集（実体 = target を直接いじった状態）
+
+# ② 乖離を確認
+chezmoi status      # 各行 MM = source/target 両方変更あり
+chezmoi diff        # 何が違うか
+
+# ③ live を source に取り込む（実体 ──▶ source）
+chezmoi re-add ~/.config/chord/config.toml
+# 例: ~/.config/wand/config.toml・~/.config/facet/config.toml・~/.config/halo/config.toml も同様
+#   ※ 実体を編集したら必ず re-add が先。先に apply すると古い source で
+#     実体を上書きして編集が消える。
+
+# ④ source ──▶ live を反映（= apply）。本体一致でも run_onchange 検証が走り、
+#    chezmoi status の "R"（chord-validate 等）が消える。
+chezmoi apply -v
+chezmoi status      # クリーン（差分なし）を確認
+
+# ⑤ ここから git 側（source を main に刻む）。chezmoi 側とは独立した工程。
+cd "$(ghq root)/github.com/akira-toriyama/dotfiles"
+git status
+git checkout -b chore/sync-chord-config
+git add chezmoi/dot_config/chord/private_config.toml
+glyph lint --range origin/main..HEAD   # push 前に必ず
+git commit -m ":memo:(chord) sync the chord config into the chezmoi source"
+git push -u origin chore/sync-chord-config   # pre-push フックが chezmoi verify で乖離を警告（warn-only、§5.11）
+gh pr create --title "..." --body "..."
+gh pr merge --auto --squash
+```
+
+### ⚠️ apply と commit は別物（2 つの台帳）
+
+`chezmoi apply`（③④の live 反映）と `git commit`（⑤の source を main へ）は**連動しない**:
+
+- `chezmoi apply` しても **git の差分は消えない**（apply は source→live の同期で、commit ではない）
+- `git commit` しても **`chezmoi status` の "R" は消えない**（commit は source を履歴に刻むだけ）
+
+両方やって初めてクリーン。**②③で実体を編集したら必ず apply してから push**（apply 忘れは §5.11 の pre-push フックが警告する＝warn-only。乖離ゼロの恒久保証は CI）。
+
+</details>
+
+---
+
+<details>
+<summary><b>2. GUI アプリ（<code>.app</code> バンドル）を追加したい</b></summary>
+
+### 手順
+
+```sh
+# 1. cask が存在するか確認
+brew search foo
+brew info --cask foo
+
+# 2. (任意) 試用 install
+brew install --cask foo
+# 起動して試す → 良ければ続行、ダメなら brew uninstall して終了
+
+# 3. system/modules/homebrew.nix の casks に追記（1 行コメント必須）
+#    casks = [
+#      ...
+#      "foo"             # 何のアプリか／なぜ入れるか
+#    ];
+
+# 4. chezmoi 連携の要否を判定
+#    ~/Library/Containers/...      → 不要（sandbox 配下、追跡しづらい）
+#    ~/.config/<app>/...           → 必要、セクション 1 の手順で取り込む
+#    ~/Library/Preferences/*.plist → defaults.nix で書く（chezmoi ではない）
+
+# 5. ローカルで非破壊チェック
+cd "$(ghq root)/github.com/akira-toriyama/dotfiles"
+nix flake check --no-build
+nix run nix-darwin#darwin-rebuild -- build --flake .#default --impure
+
+# 6. PR
+git checkout -b feat/add-foo-cask
+git add system/modules/homebrew.nix
+glyph lint --range origin/main..HEAD   # push 前に必ず
+git commit -m ":sparkles:(homebrew) declare the foo cask"
+git push -u origin feat/add-foo-cask
+gh pr create
+# CI の "Verify casks installed" が cask 名のタイポを検知
+
+# 7. merge 後、手元に反映
+gh pr merge <PR#> --auto --squash
+git checkout main && git pull
+sudo /run/current-system/sw/bin/darwin-rebuild switch --flake .#default --impure
+# 既に手で試用 install してた場合は実質 no-op
+```
+
+### カスタム tap の cask の場合
+
+`homebrew.taps = [ "owner/repo" ]` も追加。既存例: `barutsrb/tap` for `omniwm`。
+
+</details>
+
+---
+
+<details>
+<summary><b>3. Mac App Store 限定アプリを追加したい</b></summary>
+
+現在 MAS アプリの利用はゼロで、`homebrew.masApps` 経由の install は使っていない。
+
+**⚠️ 生きている制約**: `flake.nix` の `bootstrapBrewOverride` が `homebrew.masApps` を
+`lib.mkForce { }` で強制的に空にする（App Store 未サインインの bootstrap/CI/VM で
+switch を落とさないため。PR #108 で常用 + bootstrap 共通方針に統一）。
+**masApps に何を宣言しても live では `{}`** — 「宣言したのに入らない」は不具合ではない。
+
+将来 MAS アプリが必要になったら:
+
+- (a) 手動で App Store からインストール（最も確実）、または
+- (b) `mas` CLI を一時導入して（nixpkgs にあり。利用ゼロのため常設はしていない）
+  `mas install <id>` を手で叩く
+- 宣言的に戻したい場合は `bootstrapBrewOverride` の緩め方（サインイン済み前提の
+  構成分離等）の設計から始める
+
+</details>
+
+---
+
+<details>
+<summary><b>4. その他のもの（CLI / ランタイム / DSL 設定 / カスタム tap / macOS defaults / secret）</b></summary>
+
+判定は [CLAUDE.md のインストール先の判断フロー](../CLAUDE.md) に従う。ここでは編集先のファイルだけ早見表:
+
+| 種類 | 編集ファイル | 例 |
+|---|---|---|
+| nixpkgs にある汎用 CLI | `home/modules/packages.nix` | `jq`, `gh`, `chezmoi`, `docker`, `_1password-cli` |
+| nixpkgs に無い / macOS 専用 CLI | `system/modules/homebrew.nix` の `brews = [ ... ]` | `blueutil`, `duti` 等（現状空） |
+| カスタム tap | `system/modules/homebrew.nix` の `taps = [ ... ]` + 対応 `casks/brews` | `barutsrb/tap` → `omniwm` |
+| ランタイム（node / python / deno / ruby） | `home/modules/mise.nix` の `globalConfig.tools` | `node = "lts"`, `python = "3.13"` |
+| DSL のあるプログラム設定（zsh / git / mise 等） | `home/modules/*.nix` の `programs.*` | `programs.zsh.*`, `programs.mise.*` |
+| macOS defaults（dock / finder / -g 等） | `system/modules/defaults.nix` | `system.defaults.dock.autohide` 等 |
+| 手編集の生 dotfile / バイナリ資産 | `chezmoi/dot_*` | `chezmoi/dot_config/chord/...` |
+| シークレット（鍵 / トークン / PAT） | `chezmoi/private_*.tmpl` | `{{ onepasswordRead "op://..." }}` |
+
+### 編集後の反映パターン
+
+| 編集したもの | 反映コマンド |
+|---|---|
+| `*.nix`（flake / system / home 配下） | `darwin-rebuild switch` |
+| `chezmoi/...` | `chezmoi apply` |
+| 両方 | `darwin-rebuild switch` → `chezmoi apply`（順序重要、`op` CLI などは Nix が先に置く） |
+
+</details>
+
+---
+
+<details>
+<summary><b>5. その他運用</b></summary>
+
+### 5.1 アンインストール
+
+```sh
+# cask の場合
+# 1. system/modules/homebrew.nix から該当行を削除 → PR → merge
+# 2. cleanup="none" なので live は残る、手で消す:
+brew uninstall --cask foo
+
+# Nix package の場合
+# 1. home/modules/packages.nix から削除 → PR → merge
+# 2. darwin-rebuild switch で自動的に消える
+```
+
+`homebrew.onActivation.cleanup = "zap"` に切り替えれば未宣言の brew/cask を自動 uninstall。**現状は `"none"` 据え置き**（フェーズ 4 残りを宣言化してからユーザー確認の上で切り替える方針、[CLAUDE.md「既知の落とし穴」節](../CLAUDE.md#既知の落とし穴読まずに修正を試みない)）。
+
+### 5.2 darwin-rebuild rollback
+
+```sh
+sudo /run/current-system/sw/bin/darwin-rebuild --rollback
+# 1 世代戻る。switch 後に問題が出たときの即時退避。
+```
+
+世代一覧は:
+```sh
+darwin-rebuild --list-generations
+```
+
+### 5.3 drift 検知（手元で即チェック）
+
+```sh
+# chezmoi 側（source ↔ live の差分）
+chezmoi status      # 乖離一覧
+chezmoi diff        # 詳細
+
+# Nix 側
+nix flake check --no-build                                          # eval/型
+nix run nix-darwin#darwin-rebuild -- build --flake .#default --impure  # 非破壊 build
+
+# brew 側（宣言 vs 実 install）
+brew list --cask | sort                                                          # 実 install
+nix eval --json '.#darwinConfigurations.default.config.homebrew.casks' --impure \
+  | jq -r '.[].name' | sort                                                           # 宣言
+diff <(brew list --cask | sort) \
+     <(nix eval --json '.#darwinConfigurations.default.config.homebrew.casks' --impure | jq -r '.[].name' | sort)
+```
+
+### 5.4 別 PC ブートストラップ
+
+新 Mac で（Apple Silicon の chip transfer 後、ターミナル一発）:
+```sh
+sh <(curl -fsSL https://raw.githubusercontent.com/akira-toriyama/dotfiles/main/install.sh)
+```
+
+これだけで:
+1. Xcode CLT install
+2. Nix install（Determinate）
+3. flake clone → git hooks 有効化（`core.hooksPath = .githooks`、§5.11）→ `darwin-rebuild switch --flake .#default --impure`（cask / brew / macOS defaults を一括、masApps は `bootstrapBrewOverride` で `{}` forced のためスキップ）
+4. chezmoi init → apply（dot_* / private_* を配置、`op signin` 済の前提で secret も注入）
+5. `run_onchange_` 自動実行（VSCode 拡張 install / chord-validate 等）
+
+詳細: [docs/reproduction-architecture.md](reproduction-architecture.md)
+
+### 5.5 secret 取り扱い（YOU MUST）
+
+[CLAUDE.md「シークレット取扱」節](../CLAUDE.md#シークレット取扱you-must) より:
+
+- 平文を `print / log / echo / コミット / template リテラル` しない
+- chezmoi template で参照: `{{ onepasswordRead "op://Vault/Item/field" }}`
+- shell から参照: `$(op read "op://...")` / `$(gh auth token)` / `$ENV_VAR`
+- ファイルとして置く場合は `private_*`（権限 600）または `encrypted_*`（age/gpg）接頭辞必須
+- `home.file.*.text` に secret を書かない（`/nix/store` は world-readable）
+
+### 5.6 CI ジョブの意味
+
+[.github/workflows/ci.yml](../.github/workflows/ci.yml) ＋ chord 専用 verify-* ワークフロー:
+
+`ci.yml` の job は 11 本。**表に無い job があれば ci.yml が正**（この表は説明用の写し）。
+
+| ジョブ | 内容 | runner |
+|---|---|---|
+| `nix flake check (eval only)` | Nix の eval/型検査 | ubuntu-latest |
+| `lint` | `scripts/lint --ci`（ruff / ruff-format / mypy / shellcheck / shfmt / exec-bit / tmpl-shellcheck / tmpl-plist / actionlint / typos / lychee / doc-paths / claude-md-guard / gitleaks の 14 ゲート） | ubuntu-latest |
+| `convention / executable_ prefix` | `chezmoi/` の shebang スクリプトに `executable_` 接頭辞を強制（例外: `run_*` / `modify_*` / `.chezmoiscripts/`） | ubuntu-latest |
+| `script test` | Stop hook の fixture + `scripts/**` と `scripts/claude-md-eval/` の unittest | ubuntu-latest |
+| `chezmoi templates render` | 全 `.tmpl` の execute-template 検証（get.chezmoi.io の最新版で） | ubuntu-latest |
+| `docs link check (external URLs)` | 外部 URL 込みの lychee。**nightly / 手動のみ**・`ci-gate` の needs 外 | ubuntu-latest |
+| `detect flake-affecting changes` | PR が flake/nix/ci.yml を触ったかを判定し、下 2 本の実行可否を出す | ubuntu-latest |
+| `darwin-rebuild build (macOS)` | 実 build（cask DL 含む・非破壊） | macos-latest |
+| `darwin-rebuild switch smoke (macOS)` | 実 switch＋PATH/cask 検証＋`chezmoi apply`（ephemeral runner なので副作用 OK） | macos-latest |
+| `ci-gate` | 上を全部 needs。**branch protection の必須チェックはこれ 1 本だけ** | ubuntu-latest |
+| `notify red main` | 非 PR の赤を固定タイトル issue に集約（PR では走らない） | ubuntu-latest |
+
+chord 専用の別ワークフロー:
+
+| ジョブ | 内容 | runner |
+|---|---|---|
+| `validate` (verify-chord-validate.yml) | chord config strict validation | macos-15（Swift 6 toolchain 必須） |
+| `verify` (verify-chord-doc.yml) | chord doc 同期検証 | ubuntu-latest |
+
+### 5.6.1 lint を手元で回す / gitleaks が赤くなったら
+
+```sh
+nix develop .#lint --command scripts/lint            # CI と同一コマンド・同一バイナリ
+nix develop .#lint --command scripts/lint python     # 一部だけ（docs / python / secret / shell / tmpl / workflow）
+nix develop .#lint --command scripts/lint external   # 外部 URL のリンク検査（既定では走らない）
+```
+
+**`external` は opt-in**。ネットワークを叩くゲートは他人のサーバの 5xx / rate limit で
+落ちるので、PR の合否に混ぜない（`ci-gate` の needs に入っていない）。回すのは nightly と
+`workflow_dispatch` の `docs link check (external URLs)` job で、赤は `notify-red-main` が
+issue に集約する。素の `scripts/lint` がネットワークを叩かないことは `test_lint.py` が固定。
+
+**素で `scripts/lint` を叩かないこと** —— PATH は `/opt/homebrew/bin` が nix profile より
+前なので、brew 版の shfmt / typos / lychee / gitleaks が混ざって CI と結果がずれる。
+ツールの版の正本は `flake.lock` 1 本で、`devShells.lint`（[flake.nix](../flake.nix)）が配る。
+**開発機で PATH に居るだけのツールを devShell の宣言と混同しないこと** —— `chezmoi` は
+`home.packages` からも来るので、devShell に足し忘れても手元は緑になり CI だけが落ちる。
+
+**gitleaks が真陽性を出したら**（履歴は書き換えない — 絶対ルール 4）:
+
+1. **まず鍵を rotate する**（public repo なので、push された時点で漏れている前提で動く）
+2. `.gitleaksignore` に fingerprint を追記して CI を緑に戻す
+3. `gitleaks git` は全 ref の全履歴を毎回見るので、**真陽性を放置すると `ci-gate` が恒久的に赤**になる
+
+> push **後**にしか走らないのが CI の限界。push 時点で止めるのは GitHub の
+> secret scanning push protection の役目で、そちらは repo 設定（Settings → Code security）。
+
+### 5.7 run_onchange_ スクリプト
+
+`chezmoi/run_onchange_*` は **「rendered 後の本文 hash が変わったら再走」** の仕組み。`.tmpl` 接尾辞は任意（必要な時だけ）。現状:
+
+- `run_onchange_after_chord-validate.sh.tmpl` — chord config 変更時に `chord --validate --strict` 検証。`{{ include "..." | sha256sum }}` で **外部** chord config の hash を埋め込むため **`.tmpl` 必須**。
+- `run_onchange_install-vscode-extensions.sh` — 拡張リスト変更時に `code --install-extension`。拡張リストは script 本文の `for ext in ...` の右辺に直書き → 本文 hash で再走判定するため **`.tmpl` 不要** (PR #108 で plain 化)。
+
+外部ファイルの内容変化を再走トリガにしたい場合のみ `.tmpl` + `{{ include "..." | sha256sum }}` を使う。スクリプト本文内の宣言で済むなら plain `.sh` で良い。
+
+新規追加する場合は `run_once_` ではなく **`run_onchange_` を既定**（idempotent）。`run_once_` は本当に一度きりの bootstrap 用。
+
+#### 家訓: `.tmpl` / chord config を動かすときの影響範囲
+
+- **`.tmpl` 自体は read-only**: `run_onchange_after_chord-validate.sh.tmpl` は chord config を `include` で読んで `chord --validate` するだけで、**他リポへ書き込まないので副作用は出ない**。`verify-chord-validate.yml` も apply target を `~/.config/chord` に絞っている。「`.tmpl` 編集で他リポが壊れる」心配は不要。
+- **chord config パスは 4 箇所が同じファイルを指す**ので、リネーム/移動は同時に直す（PR #108 の `.tmpl` 廃止後、PR #123 で古参照を踏んだ実績あり）:
+  1. `chezmoi/run_onchange_after_chord-validate.sh.tmpl` の `{{ include "dot_config/chord/private_config.toml" | sha256sum }}`
+  2. `.github/workflows/verify-chord-validate.yml` の `paths:` フィルタ
+  3. `.github/workflows/verify-chord-doc.yml` の `paths:` フィルタ
+  4. `scripts/gen-chord-doc.py` の `CONFIG`
+- **config 文法は released chord と歩調を合わせる**: `verify-chord-validate.yml` は brew tap (`akira-toriyama/tap`) の **released** chord を install して strict 検証する。config の文法が released 版を追い越すと CI が落ちる。tap が追いつくまでは §5.10 の手元 build を使うか、文法変更と tap release を揃える。
+
+### 5.8 よく使うコマンド早見表
+
+```sh
+# 確認系
+chezmoi status                                                 # source ↔ live の乖離
+chezmoi diff                                                   # 内容差分
+nix flake check --no-build                                     # Nix eval
+darwin-rebuild build --flake .#default --impure                  # 非破壊 Nix build
+
+# 反映系
+chezmoi apply [-v] [--force]                                   # chezmoi 適用
+sudo /run/current-system/sw/bin/darwin-rebuild switch \
+  --flake .#default --impure                                     # Nix 適用（sudo 必要）
+
+# 取り込み系
+chezmoi add <path>                                             # 新規取り込み
+chezmoi re-add <path>                                          # 既存ファイルの更新
+chezmoi chattr +template <path>                                # .tmpl 化
+
+# 1Password
+op signin                                                      # まず最初に
+op read "op://Vault/Item/field"
+
+# リポジトリ
+ghq-get-mine                                                   # 自リポジトリ(active)を workspace へ一括 clone（冪等・§5.12）
+```
+
+### 5.9 トラブルシュート定番
+
+| 症状 | 確認すること |
+|---|---|
+| `darwin-rebuild switch` が PATH 関連で失敗 | sudo は PATH 引き継がない → **フルパスで呼ぶ** `sudo /run/current-system/sw/bin/darwin-rebuild ...` |
+| switch 後の親シェルで PATH 異常に見える | `__NIX_DARWIN_SET_ENVIRONMENT_DONE=1` 継承の false positive → **新ターミナル**または `env -i HOME=$HOME /bin/zsh -l -c '...'` |
+| `chezmoi apply` が prompt で止まる | MM 状態 → `--force` で source 優先、または re-add で live 優先 |
+| cask が CI で fail | cask 名タイポ / 廃止 / macOS 要件不一致 → `brew info --cask <name>` で確認 |
+| `system.defaults` がアプリに反映されない | TCC/sandbox 保護領域（Mail/Safari/Calendar 等）は switch 成功でも適用されない、深追いしない |
+
+### 5.10 chord daemon を手元 build で入れ替え（AX 維持）
+
+chord 本体に PR が ship されたけど tap formula がまだ古い、という過渡期に「手元 build を brew install の代わりに走らせる」手順。chord-dev 自己署名で再署名すれば既存 AX (Accessibility) 許可が引き継がれる。
+
+```sh
+# 1. 最新 chord (PR 含む main) を release build
+cd "$(ghq root)/github.com/akira-toriyama/chord"
+git switch main && git pull
+swift build -c release
+
+# 2. daemon 停止
+brew services stop chord
+sleep 1
+
+# 3. brew install の Chord.app 中の binary を swap
+#    `/opt/homebrew/opt/chord` は現バージョンへの symlink (例: ../Cellar/chord/0.5.0)
+#    なので version 数字を埋め込まずに済む。
+CHORD_APP="$(brew --prefix chord)/Chord.app"
+NEW="$(ghq root)/github.com/akira-toriyama/chord/.build/release/chord"
+cp "$CHORD_APP/Contents/MacOS/chord" "$CHORD_APP/Contents/MacOS/chord.bak"
+cp "$NEW" "$CHORD_APP/Contents/MacOS/chord"
+
+# 4. chord-dev で再署名 (TCC が同一 identity として認識 → AX 維持)
+codesign --force --sign chord-dev "$CHORD_APP"
+
+# 5. daemon 再起動 + 確認
+brew services start chord
+sleep 2
+chord --doctor
+# bindings: N loaded, ... 0 dropped (期待値)
+```
+
+戻すとき: `cp "$CHORD_APP/Contents/MacOS/chord.bak" "$CHORD_APP/Contents/MacOS/chord" && codesign --force --sign chord-dev "$CHORD_APP" && brew services restart chord`
+
+正規 tap release が出たら `brew upgrade chord && chord --resign` で本来の運用に戻る。
+
+### 5.11 pre-push フック（apply 忘れ warn-only 通知）
+
+`~/.config` を編集 → `chezmoi re-add` → **`chezmoi apply` を忘れて push** すると、「リポは新しいのに自分のマシンは古い」「run_onchange の検証ゲート（chord-validate 等）が未実行のまま push」といった事故になり得る。これに気づけるよう [`.githooks/pre-push`](../.githooks/pre-push) が push 前に `chezmoi --source ./chezmoi verify` を実行し、source ↔ live に乖離があれば**警告する（`chezmoi status` の "R" 保留も検知）**。
+
+**warn-only（2026-07-03〜）**: 以前は乖離で push を止めていたが、この repo は Claude Code 主導で運用するため「止めない（常に通す・警告のみ）」に緩めた。理由 = source 編集→apply→push の Claude 主導フローでは apply 忘れ型事故が起きにくく、facet 等 開発中ツールの恒常 drift で無関係な chezmoi/ push まで止まる誤発火（PR #185 で `--no-verify` を強いた）の摩擦が実害だったため。乖離ゼロの恒久保証は CI（darwin build/switch smoke + `chezmoi apply` + templates render）と main のブランチ保護が担う。ローカル live の追従は警告を見て `chezmoi apply` で。
+
+#### 有効化（`core.hooksPath` の設定）
+
+git は **clone 同梱の hook/設定を自動では有効化しない**（悪意あるリポを clone した瞬間にコードが走るのを防ぐセキュリティ仕様）。そのため `core.hooksPath` は次の経路で自動設定する:
+
+- **新 PC**: `install.sh` が clone 直後に設定（§3.5）。
+- **それ以外の clone（ghq / 手動 `git clone` 等）**: [`chezmoi/run_onchange_after_enable-git-hooks.sh`](../chezmoi/run_onchange_after_enable-git-hooks.sh) が **`chezmoi apply` のたび**に `CHEZMOI_SOURCE_DIR` から「いま使っている clone」の repo root を特定し、best-effort で設定する。`chezmoi source-path` が指す = 実際に push する clone なので確実に当たる。
+
+手動でやるなら（上記が走る前に効かせたい等）:
+```sh
+git config core.hooksPath .githooks
+```
+
+その他:
+
+- **警告のみ**: 乖離があっても push は止まらない（warn-only）。警告文も出したくない時だけ `git push --no-verify` でフック自体を skip。
+- chezmoi 未導入環境（CI / bootstrap 途中）ではフックは何もせず通す（`command -v chezmoi` で skip）。
+- **スコープ**: 検査するのは chezmoi/ を触る push だけ（`docs/` や `*.nix` のみの push は verify せず即通す）。旧仕様の「全乖離で無関係な push まで止まる」問題は解消済み。
+
+### 5.12 自リポジトリ一括 clone（ghq-get-mine）
+
+GitHub 上の自分の active（非 archived）repo を `/Volumes/workspace` へ
+ghq レイアウトで一括 SSH clone するコマンド。fork・private を含む。
+
+```sh
+ghq-get-mine
+```
+
+- **いつ**: 新 repo を作った後の追従 / 新 Mac では install.sh §6.5 が自動実行
+  （対話モードのみ、CI は skip）
+- **冪等**: clone 済み repo は no-op（`-u` は付けない = working copy 不可侵）
+- **前提**: gh 認証（or `GITHUB_TOKEN`）+ GitHub への SSH 疎通。未整備なら
+  1 行 warn で fail-fast → 整備後に再実行すれば欠けた分だけ補完される
+- 実体: [home/modules/packages.nix](../home/modules/packages.nix) の
+  `writeShellScriptBin`
+
+### 5.13 azooKey いい感じ変換ブリッジ（azookey-bridge）— 退役済み（2026-08-04）
+
+azooKey の「いい感じ変換」（変換中 Ctrl+S）をローカルブリッジ（`127.0.0.1:8787`
+常駐 + azooKey の「OpenAI API」backend の endpoint 差し替え）で動かしていたが、
+**ブリッジ・LaunchAgent・defaults 宣言ごと撤去した**。いい感じ変換は azooKey の
+既定（Off）に戻してある。
+
+作り直したくなった時のために、退役の理由（すべて実機実測）:
+
+- **速度が届かない**。実機の Ctrl+S 1 回で 8.1〜14.9 秒。しかもその下限は
+  推論ではなく `claude` CLI の起動そのもの（`hi` の一言でも 5.3〜6.2 秒）なので、
+  プロンプトを削ってもモデルを替えても縮まない。IME の応答としては使えない。
+- **速い方（オンデバイス FoundationModels、~1 秒）は品質が足りない**。
+  azooKeyMac バイナリから復元した実 stock プロンプト 8 ケースで正解 1〜2。
+  当たるのは入力が stock の few-shot 例と字面一致した時だけで、
+  `明日の会議を<えんき>` は天気の候補を、`ありがとう<えいご>` は 3/3 で
+  スペイン語を返した。例文の模倣を断つプロンプトを 2 種試すと 0/5 に悪化する。
+- つまり**速い経路と正しい経路が両立しない**。恒久対応は azooKey-Desktop への
+  upstream プロンプト修正（projects t-22se）。検証ログは projects t-85fn。
+
+</details>
+
+---
+
+## 5.14 `~/.claude` の一時ファイルを恒久保管先にしない（不変条件）
+
+`~/.claude/` は Claude Code の**実行時ディレクトリ**であり、宣言管理の対象は
+`chezmoi/private_dot_claude/` 配下（`CLAUDE.md` / `agents/` / `skills/` /
+`modify_settings.json`）だけ。それ以外にできたファイルは**どこにもバックアップされない**。
+
+- **`~/.claude/plans/` とホーム直下の一時メモ（`tmp-*.txt` 等）を恒久保管先にしない。**
+  作業計画・引き継ぎの正本は **furrow の task body**（大きい資料は `furrow attach` で
+  `bodies/assets/` へ）。実例: 2026-07-27 に `plans/` の 4 本を整理し、生きている 2 本は
+  `furrow attach` で t-8qqz / t-j8ek に移送、完了 2 本は削除した。
+- **memory の slug は必ず `MEMORY.md` の索引から link されていること。** 索引に載らない
+  memory は次のセッションで読まれず、書いた事実が静かに消える。`claude-maint` の
+  月次レーンは memory を見ていない（skills / commands / agents のみ）ので、
+  ここは今のところ**散文頼み**。
+
+## 完了済の大きな migration
+
+- **chord `[input-aliases]` 機能 + 論理名移行** — chord 本体で `[input-aliases]` 機能が ship 済 ([PR #4](https://github.com/akira-toriyama/chord/pull/4) v0.5.0 初版、[PR #7](https://github.com/akira-toriyama/chord/pull/7) で v0.6.0 として `$prefix` 必須 + `[aliases]` → `[action-aliases]` rename + schema v2 → v3)。`chezmoi/dot_config/chord/private_config.toml` は `[action-aliases]` + `[input-aliases]` + `$prefix` 参照 (`input = "$ULTRA_LL - c"`) に移行済。`scripts/gen-chord-doc.py` の hardcoded dict は削除済 (chord 自身が alias 解決)。daemon 入れ替えは `brew upgrade chord && chord --resign` か 5.10 の手元 build 手順を参照。
+
+## 参考
+
+- [CLAUDE.md](../CLAUDE.md) — 鉄則・責務分担・判断フロー・既知の落とし穴
+- [docs/reproduction-architecture.md](reproduction-architecture.md) — 全体アーキテクチャ・新 PC bootstrap の設計
+- [docs/roadmap.md](roadmap.md) — 進捗・未決事項
+- [docs/system-inventory.md](system-inventory.md) — 環境素材一覧


### PR DESCRIPTION
Second half of t-322v, following #343. Adds the `*.ja.md` human-facing review copies for the three operations docs, by the t-0btf method the epic uses (same shape as #342).

- **Header**: the shared three lines — 和訳・人間向け / 最新とは限りません — 基準: 英語版 @ `13d20e6` / 同時更新はしない. The baseline is #343's squash commit, so a future retranslation diffs the English side from there rather than guessing.
- **Content is the pre-translation Japanese text**, which the nine adversarial fidelity audits in #343 had already compared against the English line by line. `operations.ja.md` and `claude-md-ledger.ja.md` are byte-identical to their originals (verified by `diff` against `13d20e6~1`).
- **One mirrored normalization**, the same class #342 mirrored for the garbled `要measured` token: glossary's self-citation `規則 :15-17` names a line range *inside its own file* (the "canonical names are kept in English" paragraph). The English side re-pointed it to `:14-16` when the wrap moved, and the 6-line header shifts the Japanese copy, so it becomes `:21-23`. Left as written it would send a reader six lines past the very rule it cites — and being readable by a human is the only job this file has.
- **No `.chezmoiignore` entry needed**: all three live outside `chezmoi/`, so nothing deploys to `$HOME`.
- **Policy**: the doc-consistency-policy exception for non-canonical review copies rides .github t-dbcg, same as the projects precedent.
- Local `scripts/lint` (all 13 gates) passes with the files tracked — `doc-paths` goes from 31 to 34 markdown files, confirming they are actually covered rather than silently skipped as untracked.

With this merged, e-5pax has one member left: t-5hz8 (the repo `CLAUDE.md`). Two hand-offs are already recorded in the t-322v body — operations.md's two anchors into `CLAUDE.md`'s Japanese headings will break when that file is translated, and `CLAUDE.md` repeats the non-existent `tmpl-plist` gate claim that #343 preserved in operations.md.

SetStatus-task: https://github.com/akira-toriyama/projects/blob/main/.furrow/bodies/t-322v.md in-progress

🤖 Generated with [Claude Code](https://claude.com/claude-code)