### PR TITLE
:sparkles:(chord)= remap ctrl-l to hiragana conversion via azooKey ctrl-j

### DIFF
--- a/chezmoi/dot_config/chord/private_config.toml
+++ b/chezmoi/dot_config/chord/private_config.toml
@@ -291,6 +291,22 @@ input = "ctrl - j"
 action-keys = "return"
 
 
+# ---- azooKey 変換 remap ----
+# azooKey の変換中ショートカットは hardcode（Ctrl+J ひらがな / Ctrl+K カタカナ /
+# Ctrl+L 全角英数 — Core の UserAction.swift、preference キー無し・変更不可）。
+# 上の ctrl-j → return が物理 Ctrl+J を潰し、ひらがな一括変換が使えないため、
+# Ctrl+K（カタカナ）の隣の Ctrl+L を入口にする。再送分は synthetic タグ付きで
+# matcher に再入しないので、ctrl-j → return には化けず azooKey に素の Ctrl+J が
+# 届く。未変換時は azooKey が Ctrl+J を素通しするため、アプリに届くのは Ctrl+L
+# でなく Ctrl+J になる（terminal では clear でなく LF）。
+
+# doc: Hiragana conversion while composing (azooKey Ctrl+J)
+[[bindings]]
+name = "ctrl-l → ctrl-j (hiragana)"
+input = "ctrl - l"
+action-keys = "ctrl - j"
+
+
 # ---- facet オーバーレイ ----
 # macOS は矢印キーに常に fn (NSEventModifierFlagFunction / maskSecondaryFn) を
 # 付与する。chord の matcher は未言及カテゴリの modifier 不在を要求し、fn は

--- a/docs/chord.md
+++ b/docs/chord.md
@@ -80,6 +80,7 @@ private_config.toml → regenerate with `python3 scripts/gen-chord-doc.py`.
 | `Ctrl + H` | Backspace | * |
 | `Ctrl + D` | Forward Delete | * |
 | `Ctrl + J` | Return | * |
+| `Ctrl + L` | Hiragana conversion while composing (azooKey Ctrl+J) | * |
 | `Ctrl + Fn + right` | Move a space right and show the facet tree (ctrl+→) | * |
 | `Ctrl + Fn + left` | Move a space left and show the facet tree (ctrl+←) | * |
 


### PR DESCRIPTION
## What

Add a chord binding `ctrl - l` → synthetic `ctrl - j`, making Ctrl+L commit the composing text as all-hiragana in azooKey — the hiragana counterpart next to Ctrl+K (katakana).

## Why

azooKey's composition shortcuts are hardcoded (Ctrl+J hiragana / Ctrl+K katakana / Ctrl+L fullwidth alphanumeric; Core UserAction.swift, no preference key), and chord's existing `ctrl-j → return` remap consumes the hiragana entry point on any machine running chord. The synthetic resend skips the matcher (same mechanism as the facet arrow bindings), so azooKey receives a plain Ctrl+J.

## Notes

- Trade-off (documented in the config comment): while not composing, azooKey passes Ctrl+J through, so apps receive Ctrl+J rather than Ctrl+L (terminals get LF instead of clear).
- docs/chord.md regenerated with `gen-chord-doc.py`; docs/chord.ja.md is the frozen review copy from #342 and stays untouched.
- Applied to live (`chezmoi apply`, source == live verified). The chord daemon is not installed on tominoMac-mini (measured 2026-08-26), so the binding takes effect on chord-running machines only; end-to-end IME behavior there is inferred from the working ctrl-j → return path, not measured.

SetStatus-task: https://github.com/akira-toriyama/projects/blob/main/.furrow/bodies/t-j34d.md done

🤖 Generated with [Claude Code](https://claude.com/claude-code)