### PR TITLE
:bug: purge stale claims from code comments (t-sm8h audit)

### DIFF
--- a/chezmoi/run_onchange_after_enable-git-hooks.sh
+++ b/chezmoi/run_onchange_after_enable-git-hooks.sh
@@ -4,8 +4,8 @@
 # git は clone 同梱の hook/設定を自動では有効化しない（セキュリティ仕様）。
 # そこで chezmoi apply のたびに、いま使っている clone を CHEZMOI_SOURCE_DIR
 # から特定し、その repo に core.hooksPath=.githooks を best-effort で設定する。
-# install.sh §3.5（~/dotfiles 向け）と冗長だが idempotent で、ghq 等
-# install.sh を経ない clone でも apply 一回で効く。詳細 docs/operations.md §5.11
+# install.sh も clone 直後に同じ設定をする（df_step git-clone の直後）が、ghq 等
+# install.sh を経ない clone でも apply 一回で効くよう冗長に持つ。詳細 docs/operations.md §5.11
 set -u
 
 [ -n "${CHEZMOI_SOURCE_DIR:-}" ] || exit 0

--- a/home/modules/default.nix
+++ b/home/modules/default.nix
@@ -23,7 +23,7 @@
   home.sessionPath = [ "/opt/homebrew/bin" "/opt/homebrew/sbin" "$HOME/.local/bin" ];
 
   # ghq の clone 先を case-sensitive APFS Volume に固定。
