### PR TITLE
:memo:(docs) fix the four doc-fact anomalies adjudicated at the e-5pax close

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,7 @@ Gray-zone examples:
 - `.chezmoiroot = chezmoi` — the repository root is the Nix flake; dotfile sources live under `chezmoi/`.
 - Repository-operations files (`README.md` `install.sh` `docs/` `.github/` `CLAUDE.md` etc.) are **outside** `chezmoi/` and therefore not applied to `$HOME`.
 - Scripts under `chezmoi/` reproduce +x with the `executable_` prefix (**enforced by CI**).
-- As the exception, `run_*` and anything under `.chezmoiscripts/` are executed by chezmoi itself, so they need no prefix.
+- As the exception, `run_*` / `modify_*` and anything under `.chezmoiscripts/` are executed by chezmoi itself, so they need no prefix.
 
 ## GitHub / CI
 
@@ -76,7 +76,7 @@ Gray-zone examples:
 - **Commit messages are gitmoji-driven** (`<:gitmoji:>[(<scope>)][!] <subject>`; the Conventional `<type>` words are retired). The canonical source of the convention is .github's [CONTRIBUTING.md](https://github.com/akira-toriyama/.github/blob/main/CONTRIBUTING.md) ([docs/commit-convention.md](docs/commit-convention.md) is the fleet-distributed pointer; the machine check = `glyph lint`). **Before pushing: `glyph lint --range origin/main..HEAD`** (history still carries commits in the retired format, so do not take `git log` as a model).
 - **CI jobs ([.github/workflows/ci.yml](.github/workflows/ci.yml), triggered on push and PR)**:
   - `nix flake check --no-build` — Nix type/eval checks (Linux runner)
-  - `lint` — `scripts/lint` in one shot (ruff / mypy --strict / shfmt / shellcheck / actionlint / typos / lychee --offline / gitleaks / `.tmpl` gets shellcheck and plist-syntax checks after rendering / existence of the paths inside code spans). **The same command runs locally**: `nix develop .#lint --command scripts/lint`
+  - `lint` — `scripts/lint` in one shot (ruff / mypy --strict / shfmt / shellcheck / actionlint / typos / lychee --offline / gitleaks / `.tmpl` gets shellcheck after rendering / existence of the paths inside code spans). **The same command runs locally**: `nix develop .#lint --command scripts/lint`
   - `script test` — the Stop hook's fixture tests + the unittests of `scripts/` and `scripts/claude-md-eval/`
   - Convention check — enforces the `executable_` prefix on shebang scripts under `chezmoi/` (exceptions: `run_*` / `modify_*` / `.chezmoiscripts/`)
   - `chezmoi templates render` — `execute-template` verification of every `.tmpl`
