### PR TITLE
:wrench:(git)= ignore .claude/worktrees/ globally

### DIFF
--- a/home/modules/git.nix
+++ b/home/modules/git.nix
@@ -64,6 +64,10 @@
     ignores = [
       ".DS_Store"
       "**/.claude/settings.local.json"
+      # Claude Code の Agent worktree 置き場。untracked のまま残ると repo を歩く
+      # 道具（jscpd 等）に working copy が二重に見える（t-6211）。.claude/ 全体は
+      # 無視しない — settings.json 等を commit している repo があるため。
+      "**/.claude/worktrees/"
     ];
   };
 }


### PR DESCRIPTION
Adds `**/.claude/worktrees/` to the home-manager global gitignore (`programs.git.ignores`).

Claude Code's agent worktrees live under `<repo>/.claude/worktrees/` and are neither tracked nor ignored, so repo-walking tools see every working copy twice — found by the 2026-08-16 jscpd fleet scan over 28 checkouts (task t-6211). One global line covers every checkout instead of ~30 per-repo `.gitignore` entries.

Scope decision (the open question in the task body): only `worktrees/` is ignored, **not** `.claude/` wholesale — the existing `**/.claude/settings.local.json` entry shows repos commit `.claude/settings.json` and friends, which a blanket ignore would hide.

Verification: `nix flake check --no-build` and non-destructive `darwin-rebuild build` green; `glyph lint --range` clean (first commit in this repo linted under the newly landed glyph.toml, sigil grammar). Live effect lands at the next `darwin-rebuild switch`.

SetStatus-task: https://github.com/akira-toriyama/projects/blob/main/.furrow/bodies/t-6211.md done

🤖 Generated with [Claude Code](https://claude.com/claude-code)