-  # install.sh の §1.5 で作成される。$GHQ_ROOT は ghq が `git config ghq.root`
+  # install.sh の df_step workspace-addvolume で作成される。$GHQ_ROOT は ghq が `git config ghq.root`
   # より優先して読むので、~/.gitconfig 未整備の新規 PC でも即座に効く。
   home.sessionVariables = {
     GHQ_ROOT = "/Volumes/workspace";

--- a/home/modules/packages.nix
+++ b/home/modules/packages.nix
@@ -110,11 +110,11 @@ in
     # scripts/lint の各ゲートが起動する実体。CI は devShells.lint（flake.lock 固定）から
     # 供給するので、ここは **開発機で素の `scripts/lint` を叩ける** ための供給源。
     # 同じ flake.lock 由来なので CI とローカルでバージョンが一致する。
-    # 4 本（shfmt / typos / lychee / gitleaks）は #297 で homebrew.brews に置かれて
-    # いたが、いずれも nixpkgs にある汎用 CLI ＝ 判断フローでは home.packages 側。
-    # brew bundle は 1 つの cask が壊れると bundle 全体を道連れにする（2026-08-02〜の
-    # CI 赤で実際に道連れになった）ので、Nix で足りるものは Nix に置く。
-    # switch 後に brew 版を uninstall すること。
+    # 4 本（shfmt / typos / lychee / gitleaks）はいずれも nixpkgs にある汎用 CLI
+    # ＝ 判断フローでは home.packages 側。brew bundle は 1 つの cask が壊れると
+    # bundle 全体を道連れにする（2026-08-02〜の CI 赤で実際に道連れになった）ので、
+    # Nix で足りるものは Nix に置く。ただし現在も homebrew.nix の brews と二重宣言
+    # で brew 実体も残存（解消は projects t-nmdj）。
     shellcheck # shell の lint。system/modules/scripts/*.sh 等の自己検証にも使う
     shfmt      # shell の formatter（scripts/lint の shfmt ゲート）
     actionlint # GitHub Actions workflow の静的チェック。push 前にローカルで拾う
@@ -156,7 +156,7 @@ in
     # ghq-get-mine: GitHub 上の自分の active(非 archived)repo を GHQ_ROOT
     # (/Volumes/workspace) へ ghq レイアウトで一括 SSH clone。clone 済みは
     # no-op(冪等・-u なし = 既存 working copy 不可侵)。新 repo 作成後の追従や
-    # 新 Mac ブートストラップ (install.sh §6.5) で実行。fork・private は含み
+    # 新 Mac ブートストラップ (install.sh の df_step ghq-get-mine) で実行。fork・private は含み
     # archived は除外。前提 = gh 認証 (or GITHUB_TOKEN) + GitHub への SSH 疎通。
     # 未整備なら 1 行 warn で fail-fast(SSH の 1Password 整備は projects t-eep4)。
     # pipefail はグローバルには効かせない: 前段の `ssh -T | grep` は ssh -T が

--- a/system/modules/claude-maint.nix
+++ b/system/modules/claude-maint.nix
@@ -1,7 +1,7 @@
 { ... }:
 
 {
-  # ~/.claude の自作ドキュメント (CLAUDE.md 要所トリガー索引 / commands / skills / agents) を
+  # ~/.claude の自作ドキュメント (global CLAUDE.md / skills / agents) を
   # 毎月 1 回まとめて保守し、判断レポート付きの PR を 1 本作る LaunchAgent。
   # launchd-drift.nix の兄弟 (同じ流儀)。スクリプト本体は
   # ./scripts/claude-maint.sh (Nix store にコピーされる)。

--- a/system/modules/defaults.nix
+++ b/system/modules/defaults.nix
@@ -16,27 +16,27 @@
   system.defaults = {
     # === Finder ===
     finder = {
-      AppleShowAllFiles = true;                  # 隠しファイル表示
-      ShowStatusBar = true;                      # ステータスバー表示
-      ShowPathbar = true;                        # パスバー表示
-      AppleShowAllExtensions = true;             # 全拡張子表示（finder ドメインにもある）
-      ShowExternalHardDrivesOnDesktop = false;   # デスクトップ: 外付け HDD 非表示
-      ShowHardDrivesOnDesktop = false;           # デスクトップ: 内蔵 HDD 非表示
-      ShowMountedServersOnDesktop = false;       # デスクトップ: サーバ非表示
-      ShowRemovableMediaOnDesktop = false;       # デスクトップ: リムーバブル非表示
+      AppleShowAllFiles = true;
+      ShowStatusBar = true;
+      ShowPathbar = true;
+      AppleShowAllExtensions = true;             # NSGlobalDomain にも同キーを宣言（両ドメイン意図的に重複）
+      ShowExternalHardDrivesOnDesktop = false;
+      ShowHardDrivesOnDesktop = false;
+      ShowMountedServersOnDesktop = false;
+      ShowRemovableMediaOnDesktop = false;
     };
 
     # === Dock ===
     dock = {
-      autohide = true;                           # 自動非表示
-      autohide-delay = 0.0;                      # マウスオン遅延ゼロ
+      autohide = true;
+      autohide-delay = 0.0;
       mru-spaces = false;                        # Space を使用順で並べ替えない
     };
 
     # === NSGlobalDomain（全アプリ横断）===
     NSGlobalDomain = {
-      AppleShowAllExtensions = true;             # 全拡張子表示
-      _HIHideMenuBar = true;                     # メニューバー非表示
+      AppleShowAllExtensions = true;
+      _HIHideMenuBar = true;
       "com.apple.swipescrolldirection" = false;  # ナチュラルスクロール OFF（従来方向）
       NSAutomaticWindowAnimationsEnabled = false; # 余計な window アニメ抑制（任意・健康的）
     };
@@ -49,7 +49,7 @@
     # === 個別ドメイン（typed option に無いもの）===
     CustomUserPreferences = {
       "com.apple.finder" = {
-        ShowTabView = true;                      # タブバー表示
+        ShowTabView = true;
       };
       "com.apple.LaunchServices" = {
         LSQuarantine = false;                    # 未確認アプリ警告（download quarantine）無効

--- a/system/modules/homebrew.nix
+++ b/system/modules/homebrew.nix
@@ -5,7 +5,7 @@
   # 既存の /opt/homebrew は nix-homebrew の autoMigrate で吸収済み(commit 13f75ab)。
   #
   # ⚠️ cleanup は当面 "none" のまま据え置く。
-  #    "zap" にすると本ファイルに宣言してない既存 brew(90+ formula 等)を消すので、
+  #    "zap" にすると本ファイルに宣言してない既存 brew を消すので、
   #    フェーズ4 で残りを全部移行し終えてから初めて検討する。
   homebrew = {
     enable = true;
@@ -31,10 +31,9 @@
       "hashicorp/tap/packer"  # Packer
       "gitleaks"  # Audit git repos for secrets
       "sourcekitten"  # Framework and command-line tool for interacting with SourceKit
-      # typos-cli / shfmt / lychee / gitleaks は home/modules/packages.nix へ移した
-      # （#297 で「対話でも使えるように」brew 側に置いたが、4 本とも nixpkgs にある
-      # 汎用 CLI ＝ 判断フローの「nixpkgs にあり & 汎用 CLI → home.packages」に該当。
-      # devShells.lint と同じ flake.lock に載るので CI と版が揃う）。
+      # typos-cli / shfmt / lychee / gitleaks は home/modules/packages.nix と
+      # 二重宣言（#306 で nix 側へ移した後、#322 の live 取り込みで brew 側が復活。
+      # One file, one owner 違反 — 解消は projects t-nmdj）。
       # go は mise 管理へ移行（home/modules/mise.nix）。dev runtime は mise に一元化。
       "git-cliff"  # Highly customizable changelog generator
       "gifski"  # Highest-quality GIF encoder based on pngquant

--- a/system/modules/scripts/check-dotfiles-drift.sh
+++ b/system/modules/scripts/check-dotfiles-drift.sh
@@ -35,7 +35,6 @@
 #     dotfiles/ が壊れている間は毎日リマインドが欲しいという運用方針。timeout 無し =
 #     押すまで残る。md は毎回最新に更新。
 #   - drift が解消したら md を削除する。
-#   - flake パスは ghq → $HOME/dotfiles → $DOTFILES_FLAKE_DIR の順で解決
 #   - 実行ログ (append): /tmp/dotfiles-drift.log (launchd の Std{Out,Err}Path)
 # pipefail は add-homebrew.sh と揃える。この 2 本は launchd(/bin/bash 直起動)と
 # home.packages の writeShellApplication wrapper の 2 経路から走るので、`set` 行が

--- a/system/modules/scripts/claude-maint.sh
+++ b/system/modules/scripts/claude-maint.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-# ~/.claude の自作ドキュメント (CLAUDE.md 要所トリガー索引 / commands / skills / agents) を
+# ~/.claude の自作ドキュメント (global CLAUDE.md / skills / agents。commands は
+# ディレクトリ未作成で常に空集合 — 作るか撤去かは projects t-pd5r のユーザー判断待ち) を
 # 月 1 回まとめて保守し、判断レポート付きの PR を 1 本作る。launchd (claude-maint.nix)
 # から毎月 1 日に起動される。check-dotfiles-drift.sh の兄弟 (= 同じ流儀)。
 #
@@ -27,8 +28,8 @@
 #   claude-maint.sh            # 本番 (worktree → PR)
 #   claude-maint.sh --dry-run  # push/PR せず、レポートを /tmp に出して worktree を残す
 #
-# remote 非依存: dotfiles repo を ghq → $HOME/dotfiles → $DOTFILES_FLAKE_DIR の順で
-# 解決し、その origin に PR を出す (akira→emmett 移行後は自動で emmett へ向く)。
+# remote 非依存: dotfiles repo を解決し (下の FLAKE_DIR 解決部)、その origin に
+# PR を出す (akira→emmett 移行後は自動で emmett へ向く)。
 set -eu
 
 DRY_RUN=0
@@ -195,7 +196,7 @@ PROMPT=$(
 あなたは ~/.claude の自作ドキュメント保守担当。作業ツリーは現在の作業ディレクトリ。
 
 ## 対象 (自作分のみ。plugin / symlink は対象外)
-- 索引: ${CLAUDE_SRC}/CLAUDE.md
+- global CLAUDE.md (fleet 既定ルール本体): ${CLAUDE_SRC}/CLAUDE.md
 - commands: ${CLAUDE_SRC}/commands/*.md
 - skills:   ${CLAUDE_SRC}/skills/*/SKILL.md
 - agents:   ${CLAUDE_SRC}/agents/*.md


### PR DESCRIPTION
Fixes the rotten comments confirmed by the 2026-08-25 comment audit (task t-sm8h). 12 spots were audited in this repo; 2 (modify_settings.json, claude-furrow-board-note) were already fixed by #334 and needed no change. The remaining 10, plus the same rot copied into claude-maint.nix, are fixed here.

## What changed

- **homebrew.nix / packages.nix** — the comments claimed the 4 lint CLIs (typos-cli / shfmt / lychee / gitleaks) were "moved" to home.packages. Reality: #306 moved them, #322 restored the brew side, and they are dual-declared with live brew binaries present. Both comments now state the dual declaration and point at projects t-nmdj (the fix task) instead of claiming resolution. The stale "90+ formula" count backing the cleanup="none" decision is dropped (live is 27).
- **default.nix / packages.nix / enable-git-hooks.sh** — install.sh section numbers (§1.5 / §3.5 / §6.5) no longer exist; install.sh was restructured into named df_step steps. Comments now point by name (workspace-addvolume / git-clone / ghq-get-mine).
- **check-dotfiles-drift.sh** — deleted the resolution-order bullet that contradicted the code since birth (DOTFILES_FLAKE_DIR is the first override, not the last fallback).
- **claude-maint.sh / claude-maint.nix** — ~/.claude/commands was deleted in #156 and CLAUDE.md is no longer a "trigger index"; the headers now describe reality and note the empty commands walk is parked on projects t-pd5r. The copied resolution-order lie from the drift script is also fixed. The prompt label for CLAUDE.md no longer calls it an index.
- **defaults.nix** — deleted the pure name-paraphrase comments (e.g. `AppleShowAllFiles = true; # 隠しファイル表示`); kept only comments that decode cryptic keys (mru-spaces), inverted semantics (swipescrolldirection), or record intent (deliberate cross-domain duplication of AppleShowAllExtensions).

## Verification

- `nix flake check --no-build` green
- `nix develop .#lint --command scripts/lint` — 13 gates passed
- `darwin-rebuild build` (non-destructive) green
- `glyph lint` cannot run here (no glyph.toml — known fleet gap, requests t-6bxz); the message format was checked by hand against CONTRIBUTING.md

SetStatus-task: https://github.com/akira-toriyama/projects/blob/main/.furrow/bodies/t-sm8h.md done

🤖 Generated with [Claude Code](https://claude.com/claude-code)