@@ -156,7 +156,7 @@ chezmoi add <path>                                                              
 op read "op://Vault/Item/field"
 ```
 
-## Roadmap board / task tracker
+## Roadmap board
 
 For dotfiles work tasks (backlog, design notes, handovers), **the canonical source is furrow + the private repo
 [`akira-toriyama/projects`](https://github.com/akira-toriyama/projects)**.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -106,7 +106,7 @@ sudo /run/current-system/sw/bin/darwin-rebuild switch --flake .#default --impure
 
 ### For a cask from a custom tap
 
-Add `homebrew.taps = [ "owner/repo" ]` as well. Existing example: `barutsrb/tap` for `omniwm`.
+Add `homebrew.taps = [ "owner/repo" ]` as well. Existing example: `steipete/tap` for `peekaboo` (a brew — no cask currently comes from a custom tap).
 
 </details>
 
@@ -143,7 +143,7 @@ The decision follows [the install-target decision flow in CLAUDE.md](../CLAUDE.m
 |---|---|---|
 | A general-purpose CLI available in nixpkgs | `home/modules/packages.nix` | `jq`, `gh`, `chezmoi`, `docker`, `_1password-cli` |
 | A CLI not in nixpkgs / macOS-only | `brews = [ ... ]` in `system/modules/homebrew.nix` | `blueutil`, `duti`, etc. (currently empty) |
-| Custom tap | `taps = [ ... ]` in `system/modules/homebrew.nix` + the matching `casks/brews` | `barutsrb/tap` → `omniwm` |
+| Custom tap | `taps = [ ... ]` in `system/modules/homebrew.nix` + the matching `casks/brews` | `steipete/tap` → `peekaboo` |
 | Runtime (node / python / deno / ruby) | `globalConfig.tools` in `home/modules/mise.nix` | `node = "lts"`, `python = "3.13"` |
 | Program config that has a DSL (zsh / git / mise, etc.) | `programs.*` in `home/modules/*.nix` | `programs.zsh.*`, `programs.mise.*` |
 | macOS defaults (dock / finder / -g, etc.) | `system/modules/defaults.nix` | `system.defaults.dock.autohide`, etc. |
@@ -246,7 +246,7 @@ From [the "Secret handling" section of CLAUDE.md](../CLAUDE.md#secret-handling-y
 | Job | What it does | runner |
 |---|---|---|
 | `nix flake check (eval only)` | Nix eval/type checking | ubuntu-latest |
-| `lint` | `scripts/lint --ci` (the 14 gates: ruff / ruff-format / mypy / shellcheck / shfmt / exec-bit / tmpl-shellcheck / tmpl-plist / actionlint / typos / lychee / doc-paths / claude-md-guard / gitleaks) | ubuntu-latest |
+| `lint` | `scripts/lint --ci` (the 13 PR/push gates: ruff / ruff-format / mypy / shellcheck / shfmt / exec-bit / tmpl-shellcheck / actionlint / typos / lychee / doc-paths / claude-md-guard / gitleaks — the 14th, `lychee-external`, is the nightly job below) | ubuntu-latest |
 | `convention / executable_ prefix` | Enforces the `executable_` prefix on shebang scripts under `chezmoi/` (exceptions: `run_*` / `modify_*` / `.chezmoiscripts/`) | ubuntu-latest |
 | `script test` | The Stop hook fixtures + the unittests in `scripts/**` and `scripts/claude-md-eval/` | ubuntu-latest |
 | `chezmoi templates render` | execute-template verification of every `.tmpl` (with the latest version from get.chezmoi.io) | ubuntu-latest |


### PR DESCRIPTION
Executes the anomaly adjudication at the close of e-5pax (harvest recorded in the t-322v / t-5hz8 bodies; preserved faithfully during translation per contract, fixed now that the epic closes). Fact corrections only — no behavior-targeting prose is rewritten, so no claude-md-eval run is owed.

- **tmpl-plist claim removed** (CLAUDE.md CI bullet + operations.md CI table): `scripts/lint`'s `GATES` has no plist gate — the only tmpl gate is `tmpl-shellcheck` (`TMPL_SUFFIXES = (".sh.tmpl",)`). The table now counts the 13 PR/push gates and points at `lychee-external` as the 14th (nightly job, already its own row).
- **`modify_` added to the no-prefix exception list** (CLAUDE.md layout conventions): chezmoi executes `modify_` scripts itself, and the CI convention job has always exempted them — the prose omitted what the mechanism honors.
- **Stale custom-tap example replaced** (operations.md ×2): `barutsrb/tap` → `omniwm` are both recorded as deleted in `system/modules/homebrew.nix`; the live example is `steipete/tap` → `peekaboo`, honestly labeled a brew (no cask currently comes from a custom tap).
- **Heading "Roadmap board / task tracker" → "Roadmap board"** (CLAUDE.md): "task tracker" is an alias `docs/glossary.md` forbids for furrow by name. No anchor in the repo points at the old slug (grep-verified); `docs/roadmap.md` refers to the section as "Roadmap board", which survives.

Adjudicated no-change: the `onepasswordRead` line is a prescription ("when a template handles a secret, use…"), not a claim that instances exist — no contradiction with glossary's zero-instances record. The Japanese review copies stay frozen at their 基準 per the three-line-header contract; this drift is exactly what "最新とは限りません" declares.

Local `scripts/lint` (all 13 gates) passes. `glyph lint` unavailable (no `glyph.toml`, open request t-6bxz); message hand-checked against CONTRIBUTING.md.

SetStatus-task: https://github.com/akira-toriyama/projects/blob/main/.furrow/bodies/t-5hz8.md done

🤖 Generated with [Claude Code](https://claude.com/claude-code)